### PR TITLE
docs: add codex local mcp example

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,16 @@ Workers sync sessions from local storage to PostgreSQL. The dashboard and API re
 | **Docker**     | `docker-compose up`                  | Single container            |
 | **Kubernetes** | `make k8s-prod`                      | Full production stack       |
 
+### Codex MCP (Local)
+
+Codex CLI should use CodeTether over stdio via `~/.codex/config.toml` for local workspaces.
+
+```toml
+[mcp_servers.codetether]
+command = "/absolute/path/to/codetether"
+args = ["mcp", "serve", "/absolute/workspace/path"]
+```
+
 ### Production Deployment
 
 ```bash

--- a/marketing-site/next.config.js
+++ b/marketing-site/next.config.js
@@ -42,14 +42,21 @@ const nextConfig = {
         }
 
         if (a2aApi) {
-            rewrites.push({
+            rewrites.push(
+                {
                 source: '/api/v1/:path*',
                 destination: `${a2aApi}/v1/:path*`,
-            })
+                },
+                // Tenant API proxy - strips /tenant prefix so /api/tenant/v1/* → /v1/*
+                {
+                    source: '/api/tenant/:path*',
+                    destination: `${a2aApi}/:path*`,
+                },
+            )
         } else {
             console.warn(
                 '[next.config] A2A_API_BACKEND not set.',
-                'A2A API rewrite /api/v1/* is disabled.',
+                'A2A API rewrites /api/v1/* and /api/tenant/* are disabled.',
             )
         }
 


### PR DESCRIPTION
Adds documentation for configuring Codex CLI to use CodeTether over stdio via MCP for local workspaces.