### PR TITLE
chore: add local codetether launcher

### DIFF
--- a/scripts/start-local-codetether.sh
+++ b/scripts/start-local-codetether.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST="${CODETETHER_HOST:-127.0.0.1}"
+PORT="${CODETETHER_PORT:-4096}"
+TOKEN="${CODETETHER_AUTH_TOKEN:-codetether-local-dev}"
+export CODETETHER_AUTH_TOKEN="$TOKEN"
+
+if [[ -x "$ROOT_DIR/codetether-agent/target/release/codetether" ]]; then
+  CODETETHER_BIN="$ROOT_DIR/codetether-agent/target/release/codetether"
+elif command -v codetether >/dev/null 2>&1; then
+  CODETETHER_BIN="$(command -v codetether)"
+else
+  echo "codetether binary not found" >&2
+  exit 1
+fi
+
+printf 'MCP URL: http://%s:%s/mcp?token=%s\n' "$HOST" "$PORT" "$TOKEN"
+exec "$CODETETHER_BIN" serve --hostname "$HOST" --port "$PORT"


### PR DESCRIPTION
## Summary
- add a small local launcher for `codetether serve`
- print the authenticated local MCP URL before startup
- prefer the repo-local Codetether binary and fall back to PATH

## Verification
- `bash -n scripts/start-local-codetether.sh`
- confirmed the script stays under 50 nonblank lines