### PR TITLE
feat: add nginx ingress API proxy for /api/v1/* → a2a-server

### DIFF
--- a/chart/a2a-server/charts/marketing/templates/api-proxy-ingress.yaml
+++ b/chart/a2a-server/charts/marketing/templates/api-proxy-ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.enabled .Values.ingress.enabled .Values.apiProxy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "marketing.fullname" . }}-api-proxy
+  labels:
+    {{- include "marketing.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api-proxy
+  annotations:
+    cert-manager.io/cluster-issuer: "cloudflare-issuer"
+    nginx.ingress.kubernetes.io/rewrite-target: /v1/$1
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /api/v1/(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ .Values.apiProxy.backendService }}
+                port:
+                  number: {{ .Values.apiProxy.backendPort }}
+{{- end }}

--- a/chart/codetether-values.yaml
+++ b/chart/codetether-values.yaml
@@ -76,8 +76,13 @@ marketing:
     NEXTAUTH_URL: "https://codetether.run"
     KEYCLOAK_CLIENT_ID: "a2a-monitor"
     KEYCLOAK_ISSUER: "https://auth.quantum-forge.io/realms/quantum-forge"
-    # Backend API proxy — enables /api/v1/* and /api/tenant/* rewrites in next.config.js
+    # Backend API proxy — nginx ingress routes /api/v1/* → a2a-server /v1/*
     A2A_API_BACKEND: "http://codetether-a2a-server.a2a-server.svc.cluster.local:8000"
+  # API proxy ingress — routes /api/v1/* on the marketing host to the a2a-server
+  apiProxy:
+    enabled: true
+    backendService: codetether-a2a-server
+    backendPort: 8000
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
## Summary

Implements nginx-level API proxying from the marketing site (`codetether.run`) to the a2a-server backend, replacing the broken Next.js build-time rewrites approach.

## Changes

- **New template**: `chart/a2a-server/charts/marketing/templates/api-proxy-ingress.yaml` — dedicated nginx Ingress resource that routes `/api/v1/*` to the a2a-server with path rewrite (`/api/v1/*` → `/v1/*`)
- **Values update**: Added `apiProxy` config section to `chart/codetether-values.yaml` with `enabled`, `backendService`, and `backendPort` fields
- Updated comment to clarify the nginx-level proxy approach

## How It Works

The Next.js `output: 'standalone'` mode evaluates `rewrites()` at **build time**, not runtime. Setting `A2A_API_BACKEND` as a runtime env var has no effect — the image must be rebuilt. Instead, this PR creates a separate nginx Ingress resource that:

1. Matches `/api/v1/(.*)` with regex on `codetether.run`
2. Rewrites to `/v1/$1` using `nginx.ingress.kubernetes.io/rewrite-target`
3. Proxies to `codetether-a2a-server:8000`

## Verified

```bash
$ curl -H "Authorization: Bearer $TOKEN" https://codetether.run/api/v1/monitor/workers
# Returns 341 workers ✅
$ curl -H "Authorization: Bearer $TOKEN" https://codetether.run/api/v1/monitor/stats  
# Returns monitoring stats ✅
```

## Related

- Fixes the proxy issue discovered after PR #30
- Runtime fix already applied via `kubectl apply` — this PR makes it persistent via Helm