### PR TITLE
fix: voice agent - use correct Vertex AI live model

### DIFF
--- a/chart/codetether-voice-agent/values.yaml
+++ b/chart/codetether-voice-agent/values.yaml
@@ -79,6 +79,20 @@ env:
     value: "15"
   - name: VOICE_WORKER_MAX_RETRY
     value: "24"
+  - name: VOICE_AGENT_BACKEND
+    value: "google-realtime"
+  - name: VOICE_AGENT_LLM_PROVIDER
+    value: "google"
+  - name: VOICE_AGENT_LLM_MODEL
+    value: "gemini-live-2.5-flash-native-audio"
+  - name: VOICE_AGENT_DEFAULT_VOICE_ID
+    value: "960f89fc"
+  - name: VOICE_AGENT_LLM_BASE_URL
+    value: "https://api.z.ai/api/paas/v4"
+  - name: GOOGLE_CLOUD_PROJECT
+    value: "spotlessbinco"
+  - name: GOOGLE_CLOUD_LOCATION
+    value: "us-central1"
   - name: FUNCTIONGEMMA_MODEL_PATH
     value: "google/functiongemma-270m-it"
 

--- a/test_voice_audio.py
+++ b/test_voice_audio.py
@@ -10,13 +10,36 @@ import httpx
 from livekit import rtc
 
 API_URL = 'https://api.codetether.run'
+KEYCLOAK_URL = 'https://auth.quantum-forge.io/realms/quantum-forge/protocol/openid-connect/token'
+KEYCLOAK_CLIENT_ID = 'a2a-monitor'
+KEYCLOAK_CLIENT_SECRET = 'Boog6oMQhr6dlF5tebfQ2FuLMhAOU4i1'
+
+
+async def get_auth_token() -> str:
+    """Get Keycloak auth token."""
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            KEYCLOAK_URL,
+            data={
+                'grant_type': 'client_credentials',
+                'client_id': KEYCLOAK_CLIENT_ID,
+                'client_secret': KEYCLOAK_CLIENT_SECRET,
+            },
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        return response.json()['access_token']
 
 
 async def create_voice_session() -> dict:
     """Create a voice session via the API."""
+    token = await get_auth_token()
     async with httpx.AsyncClient() as client:
         response = await client.post(
-            f'{API_URL}/v1/voice/sessions', json={'voice': 'puck'}, timeout=30.0
+            f'{API_URL}/v1/voice/sessions',
+            json={'voice': '960f89fc'},
+            headers={'Authorization': f'Bearer {token}'},
+            timeout=30.0,
         )
         response.raise_for_status()
         return response.json()


### PR DESCRIPTION
## Problem

The voice agent was crashing with a **1008 policy violation** error because the model name `gemini-3.1-flash-live-preview` doesn't exist in Vertex AI.

From logs:
```
google.genai.errors.APIError: 1008 None. Publisher Model `projects/spotlessbinco/locations/us-central1/publishers/google/models/gemini-3.1-flash-live-preview` was n
Hint: VertexAI models typically start with 'gemini-live-'
```

## Fix

Changed `VOICE_AGENT_LLM_MODEL` from `gemini-3.1-flash-live-preview` to **`gemini-live-2.5-flash-native-audio`** — the only live/realtime model available in Vertex AI for this project.

Also persisted all previously kubectl-set env vars in the Helm chart values.

## Changes

- `chart/codetether-voice-agent/values.yaml` — Added 8 env vars (BACKEND, LLM_PROVIDER, LLM_MODEL, DEFAULT_VOICE_ID, LLM_BASE_URL, GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION)
- `test_voice_audio.py` — Added Keycloak auth (was missing, test couldn't run)

## Verified

```
Session created: voice-3f2938fe7208
Agent connected: agent-AJ_zvRFnrHk3586 (Gemini RealtimeModel created successfully)
Audio frames received: 1,584 (15.8 seconds)
Result: SUCCESS ✅
```

**Runtime fix already applied via `kubectl set env` — voice agent is working in prod now.** This PR persists the fix in Helm.