### PR TITLE
fix: stabilize GitHub worker task dispatch

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -21,6 +21,8 @@ Autogen
 Blogs
 CAs
 CLIs
+CODETETHER
+CONFIGMAP
 Camry
 Cjava
 Cpzuhi
@@ -64,8 +66,10 @@ JWTs
 Jhb
 Jra
 KGgo
+KNATIVE
 KRW
 LHR
+LIVEKIT
 LJcvt
 LLM
 LLMs
@@ -143,6 +147,7 @@ backstory
 backticks
 bbb
 beeai
+bluegreen
 bufbuild
 bzr
 cae
@@ -150,11 +155,15 @@ ccc
 cdn
 ceee
 cfe
+claude
 cls
 coc
 codegen
 codeowner
+codetether
+configmap
 crewai
+curlimages
 datamodel
 datapart
 dbc
@@ -174,11 +183,14 @@ endblock
 endmacro
 envoyproxy
 euo
+eventing
 evt
 excinfo
 faa
 fafd
 fdebd
+fetchrow
+fetchval
 ffbb
 firewalls
 flightbook
@@ -192,7 +204,9 @@ geneknit
 genkit
 genproto
 georoute
+getpid
 gettickets
+ghs
 gitvote
 gle
 googleai
@@ -220,6 +234,7 @@ langgraph
 linenums
 linkedin
 linting
+livekit
 llm
 llms
 lng
@@ -235,6 +250,7 @@ multipage
 mydb
 myorg
 nearform
+nindent
 nlp
 notif
 npush
@@ -251,6 +267,7 @@ pqr
 prefecthq
 protoc
 protolint
+pvc
 pyguide
 pymdownx
 pypa
@@ -262,6 +279,7 @@ rcm
 repomapr
 reportgen
 reposted
+rollme
 rst
 rvelicheti
 scm
@@ -273,6 +291,7 @@ sse
 stateclass
 stephenh
 styleguide
+subcall
 svn
 systemctl
 tagwords
@@ -288,6 +307,7 @@ toolkits
 tracestate
 ugc
 undoc
+userinfo
 utm
 versioned
 vnd
@@ -298,6 +318,7 @@ webform
 webpage
 whatwg
 wikipedia
+wrk
 wsgi
 wwwwwwww
 xxxxx

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -18,6 +18,7 @@ AStarlette
 AUTOCOMMIT
 Agentspace
 Autogen
+Bitbucket
 Blogs
 CAs
 CLIs
@@ -77,6 +78,7 @@ Lix
 MSIs
 MWpm
 Mapr
+NDJSON
 Nszl
 OIDC
 OOa
@@ -87,6 +89,8 @@ PMEEi
 PTH
 QFdk
 Qvandrcy
+RLS
+ROWTYPE
 RPCs
 RUF
 SLAs
@@ -147,6 +151,7 @@ backstory
 backticks
 bbb
 beeai
+bitbucket
 bluegreen
 bufbuild
 bzr
@@ -207,8 +212,10 @@ georoute
 getpid
 gettickets
 ghs
+gitlab
 gitvote
 gle
+glm
 googleai
 googleapi
 googleblog
@@ -228,6 +235,7 @@ iss
 jherr
 jti
 jwks
+knative
 konami
 kty
 langgraph
@@ -261,6 +269,7 @@ ollama
 oneof
 openapis
 oreilly
+plpgsql
 postgres
 postgresql
 pqr
@@ -321,8 +330,10 @@ wikipedia
 wrk
 wsgi
 wwwwwwww
+xai
 xxxxx
 xxxxxxxx
 youtube
 yyyyyyyy
+zai
 zzzzzzzz

--- a/.github/linters/eslintrc.js
+++ b/.github/linters/eslintrc.js
@@ -1,0 +1,24 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    root: true,
+    parser: '@typescript-eslint/parser',
+    plugins: ['@typescript-eslint', 'n'],
+    extends: [
+      'eslint:recommended',
+      'plugin:@typescript-eslint/recommended',
+      'plugin:n/recommended',
+    ],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'n/no-unsupported-features/es-syntax': 'off',
+    },
+    overrides: [
+      {
+        files: ['*.ts', '*.tsx'],
+        parserOptions: {
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+        },
+      },
+    ],
+  };

--- a/.github/linters/markdownlint.json
+++ b/.github/linters/markdownlint.json
@@ -1,0 +1,10 @@
+{
+    "default": true,
+    "MD013": false,
+    "MD007": {
+        "indent": 4
+    },
+    "MD033": false,
+    "MD046": false,
+    "MD024": false
+}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -31,10 +31,7 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_CHECKOV: false
           VALIDATE_NATURAL_LANGUAGE: false
-          VALIDATE_MARKDOWN: false
-          MARKDOWN_CONFIG_FILE: ".github/linters/markdownlint.json"
-          VALIDATE_MARKDOWN_PRETTIER: false
-          TYPESCRIPT_ES_CONFIG_FILE: ".github/linters/eslintrc.js"
+                    TYPESCRIPT_ES_CONFIG_FILE: ".github/linters/eslintrc.js"
           VALIDATE_JAVASCRIPT_PRETTIER: false
           VALIDATE_JSON_PRETTIER: false
           VALIDATE_YAML_PRETTIER: false

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -31,6 +31,7 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_CHECKOV: false
           VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_MARKDOWN: false
           MARKDOWN_CONFIG_FILE: ".github/linters/markdownlint.json"
           VALIDATE_MARKDOWN_PRETTIER: false
           TYPESCRIPT_ES_CONFIG_FILE: ".github/linters/eslintrc.js"

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -31,9 +31,9 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_CHECKOV: false
           VALIDATE_NATURAL_LANGUAGE: false
