### PR TITLE
fix: clone_repo tasks bypass codebase affinity to prevent pipeline deadlock

### DIFF
--- a/a2a_server/github_app/workspace.py
+++ b/a2a_server/github_app/workspace.py
@@ -63,4 +63,7 @@ async def create_clone_task(context: MentionContext, pr: dict[str, Any], wid: st
         },
     }
     task = await create_agent_task(wid, AgentTaskCreate(title=f'Prepare PR workspace #{context.pr_number}', prompt=f'Clone or refresh {context.repo_full_name} on branch {pr["head"]["ref"]} for PR fix execution.', agent_type='clone_repo', metadata=metadata, model_ref=MODEL_REF))
-    return getattr(task, 'id', None) or task.get('id')
+    # create_agent_task returns {'success': True, 'task': {...}}
+    task_dict = task if isinstance(task, dict) else {}
+    task_data = task_dict.get('task', task_dict)
+    return task_data.get('id') or getattr(task, 'id', None)

--- a/a2a_server/task_routing.py
+++ b/a2a_server/task_routing.py
@@ -3,15 +3,29 @@
 from typing import Optional
 
 
+def is_clone_task(
+    agent_type: Optional[str],
+) -> bool:
+    """Return True when a task is a clone/refresh operation.
+
+    Clone tasks create workspaces on workers, so they must bypass codebase
+    ownership checks — the workspace doesn't exist yet anywhere.
+    """
+    return agent_type == 'clone_repo'
+
+
 def is_targeted_clone_task(
     agent_type: Optional[str],
     target_agent_name: Optional[str] = None,
     target_worker_id: Optional[str] = None,
 ) -> bool:
-    """Return True when a targeted clone task should bypass codebase ownership."""
-    return agent_type == 'clone_repo' and bool(
-        target_agent_name or target_worker_id
-    )
+    """Return True when ANY clone task (targeted or not) should bypass codebase ownership.
+
+    Clone tasks are the bootstrap step: they create the workspace directory
+    and clone the repo.  At this point no worker owns the codebase yet, so
+    restricting by codebase ownership would deadlock the pipeline.
+    """
+    return is_clone_task(agent_type)
 
 
 def target_agent_mismatch(

--- a/a2a_server/worker_sse.py
+++ b/a2a_server/worker_sse.py
@@ -30,7 +30,7 @@ from fastapi import APIRouter, HTTPException, Request, Query, Header
 from fastapi.responses import StreamingResponse, JSONResponse
 from pydantic import BaseModel
 
-from .task_routing import is_targeted_clone_task, target_agent_mismatch
+from .task_routing import is_clone_task, is_targeted_clone_task, target_agent_mismatch
 
 logger = logging.getLogger(__name__)
 
@@ -192,8 +192,18 @@ class WorkerRegistry:
                     return False
 
                 codebase_id = task.codebase_id
-                # Check if this is a restricted codebase (not global/__pending__)
-                if codebase_id and codebase_id not in ('global', '__pending__'):
+                # Clone/refresh tasks bypass codebase ownership — the whole
+                # point is to CREATE the workspace, so no worker owns it yet.
+                task_agent_type = getattr(task, 'agent_type', None) or (
+                    task_metadata.get('agent_type')
+                )
+                if is_clone_task(task_agent_type):
+                    logger.info(
+                        f'Clone task {task_id} (codebase {codebase_id}) — '
+                        f'skipping codebase affinity for worker {worker_id}'
+                    )
+                    # Fall through to the claim lock below
+                elif codebase_id and codebase_id not in ('global', '__pending__'):
                     if not worker:
                         # Worker not SSE-connected; allow claim anyway so
                         # polling-only / reconnecting workers aren't locked out.


### PR DESCRIPTION
## Summary

Fixes the known 409 Conflict / task claiming pipeline deadlock that prevented @codetether from completing GitHub App tasks.

## Root Cause

Three compounding bugs in the task pipeline:

### Bug 1: `task_routing.py` — Clone bypass required targeting info
`is_targeted_clone_task()` only returned `True` when `target_agent_name` or `target_worker_id` was set. When `resolve_task_target()` could not find a matching active worker, clone tasks had no targeting → codebase affinity check applied → no worker had the workspace codebase → **task stuck forever**.

### Bug 2: `worker_sse.py` — No clone bypass in `claim_task()`
Even if a worker found the task through polling, `claim_task()` had no bypass for `clone_repo` tasks → codebase ownership check rejected all claims.

### Bug 3: `github_app/workspace.py` — `create_clone_task()` always returned `None`
`create_agent_task()` returns `{"success": True, "task": {...}}` dict, but `getattr(task, "id", None)` on a dict always returned None → `monitor_pr_fix()` logged `clone task finished: id=None status=timeout`.

## Key Insight

Clone tasks (`clone_repo`) are the bootstrap step — they CREATE the workspace. Requiring a worker to already own the workspace codebase to claim the clone task is a logical impossibility (deadlock by design).

## Changes

| File | Change |
|------|--------|
| `a2a_server/task_routing.py` | `is_targeted_clone_task()` now delegates to `is_clone_task()`, bypassing codebase checks for ALL `clone_repo` tasks |
| `a2a_server/worker_sse.py` | Added clone bypass in `claim_task()` with INFO-level logging before the codebase affinity check |
| `a2a_server/github_app/workspace.py` | Fixed return value extraction from `create_agent_task()` dict |

## Test plan

- [x] Existing tests pass (`tests/test_worker_codebase_routing.py` — 5/6 pass, 1 pre-existing failure from missing DATABASE_URL)
- [x] Python syntax validation passes for all 3 modified files
- [x] `is_clone_task("clone_repo")` returns `True`; `is_clone_task("build")` returns `False`
- [ ] Deploy and verify clone tasks get claimed by workers