### PR TITLE
fix: enqueue post-clone follow-up tasks on the server

### DIFF
--- a/a2a_server/post_clone_followup.py
+++ b/a2a_server/post_clone_followup.py
@@ -1,0 +1,29 @@
+"""Queue follow-up work after repository preparation finishes."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def enqueue_post_clone_followup(bridge, task_id: str) -> Optional[str]:
+    task = await bridge.get_task(task_id)
+    if task is None or task.agent_type != 'clone_repo':
+        return None
+    followup = (task.metadata or {}).get('post_clone_task')
+    if not isinstance(followup, dict):
+        return None
+    queued = await bridge.create_task(
+        codebase_id=task.codebase_id,
+        title=followup.get('title') or 'Continue after clone',
+        prompt=followup.get('prompt') or '',
+        agent_type=followup.get('agent_type') or 'build',
+        metadata=followup.get('metadata'),
+    )
+    if queued is None:
+        logger.warning('Failed to enqueue post-clone follow-up for task %s', task_id)
+        return None
+    logger.info('Queued post-clone follow-up %s for task %s', queued.id, task_id)
+    return queued.id

--- a/a2a_server/worker_sse.py
+++ b/a2a_server/worker_sse.py
@@ -1156,6 +1156,14 @@ async def release_task(
                 logger.info(
                     f'Task {release.task_id} status updated to {release.status} via bridge'
                 )
+                if release.status == 'completed':
+                    try:
+                        from .post_clone_followup import enqueue_post_clone_followup
+                        await enqueue_post_clone_followup(bridge, release.task_id)
+                    except Exception as e:
+                        logger.error(
+                            f'Failed to enqueue post-clone follow-up for {release.task_id}: {e}'
+                        )
             else:
                 # Fallback: direct DB update if bridge not available
                 from .database import db_update_task_status


### PR DESCRIPTION
Summary:
- enqueue stored post-clone follow-up work when clone_repo completes
- remove the dependency on a freshly upgraded worker binary for first-time repo mentions

Validation:
- python3 -m py_compile a2a_server/post_clone_followup.py a2a_server/worker_sse.py