-          MARKDOWN_CONFIG_FILE: ".github/linters/.markdownlint.json"
+          MARKDOWN_CONFIG_FILE: ".github/linters/markdownlint.json"
           VALIDATE_MARKDOWN_PRETTIER: false
-          TYPESCRIPT_ES_CONFIG_FILE: ".github/linters/.eslintrc.js"
+          TYPESCRIPT_ES_CONFIG_FILE: ".github/linters/eslintrc.js"
           VALIDATE_JAVASCRIPT_PRETTIER: false
           VALIDATE_JSON_PRETTIER: false
           VALIDATE_YAML_PRETTIER: false

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = codetether-agent
 	url = https://github.com/rileyseaburg/codetether-agent.git
 	branch = main
+[submodule "models.dev"]
+	path = models.dev
+	url = https://github.com/rileyseaburg/models.dev.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "codetether-agent"]
+	path = codetether-agent
+	url = https://github.com/rileyseaburg/codetether-agent.git
+	branch = main

--- a/a2a_server/automation_api.py
+++ b/a2a_server/automation_api.py
@@ -583,7 +583,12 @@ async def dispatch_task(
     task_id = f"task-{uuid.uuid4().hex[:12]}"
     tenant_id = user.tenant_id
     user_id = user.user_id
-    codebase_id = 'global'
+    # Dispatch API tasks are virtual/global tasks: the GitHub Action includes the
+    # full review prompt/diff, so there is no registered workspace to attach.
+    # Store NULL instead of the legacy string "global" because tasks.workspace_id
+    # is a foreign key to workspaces(id); inserting "global" breaks dispatch on
+    # databases without a synthetic global workspace row.
+    workspace_id = None
 
     # Create task in database
     async with pool.acquire() as conn:
@@ -600,7 +605,7 @@ async def dispatch_task(
             request.title,
             request.description,
             request.agent_type,
-            codebase_id,
+            workspace_id,
             json.dumps(request.metadata or {}),
             tenant_id,
             request.model,

--- a/a2a_server/git_service.py
+++ b/a2a_server/git_service.py
@@ -199,6 +199,8 @@ async def issue_git_credentials(
     """Resolve workspace git credentials for helper/API use."""
     creds = await get_git_credentials(codebase_id)
     if not creds:
+        creds = await _workspace_github_app_credentials(codebase_id)
+    if not creds:
         return None
 
     git_url = creds.get('git_url') or ''
@@ -212,6 +214,15 @@ async def issue_git_credentials(
 
     token_type = creds.get('token_type', 'pat')
     if token_type == 'github_app':
+        if creds.get('token'):
+            return {
+                'username': 'x-access-token',
+                'password': creds['token'],
+                'expires_at': creds.get('expires_at'),
+                'token_type': 'github_app',
+                'host': requested_host or stored_host,
+                'path': requested_path or stored_path,
+            }
         token = await mint_github_app_installation_token(
             installation_id=str(creds.get('github_installation_id') or ''),
             owner=creds.get('github_owner'),
@@ -233,6 +244,62 @@ async def issue_git_credentials(
         'host': requested_host or stored_host,
         'path': requested_path or stored_path,
     }
+
+
+async def _workspace_github_app_credentials(
+    workspace_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Mint GitHub App credentials from workspace metadata when Vault has none."""
+    try:
+        from . import database as db
+
+        workspace = await db.db_get_workspace(workspace_id)
+    except Exception as exc:
+        logger.debug(
+            'No workspace-backed GitHub App credentials for %s: %s',
+            workspace_id,
+            exc,
+        )
+        return None
+
+    if not workspace:
+        return None
+
+    github_app = _workspace_github_app_config(workspace)
+    installation_id = str(github_app.get('installation_id') or '').strip()
+    if not installation_id:
+        return None
+
+    from .github_app.auth import installation_token
+
+    token, expires_at = await installation_token(int(installation_id))
+    git_url = str(workspace.get('git_url') or '')
+    owner, repo = _github_owner_repo_from_url(git_url)
+    return {
+        'git_url': git_url,
+        'github_owner': owner,
+        'github_repo': repo,
+        'token': token,
+        'token_type': 'github_app',
+        'expires_at': expires_at,
+    }
+
+
+def _workspace_github_app_config(workspace: Dict[str, Any]) -> Dict[str, Any]:
+    agent_config = workspace.get('agent_config') or {}
+    return (
+        ((agent_config.get('git_auth') or {}).get('github_app'))
+        or ((workspace.get('git_auth') or {}).get('github_app'))
+        or {}
+    )
+
+
+def _github_owner_repo_from_url(git_url: str) -> tuple[Optional[str], Optional[str]]:
+    parsed = urlparse(git_url)
+    parts = parsed.path.strip('/').removesuffix('.git').split('/')
+    if len(parts) >= 2 and parsed.hostname == 'github.com':
+        return parts[0], parts[1]
+    return None, None
 
 
 async def _build_auth_url(git_url: str, codebase_id: str) -> str:

--- a/a2a_server/github_app/credentials.py
+++ b/a2a_server/github_app/credentials.py
@@ -29,7 +29,12 @@ async def issue_git_credentials(workspace_id: str, request: GitCredentialRequest
     credentials = await get_git_credentials(workspace_id)
     if credentials and credentials.get('token'):
         return {'username': 'x-access-token', 'password': credentials['token'], 'expires_at': credentials.get('expires_at'), 'token_type': credentials.get('token_type', 'pat'), 'host': request.host, 'path': request.path}
-    github_app = (((workspace.get('agent_config') or {}).get('git_auth') or {}).get('github_app') or {})
+    agent_config = workspace.get('agent_config') or {}
+    github_app = (
+        ((agent_config.get('git_auth') or {}).get('github_app'))
+        or ((workspace.get('git_auth') or {}).get('github_app'))
+        or {}
+    )
     installation_id = github_app.get('installation_id')
     if not installation_id:
         raise HTTPException(status_code=404, detail='No Git credentials available for workspace')

--- a/a2a_server/github_app/mention.py
+++ b/a2a_server/github_app/mention.py
@@ -5,11 +5,11 @@ from .settings import APP_SLUG
 _FIX_TERMS = (
     'fix', 'apply', 'address', 'implement', 'patch', 'rename', 'modify',
     'edit', 'refactor', 'resolve', 'cleanup', 'clean up', 'please fix',
-    'retry', 'continue', 'finish', 'enhance', 'improve',
+    'retry', 'continue', 'finish', 'enhance', 'improve', 'handle',
     'finish the feature', 'continue the fix', 'retry this',
     'make tests pass', 'make test pass', 'make build pass',
     'make ci pass', 'make lint pass', 'make this work', 'make it work',
-    'make that work',
+    'make that work', 'handle this bug', 'handle this issue',
 )
 
 

--- a/a2a_server/github_app/pr_final_comment.py
+++ b/a2a_server/github_app/pr_final_comment.py
@@ -1,0 +1,24 @@
+"""Final PR comments for GitHub App branch edit tasks."""
+
+from .task_context import github_app_task_context
+from .watch import post_issue_comment
+
+
+async def notify_pr_final_comment(task: dict) -> None:
+    """Post the final PR update after the branch edit task ends."""
+    context = await github_app_task_context(task)
+    if context is None:
+        return
+    repo, pr_number, _, token = context
+    body = str(
+        task.get('result')
+        or task.get('error')
+        or f"Task `{task.get('id')}` ended with status `{task.get('status')}`."
+    ).strip()
+    if str(task.get('status')) == 'completed':
+        message = "## 🛠️ CodeTether Fix\n\nPushed changes to this PR branch."
+        if body:
+            message += f"\n\n{body}"
+        await post_issue_comment(repo, pr_number, token, message)
+        return
+    await post_issue_comment(repo, pr_number, token, f"## 🛠️ CodeTether Fix\n\n{body}")

--- a/a2a_server/github_app/pr_prepare_completion.py
+++ b/a2a_server/github_app/pr_prepare_completion.py
@@ -1,0 +1,56 @@
+"""Follow-up creation for GitHub App PR prepare tasks."""
+
+from .settings import MODEL_REF
+from .task_context import github_app_task_context
+from .watch import post_issue_comment
+
+
+async def handle_pr_prepare_completion(task: dict, worker_id: str | None = None) -> None:
+    """Create the PR branch edit task or post a prepare failure."""
+    from ..monitor_api import AgentTaskCreate, create_agent_task
+
+    metadata = task.get('metadata') or {}
+    context = await github_app_task_context(task)
+    if context is None:
+        return
+    repo, pr_number, _, token = context
+    if str(task.get('status')) != 'completed':
+        body = str(
+            task.get('error')
+            or task.get('result')
+            or f"Task `{task.get('id')}` ended with status `{task.get('status')}`."
+        ).strip()
+        await post_issue_comment(
+            repo,
+            pr_number,
+            token,
+            f"## 🛠️ CodeTether Fix\n\nI couldn't prepare the PR workspace.\n\n{body}",
+        )
+        return
+
+    followup = metadata.get('post_clone_task') or {}
+    workspace_id = str(metadata.get('workspace_id') or '').strip()
+    prompt = str(followup.get('prompt') or '').strip()
+    if not workspace_id or not prompt:
+        await post_issue_comment(
+            repo,
+            pr_number,
+            token,
+            "## 🛠️ CodeTether Fix\n\nI prepared the PR workspace, but the follow-up task metadata was incomplete.",
+        )
+        return
+
+    followup_metadata = dict(followup.get('metadata') or {})
+    target_worker_id = str(worker_id or task.get('worker_id') or '').strip()
+    if target_worker_id:
+        followup_metadata['target_worker_id'] = target_worker_id
+    await create_agent_task(
+        workspace_id,
+        AgentTaskCreate(
+            title=str(followup.get('title') or f'Apply PR fix #{pr_number}'),
+            prompt=prompt,
+            agent_type=str(followup.get('agent_type') or 'build'),
+            metadata=followup_metadata,
+            model_ref=MODEL_REF,
+        ),
+    )

--- a/a2a_server/github_app/task_completion.py
+++ b/a2a_server/github_app/task_completion.py
@@ -2,14 +2,22 @@
 
 from .issue_final_comment import notify_issue_final_comment
 from .issue_prepare_completion import handle_issue_prepare_completion
+from .pr_final_comment import notify_pr_final_comment
+from .pr_prepare_completion import handle_pr_prepare_completion
 
 
 async def notify_issue_task_completion(task: dict, worker_id: str | None = None) -> None:
     """Advance or finish a GitHub App issue workflow."""
     metadata = task.get('metadata') or {}
-    if metadata.get('source') != 'github-app' or metadata.get('pr_number'):
+    if metadata.get('source') != 'github-app':
         return
     title = str(task.get('title') or '')
+    if metadata.get('pr_number'):
+        if title.startswith('Prepare PR workspace #'):
+            await handle_pr_prepare_completion(task, worker_id)
+        elif title.startswith('Apply PR fix #'):
+            await notify_pr_final_comment(task)
+        return
     if title.startswith('Prepare issue workspace #'):
         await handle_issue_prepare_completion(task, worker_id)
     elif title.startswith('Work issue #'):

--- a/a2a_server/github_app/task_context.py
+++ b/a2a_server/github_app/task_context.py
@@ -3,23 +3,40 @@
 from .auth import installation_token
 
 
-async def issue_task_context(task: dict) -> tuple[str, int, str, str] | None:
-    """Resolve repo, issue, branch, and installation token for an issue task."""
+async def github_app_task_context(task: dict) -> tuple[str, int, str, str] | None:
+    """Resolve repo, issue/PR number, branch, and installation token."""
     from .. import database as db
 
     metadata = task.get('metadata') or {}
-    if metadata.get('source') != 'github-app' or metadata.get('pr_number'):
+    if metadata.get('source') != 'github-app':
         return None
     workspace_id = str(metadata.get('workspace_id') or '').strip()
     workspace = await db.db_get_workspace(workspace_id)
-    github_app = (((workspace or {}).get('agent_config') or {}).get('git_auth') or {}).get('github_app') or {}
+    agent_config = (workspace or {}).get('agent_config') or {}
+    github_app = (
+        ((agent_config.get('git_auth') or {}).get('github_app'))
+        or (((workspace or {}).get('git_auth') or {}).get('github_app'))
+        or {}
+    )
     installation_id = github_app.get('installation_id')
     if not installation_id:
         return None
     token, _ = await installation_token(int(str(installation_id)))
+    issue_number = metadata.get('issue_number') or metadata.get('pr_number')
+    branch = metadata.get('branch_name') or metadata.get('pr_head') or metadata.get('git_branch')
+    if not issue_number or not branch:
+        return None
     return (
         str(metadata.get('repo') or '').strip(),
-        int(metadata['issue_number']),
-        str(metadata.get('branch_name') or '').strip(),
+        int(issue_number),
+        str(branch).strip(),
         token,
     )
+
+
+async def issue_task_context(task: dict) -> tuple[str, int, str, str] | None:
+    """Resolve repo, issue, branch, and installation token for an issue task."""
+    metadata = task.get('metadata') or {}
+    if metadata.get('pr_number'):
+        return None
+    return await github_app_task_context(task)

--- a/a2a_server/hosted_worker.py
+++ b/a2a_server/hosted_worker.py
@@ -318,14 +318,31 @@ class HostedWorker:
         # First try to get from database directly (faster, more reliable)
         try:
             async with self._pool.acquire() as conn:
-                row = await conn.fetchrow(
-                    """
-                    SELECT id, title, prompt, agent_type, codebase_id, status,
-                           metadata, created_at
-                    FROM tasks WHERE id = $1
-                    """,
-                    task_id,
-                )
+                try:
+                    row = await conn.fetchrow(
+                        """
+                        SELECT id, title, prompt, agent_type, workspace_id, status,
+                               metadata, created_at
+                        FROM tasks WHERE id = $1
+                        """,
+                        task_id,
+                    )
+                    workspace_value = row['workspace_id'] if row else None
+                except Exception as exc:
+                    # Backward compatibility for databases that have not yet
+                    # renamed codebase_id -> workspace_id.
+                    if 'workspace_id' not in str(exc).lower():
+                        raise
+                    row = await conn.fetchrow(
+                        """
+                        SELECT id, title, prompt, agent_type, codebase_id, status,
+                               metadata, created_at
+                        FROM tasks WHERE id = $1
+                        """,
+                        task_id,
+                    )
+                    workspace_value = row['codebase_id'] if row else None
+
                 if row:
                     return {
                         'id': row['id'],
@@ -333,7 +350,9 @@ class HostedWorker:
                         'description': row['prompt'],
                         'prompt': row['prompt'],
                         'agent_type': row['agent_type'],
-                        'codebase_id': row['codebase_id'],
+                        # Keep the legacy key because _run_task consumes it.
+                        'codebase_id': workspace_value,
+                        'workspace_id': workspace_value,
                         'status': row['status'],
                         'metadata': row['metadata'] or {},
                         'created_at': row['created_at'].isoformat()
@@ -485,7 +504,9 @@ class HostedWorker:
         try:
             # Use sandboxed execution if available
             from .sandbox import is_sandbox_available, execute_sandboxed
-            if is_sandbox_available():
+            sandbox_available = is_sandbox_available()
+            process_returncode = None
+            if sandbox_available:
                 returncode, stdout_str, stderr_str = await execute_sandboxed(
                     cmd=cmd,
                     cwd=str(Path.home()),
@@ -497,6 +518,7 @@ class HostedWorker:
                     logger.error(f'Agent failed for task {task_id}: {stderr_str}')
                     raise Exception(f'Agent execution failed: {stderr_str}')
                 output = stdout_str.strip()
+                process_returncode = returncode
             else:
                 process = await asyncio.create_subprocess_exec(
                     *cmd,
@@ -522,6 +544,7 @@ class HostedWorker:
                     raise Exception(f'Agent execution failed: {error_msg}')
 
                 output = stdout.decode('utf-8', errors='replace').strip()
+                process_returncode = process.returncode
             content = self._parse_agent_output(output)
 
             # Truncate for summary
@@ -531,7 +554,7 @@ class HostedWorker:
                 'summary': summary,
                 'result': content,
                 'model': agent_model,
-                'exit_code': process.returncode,
+                'exit_code': process_returncode,
             }
 
         except asyncio.TimeoutError:
@@ -699,7 +722,7 @@ class HostedWorker:
     ) -> None:
         """Mark a task run as completed or failed."""
         async with self._pool.acquire() as conn:
-            await conn.fetchval(
+            completed = await conn.fetchval(
                 'SELECT complete_task_run($1, $2, $3, $4, $5, $6)',
                 run_id,
                 self.worker_id,
@@ -708,6 +731,40 @@ class HostedWorker:
                 json.dumps(result_full) if result_full else None,
                 error,
             )
+
+            if completed:
+                # Keep the canonical tasks row in sync with task_runs. The
+                # GitHub Action polls /v1/tasks/dispatch/{task_id}, which reads
+                # tasks.status/result (not task_runs). Without this, server-mode
+                # action jobs can finish in task_runs but poll forever as
+                # pending/running and eventually report a timeout/failure.
+                task_id = self._current_task_id
+                result_text = result_summary
+                if result_full and not result_text:
+                    result_text = (
+                        result_full.get('result')
+                        or result_full.get('summary')
+                        or result_full.get('response')
+                    )
+                    if not isinstance(result_text, str):
+                        result_text = json.dumps(result_text)
+
+                if task_id:
+                    await conn.execute(
+                        """
+                        UPDATE tasks SET
+                            status = $2,
+                            result = CASE WHEN $2 = 'completed' THEN $3 ELSE result END,
+                            error = CASE WHEN $2 = 'failed' THEN $4 ELSE error END,
+                            completed_at = CASE WHEN $2 IN ('completed', 'failed', 'cancelled') THEN NOW() ELSE completed_at END,
+                            updated_at = NOW()
+                        WHERE id = $1
+                        """,
+                        task_id,
+                        status,
+                        result_text,
+                        error,
+                    )
 
         logger.info(f'Run {run_id} marked as {status}')
 

--- a/a2a_server/migrations/019_restore_task_run_routing_claim.sql
+++ b/a2a_server/migrations/019_restore_task_run_routing_claim.sql
@@ -1,0 +1,102 @@
+-- Migration: restore full task_run claim routing after tenant isolation
+--
+-- Migration 010 redefined claim_next_task_run with a 3-argument signature,
+-- unintentionally dropping the 5-argument worker claim function used by
+-- hosted_worker.py. That makes hosted workers fail to claim GitHub Action
+-- dispatch jobs with "function claim_next_task_run(...) does not exist". This
+-- migration preserves tenant isolation while restoring agent/capability/model
+-- routing and the expected return columns.
+
+CREATE OR REPLACE FUNCTION claim_next_task_run(
+    p_worker_id TEXT,
+    p_lease_duration_seconds INTEGER DEFAULT 600,
+    p_worker_agent_name TEXT DEFAULT NULL,
+    p_worker_capabilities JSONB DEFAULT '[]'::JSONB,
+    p_worker_models_supported TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    run_id TEXT,
+    task_id TEXT,
+    user_id TEXT,
+    priority INTEGER,
+    target_agent_name TEXT,
+    required_capabilities JSONB,
+    model_ref TEXT,
+    tenant_id TEXT
+) AS $$
+DECLARE
+    v_run task_runs%ROWTYPE;
+BEGIN
+    SELECT tr.* INTO v_run
+    FROM task_runs tr
+    LEFT JOIN users u ON tr.user_id = u.id
+    WHERE tr.status = 'queued'
+      AND (tr.lease_expires_at IS NULL OR tr.lease_expires_at < NOW())
+      AND (tr.deadline_at IS NULL OR tr.deadline_at > NOW())
+      -- Agent targeting: if task has target_agent_name, only that agent can claim it.
+      AND (
+          tr.target_agent_name IS NULL
+          OR tr.target_agent_name = p_worker_agent_name
+      )
+      -- Capability check: worker must have all requested capabilities.
+      AND (
+          tr.required_capabilities IS NULL
+          OR tr.required_capabilities = '[]'::JSONB
+          OR p_worker_capabilities @> tr.required_capabilities
+      )
+      -- Model check: explicit model tasks require an advertising compatible worker.
+      AND (
+          tr.model_ref IS NULL
+          OR (
+              p_worker_models_supported IS NOT NULL
+              AND array_length(p_worker_models_supported, 1) > 0
+              AND tr.model_ref = ANY(p_worker_models_supported)
+          )
+      )
+      -- User concurrency check; service/internal rows may have no user.
+      AND (
+          tr.user_id IS NULL
+          OR u.id IS NULL
+          OR (
+              SELECT COUNT(*)
+              FROM task_runs tr2
+              WHERE tr2.user_id = tr.user_id
+                AND tr2.status = 'running'
+          ) < COALESCE(u.concurrency_limit, 999)
+      )
+    ORDER BY
+        CASE WHEN tr.target_agent_name IS NOT NULL THEN 0 ELSE 1 END,
+        CASE WHEN tr.model_ref IS NOT NULL THEN 0 ELSE 1 END,
+        tr.priority DESC,
+        tr.created_at ASC
+    FOR UPDATE OF tr SKIP LOCKED
+    LIMIT 1;
+
+    IF v_run.id IS NULL THEN
+        RETURN;
+    END IF;
+
+    UPDATE task_runs SET
+        status = 'running',
+        lease_owner = p_worker_id,
+        lease_expires_at = NOW() + (p_lease_duration_seconds || ' seconds')::INTERVAL,
+        started_at = COALESCE(task_runs.started_at, NOW()),
+        attempts = task_runs.attempts + 1,
+        updated_at = NOW()
+    WHERE id = v_run.id;
+
+    run_id := v_run.id;
+    task_id := v_run.task_id;
+    user_id := v_run.user_id;
+    priority := v_run.priority;
+    target_agent_name := v_run.target_agent_name;
+    required_capabilities := v_run.required_capabilities;
+    model_ref := v_run.model_ref;
+    tenant_id := v_run.tenant_id;
+    RETURN NEXT;
+END;
+$$ LANGUAGE plpgsql;
+
+INSERT INTO schema_migrations (migration_name, checksum)
+VALUES ('019_restore_task_run_routing_claim', md5('019_restore_task_run_routing_claim'))
+ON CONFLICT (migration_name) DO UPDATE SET applied_at = NOW();

--- a/chart/a2a-server/templates/deployment.yaml
+++ b/chart/a2a-server/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         {{- end }}
       labels:
         {{- include "a2a-server.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -565,6 +566,7 @@ spec:
       labels:
         {{- include "a2a-server.blueGreenLabels" $ | nindent 8 }}
         color: {{ $color | quote }}
+        app.kubernetes.io/component: server
         {{- with $.Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/a2a-server/templates/knative-worker-serviceaccount.yaml
+++ b/chart/a2a-server/templates/knative-worker-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.knative.enabled .Values.knative.worker.serviceAccountName }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.knative.worker.serviceAccountName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "a2a-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knative-worker
+automountServiceAccountToken: true
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/chart/a2a-server/templates/knative-worker-template.yaml
+++ b/chart/a2a-server/templates/knative-worker-template.yaml
@@ -151,7 +151,7 @@ data:
                       optional: true
                 {{- end }}
                 {{- if .Values.knative.worker.gcpCredentialsSecret }}
-                # GCP credentials for Vertex AI
+                # Google Cloud credentials for Vertex AI
                 - name: GOOGLE_APPLICATION_CREDENTIALS
                   value: "/secrets/gcp/credentials.json"
                 - name: GOOGLE_VERTEX_LOCATION

--- a/chart/a2a-server/templates/knative-worker-template.yaml
+++ b/chart/a2a-server/templates/knative-worker-template.yaml
@@ -44,6 +44,7 @@ data:
                 - http://{{ include "a2a-server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
                 - --name
                 - session-SESSION_ID
+                - --workspaces
                 - {{ .Values.knative.worker.workspacePersistence.mountPath | default "/workspace" | quote }}
               workingDir: {{ .Values.knative.worker.workspacePersistence.mountPath | default "/workspace" | quote }}
               ports:

--- a/chart/a2a-server/templates/service.yaml
+++ b/chart/a2a-server/templates/service.yaml
@@ -28,6 +28,8 @@ spec:
     {{- if and .Values.blueGreen.enabled (eq .Values.blueGreen.mode "bluegreen") }}
     {{- include "a2a-server.blueGreenSelectorLabels" . | nindent 4 }}
     color: {{ .Values.blueGreen.serviceColor | quote }}
+    app.kubernetes.io/component: server
     {{- else }}
     {{- include "a2a-server.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server
     {{- end }}

--- a/docs/codetether-github-task-smoke.md
+++ b/docs/codetether-github-task-smoke.md
@@ -1,0 +1,20 @@
+# CodeTether GitHub Task Smoke Test
+
+This document is an end-to-end smoke test for the CodeTether GitHub App issue workflow.
+
+| Field       | Value                          |
+|-------------|--------------------------------|
+| Issue       | #39                            |
+| Date (UTC)  | 2026-04-24                     |
+| Status      | Verified via automated PR      |
+
+## Purpose
+
+Confirm that CodeTether can:
+
+1. Receive an issue trigger (`@codetether fix this please`).
+2. Create a feature branch (`codetether/issue-39`).
+3. Commit a documentation change.
+4. Open a pull request that references and closes the originating issue.
+
+This is intentionally minimal — docs-only, no code changes.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,5 @@
 pytest>=7.0.0
 pytest-asyncio>=0.21.0
 httpx>=0.25.0
+python-jose[cryptography]>=3.3.0
 watchdog>=6.0.0

--- a/tests/test_github_action_dispatch.py
+++ b/tests/test_github_action_dispatch.py
@@ -1,0 +1,71 @@
+"""Regression coverage for GitHub Action server-mode dispatch tasks."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from a2a_server.automation_api import DispatchTaskRequest, dispatch_task
+
+
+class FakeConnection:
+    def __init__(self):
+        self.execute_calls = []
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((query, args))
+
+
+class FakeAcquire:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakePool:
+    def __init__(self):
+        self.conn = FakeConnection()
+
+    def acquire(self):
+        return FakeAcquire(self.conn)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_task_stores_github_action_review_as_null_workspace(monkeypatch):
+    """Server-mode GitHub Action dispatches must not FK to a fake 'global' workspace."""
+    pool = FakePool()
+    monkeypatch.setattr('a2a_server.automation_api.get_pool', AsyncMock(return_value=pool))
+    monkeypatch.setattr('a2a_server.automation_api.KNATIVE_ENABLED', False)
+    enqueue = AsyncMock(return_value=SimpleNamespace(id='run-1'))
+    monkeypatch.setattr('a2a_server.automation_api.enqueue_task', enqueue)
+
+    response = await dispatch_task(
+        DispatchTaskRequest(
+            title='PR Review: #12 Example',
+            description='Review this diff from GitHub Actions.',
+            agent_type='code-review',
+            metadata={'source': 'github-actions', 'repo': 'acme/widget', 'pr_number': 12},
+        ),
+        http_request=SimpleNamespace(),
+        user=SimpleNamespace(tenant_id='tenant-1', user_id='user-1'),
+    )
+
+    insert_calls = [
+        call for call in pool.conn.execute_calls if 'INSERT INTO tasks' in call[0]
+    ]
+    assert insert_calls, 'dispatch_task should insert a task row'
+    insert_args = insert_calls[0][1]
+
+    # Parameter $5 maps to workspace_id in the INSERT statement. It must be SQL
+    # NULL/None; using the string 'global' violates the workspaces FK in prod.
+    assert insert_args[4] is None
+    assert json.loads(insert_args[5])['source'] == 'github-actions'
+    enqueue.assert_awaited_once()
+    assert response.task_id.startswith('task-')
+    assert response.status == 'pending'

--- a/tests/test_github_app_mentions.py
+++ b/tests/test_github_app_mentions.py
@@ -1,0 +1,13 @@
+from a2a_server.github_app.mention import is_fix_request, mentions_bot
+
+
+def test_mentions_bot_is_case_insensitive():
+    assert mentions_bot('@CodeTether can you handle this bug?')
+
+
+def test_handle_this_bug_is_actionable_issue_request():
+    assert is_fix_request('@CodeTether can you handle this bug?')
+
+
+def test_plain_mention_without_action_still_not_fix_request():
+    assert not is_fix_request('@CodeTether thanks for the context')

--- a/tests/test_github_app_task_completion.py
+++ b/tests/test_github_app_task_completion.py
@@ -1,0 +1,103 @@
+import pytest
+
+from a2a_server import git_service
+from a2a_server.github_app import task_completion
+
+
+@pytest.mark.asyncio
+async def test_pr_prepare_task_creates_pr_followup(monkeypatch):
+    calls = []
+
+    async def fake_handle(task, worker_id=None):
+        calls.append((task, worker_id))
+
+    monkeypatch.setattr(task_completion, 'handle_pr_prepare_completion', fake_handle)
+
+    task = {
+        'title': 'Prepare PR workspace #40',
+        'metadata': {'source': 'github-app', 'pr_number': 40},
+    }
+    await task_completion.notify_issue_task_completion(task, 'wrk_123')
+
+    assert calls == [(task, 'wrk_123')]
+
+
+@pytest.mark.asyncio
+async def test_pr_build_task_posts_pr_final_comment(monkeypatch):
+    calls = []
+
+    async def fake_notify(task):
+        calls.append(task)
+
+    monkeypatch.setattr(task_completion, 'notify_pr_final_comment', fake_notify)
+
+    task = {
+        'title': 'Apply PR fix #40',
+        'metadata': {'source': 'github-app', 'pr_number': 40},
+    }
+    await task_completion.notify_issue_task_completion(task)
+
+    assert calls == [task]
+
+
+@pytest.mark.asyncio
+async def test_issue_prepare_task_still_uses_issue_followup(monkeypatch):
+    calls = []
+
+    async def fake_handle(task, worker_id=None):
+        calls.append((task, worker_id))
+
+    monkeypatch.setattr(task_completion, 'handle_issue_prepare_completion', fake_handle)
+
+    task = {
+        'title': 'Prepare issue workspace #39',
+        'metadata': {'source': 'github-app', 'issue_number': 39},
+    }
+    await task_completion.notify_issue_task_completion(task, 'wrk_456')
+
+    assert calls == [(task, 'wrk_456')]
+
+
+@pytest.mark.asyncio
+async def test_git_credentials_fall_back_to_workspace_github_app(monkeypatch):
+    async def fake_get_git_credentials(workspace_id):
+        assert workspace_id == 'ws_private'
+        return None
+
+    async def fake_db_get_workspace(workspace_id):
+        assert workspace_id == 'ws_private'
+        return {
+            'git_url': 'https://github.com/rileyseaburg/spotlessbinco.git',
+            'agent_config': {},
+            'git_auth': {
+                'github_app': {
+                    'installation_id': '12345',
+                }
+            },
+        }
+
+    async def fake_installation_token(installation_id):
+        assert installation_id == 12345
+        return 'ghs_test_token', '2026-04-24T22:00:00Z'
+
+    from a2a_server import database as db
+    from a2a_server.github_app import auth
+
+    monkeypatch.setattr(git_service, 'get_git_credentials', fake_get_git_credentials)
+    monkeypatch.setattr(db, 'db_get_workspace', fake_db_get_workspace)
+    monkeypatch.setattr(auth, 'installation_token', fake_installation_token)
+
+    credentials = await git_service.issue_git_credentials(
+        'ws_private',
+        requested_host='github.com',
+        requested_path='rileyseaburg/spotlessbinco.git',
+    )
+
+    assert credentials == {
+        'username': 'x-access-token',
+        'password': 'ghs_test_token',
+        'expires_at': '2026-04-24T22:00:00Z',
+        'token_type': 'github_app',
+        'host': 'github.com',
+        'path': 'rileyseaburg/spotlessbinco.git',
+    }

--- a/tests/test_hosted_worker_dispatch_sync.py
+++ b/tests/test_hosted_worker_dispatch_sync.py
@@ -1,0 +1,119 @@
+"""Regression tests for hosted-worker execution of dispatch tasks."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from a2a_server.hosted_worker import HostedWorker
+
+
+class FakeConnection:
+    def __init__(self, row=None, complete_result=True):
+        self.row = row
+        self.complete_result = complete_result
+        self.fetchrow_calls = []
+        self.fetchval_calls = []
+        self.execute_calls = []
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append((query, args))
+        return self.row
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append((query, args))
+        if 'complete_task_run' in query:
+            return self.complete_result
+        return True
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((query, args))
+        return 'UPDATE 1'
+
+
+class FakeAcquire:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def acquire(self):
+        return FakeAcquire(self.conn)
+
+
+def _worker(conn):
+    return HostedWorker(
+        worker_id='worker-1',
+        db_pool=FakePool(conn),
+        api_base_url='http://localhost:8000',
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_task_details_reads_workspace_id_schema_for_dispatch_task():
+    row = {
+        'id': 'task-1',
+        'title': 'PR Review',
+        'prompt': 'review diff',
+        'agent_type': 'code-review',
+        'workspace_id': None,
+        'status': 'pending',
+        'metadata': {'source': 'github-actions'},
+        'created_at': None,
+    }
+    details = await _worker(FakeConnection(row=row))._get_task_details('task-1')
+
+    assert details['codebase_id'] is None
+    assert details['workspace_id'] is None
+    assert details['metadata']['source'] == 'github-actions'
+
+
+@pytest.mark.asyncio
+async def test_complete_run_updates_canonical_task_for_action_polling():
+    conn = FakeConnection()
+    worker = _worker(conn)
+    worker._current_task_id = 'task-1'
+
+    await worker._complete_run(
+        'run-1',
+        status='completed',
+        result_summary='review result',
+        result_full={'result': 'full review'},
+    )
+
+    assert any('complete_task_run' in call[0] for call in conn.fetchval_calls)
+    update_calls = [call for call in conn.execute_calls if 'UPDATE tasks SET' in call[0]]
+    assert update_calls, 'canonical tasks row must be updated for /v1/tasks/dispatch polling'
+    args = update_calls[0][1]
+    assert args[:4] == ('task-1', 'completed', 'review result', None)
+
+
+@pytest.mark.asyncio
+async def test_run_llm_task_sandbox_path_has_exit_code(monkeypatch):
+    conn = FakeConnection()
+    worker = _worker(conn)
+    monkeypatch.setattr(worker, '_find_agent_binary', lambda: '/bin/codetether')
+    monkeypatch.setattr(worker, '_normalize_model', lambda model: model)
+    monkeypatch.setattr(
+        'a2a_server.sandbox.is_sandbox_available',
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        'a2a_server.sandbox.execute_sandboxed',
+        AsyncMock(return_value=(0, json.dumps({'type': 'text', 'part': {'text': 'ok'}}), '')),
+    )
+
+    result = await worker._run_llm_task('task-1', 'prompt', model='zai/glm-5.1')
+
+    assert result['result'] == 'ok'
+    assert result['exit_code'] == 0

--- a/tests/test_migration_claim_signature.py
+++ b/tests/test_migration_claim_signature.py
@@ -1,0 +1,24 @@
+"""Regression tests for hosted worker task-run claim migration."""
+
+from pathlib import Path
+
+
+def test_latest_claim_next_task_run_migration_preserves_hosted_worker_signature():
+    sql = Path('a2a_server/migrations/019_restore_task_run_routing_claim.sql').read_text()
+
+    assert 'CREATE OR REPLACE FUNCTION claim_next_task_run' in sql
+    assert 'p_worker_id TEXT' in sql
+    assert 'p_lease_duration_seconds INTEGER DEFAULT 600' in sql
+    assert 'p_worker_agent_name TEXT DEFAULT NULL' in sql
+    assert "p_worker_capabilities JSONB DEFAULT '[]'::JSONB" in sql
+    assert 'p_worker_models_supported TEXT[] DEFAULT NULL' in sql
+
+    # hosted_worker.py indexes these columns from SELECT * FROM claim_next_task_run(...)
+    assert 'target_agent_name TEXT' in sql
+    assert 'required_capabilities JSONB' in sql
+    assert 'model_ref TEXT' in sql
+
+    # Preserve the routing filters that earlier migrations added.
+    assert 'tr.target_agent_name = p_worker_agent_name' in sql
+    assert 'p_worker_capabilities @> tr.required_capabilities' in sql
+    assert 'tr.model_ref = ANY(p_worker_models_supported)' in sql


### PR DESCRIPTION
## Summary
- accept explicit issue comments like `@CodeTether can you handle this bug?` as actionable GitHub App requests
- restore hosted-worker dispatch/task-run synchronization and task-run claim migration
- add PR workflow follow-up/final-comment handling and workspace GitHub App credential fallback
- update Helm worker/server selectors and add regression coverage
- fix CI lint/spelling config used by changed files

Fixes #44

## Validation
- `./venv/bin/python -m pytest tests/test_github_app_mentions.py tests/test_github_app_task_completion.py tests/test_github_action_dispatch.py tests/test_hosted_worker_dispatch_sync.py tests/test_migration_claim_signature.py`
