### PR TITLE
feat: webhook fire-and-forget, 7-day tasks, persistent worker pool

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -189,67 +189,10 @@ jobs:
                   echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
                   echo '```' >> $GITHUB_STEP_SUMMARY
 
-    build-and-push-marketing:
-        name: Build and Push Marketing Site
-        runs-on: ubuntu-latest
-        needs: test
-        if: always() && github.event_name != 'pull_request'
-        permissions:
-            contents: read
-            packages: write
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Log in to Google Artifact Registry
-              uses: docker/login-action@v3
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: _json_key
-                  password: ${{ secrets.GCP_SA_KEY }}
-
-            - name: Extract metadata (Marketing)
-              id: meta
-              uses: docker/metadata-action@v5
-              with:
-                  images: ${{ env.REGISTRY }}/${{ env.PROJECT }}/codetether-marketing
-                  tags: |
-                      type=ref,event=branch
-                      type=semver,pattern={{version}}
-                      type=semver,pattern={{major}}.{{minor}}
-                      type=sha,prefix={{branch}}-
-                      type=raw,value=latest,enable={{is_default_branch}}
-
-            - name: Build and push Marketing image
-              uses: docker/build-push-action@v5
-              with:
-                  context: ./marketing-site
-                  file: ./marketing-site/Dockerfile
-                  push: true
-                  tags: ${{ steps.meta.outputs.tags }}
-                  labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-                  build-args: |
-                      VERSION=${{ steps.meta.outputs.version }}
-
-            - name: Output marketing image details
-              run: |
-                  echo "### Marketing Site Docker Image Built and Pushed 🎨" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image:** ${{ env.PROJECT }}/codetether-marketing" >> $GITHUB_STEP_SUMMARY
-                  echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-                  echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-
     package-and-push-helm:
         name: Package and Push Helm Chart
         runs-on: ubuntu-latest
-        needs: [build-and-push, build-and-push-worker, build-and-push-marketing]
+        needs: [build-and-push, build-and-push-worker]
         if: github.event_name != 'pull_request'
         permissions:
             contents: read
@@ -347,12 +290,7 @@ jobs:
         name: Deployment Ready Notification
         runs-on: ubuntu-latest
         needs:
-            [
-                build-and-push,
-                build-and-push-worker,
-                build-and-push-marketing,
-                package-and-push-helm,
-            ]
+            [build-and-push, build-and-push-worker, package-and-push-helm]
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         steps:
             - name: Create deployment summary

--- a/a2a_server/automation_api.py
+++ b/a2a_server/automation_api.py
@@ -533,6 +533,12 @@ class DispatchTaskRequest(BaseModel):
     metadata: Optional[Dict[str, Any]] = Field(
         default=None, description='Additional metadata for the task'
     )
+    task_timeout_seconds: int = Field(
+        default=600,
+        ge=60,
+        le=604800,
+        description='Maximum task execution time in seconds (60-604800, default 600=10min, max 7 days)',
+    )
 
 
 class DispatchTaskResponse(BaseModel):
@@ -545,6 +551,7 @@ class DispatchTaskResponse(BaseModel):
     description: str
     result: Optional[str] = Field(default=None, description='Task result text when completed')
     created_at: str
+    task_timeout_seconds: int = Field(default=600, description='Task timeout in seconds')
     dispatched_via_knative: bool = Field(
         ..., description='Whether task was dispatched to Knative broker'
     )
@@ -651,6 +658,7 @@ async def dispatch_task(
         title=request.title,
         description=request.description,
         created_at=datetime.now(timezone.utc).isoformat(),
+        task_timeout_seconds=request.task_timeout_seconds,
         dispatched_via_knative=dispatched_via_knative,
     )
 

--- a/a2a_server/github_app/build_task.py
+++ b/a2a_server/github_app/build_task.py
@@ -5,13 +5,19 @@ from .prompt import fix_prompt
 from .routing import resolve_task_target
 from .settings import MODEL_REF
 
+DEFAULT_TASK_TIMEOUT = 604800  # 7 days
+
 
 async def create_build_task(
     context: MentionContext, pr: dict, wid: str, clone_worker_id: str | None
 ) -> str:
-    """Queue the post-clone edit task on the worker that prepared the repo."""
-    from ..monitor_api import AgentTaskCreate, create_agent_task
+    """Queue the post-clone edit task on the worker that prepared the repo.
 
+    Dispatches as fire-and-forget with a 7-day timeout.
+    """
+    from ..persistent_worker_pool import create_and_dispatch_task
+
+    routing = await resolve_task_target()
     metadata = {
         'workspace_id': wid,
         'source': 'github-app',
@@ -21,18 +27,19 @@ async def create_build_task(
         'pr_base': pr['base']['ref'],
         'comment_path': context.comment_path,
         'comment_diff_hunk': context.comment_diff_hunk,
-        **(await resolve_task_target()),
+        'github_issue_url': f'https://github.com/{context.repo_full_name}/pull/{context.pr_number}',
+        'github_installation_id': context.installation_id,
+        **routing,
     }
     if clone_worker_id:
         metadata['target_worker_id'] = clone_worker_id
-    task = await create_agent_task(
-        wid,
-        AgentTaskCreate(
-            title=f'Apply PR fix #{context.pr_number}',
-            prompt=fix_prompt(context, pr),
-            agent_type='build',
-            metadata=metadata,
-            model_ref=MODEL_REF,
-        ),
+    return await create_and_dispatch_task(
+        workspace_id=wid,
+        title=f'Apply PR fix #{context.pr_number}',
+        prompt=fix_prompt(context, pr),
+        agent_type='build',
+        model_ref=MODEL_REF,
+        metadata=metadata,
+        task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
+        github_issue_url=f'https://github.com/{context.repo_full_name}/pull/{context.pr_number}',
     )
-    return getattr(task, 'id', None) or task.get('id')

--- a/a2a_server/github_app/handler.py
+++ b/a2a_server/github_app/handler.py
@@ -1,33 +1,74 @@
-"""Request dispatch for GitHub App fix comments."""
+"""Request dispatch for GitHub App fix comments.
 
-import asyncio
+Entry point: POST /v1/webhooks/github → handle_fix_request()
+
+This is fire-and-forget: we create the clone task with dispatch_mode=fire_and_forget
+and task_timeout_seconds=604800, post an acceptance comment, and return immediately.
+No GitHub Action is involved — the persistent worker (harvester) picks up tasks
+from our compute cluster.
+
+Task lifecycle:
+  1. handle_fix_request() → create_and_dispatch_task() (fire-and-forget)
+  2. Persistent worker claims task via SSE notification
+  3. Clone completes → pr/issue_prepare_completion creates build task
+  4. Build completes → pr/issue_final_comment posts result
+  5. github_progress_service posts comments every 5 min while running
+  6. task_reaper detects silent workers, requeues from checkpoint
+"""
 
 from .auth import github_json
 from .context import MentionContext
 from .issue_clone_task import create_issue_clone_task
 from .issue_prompt import accepted_issue_message, issue_branch
 from .prompt import accepted_message
-from .watch import monitor_pr_fix, post_issue_comment
+from .watch import post_issue_comment
 from .workspace import create_clone_task, ensure_workspace
 
 
+def _build_github_issue_url(repo_full_name: str, issue_number: int, pr_number: int | None) -> str:
+    """Construct the GitHub issue/PR URL for progress reporter."""
+    if pr_number:
+        return f'https://github.com/{repo_full_name}/pull/{pr_number}'
+    return f'https://github.com/{repo_full_name}/issues/{issue_number}'
+
+
 async def handle_fix_request(context: MentionContext, token: str) -> dict:
-    """Route a GitHub comment request into the PR or plain-issue automation flow."""
+    """Route a GitHub comment request into the PR or plain-issue automation flow.
+
+    This is fire-and-forget: we create the clone task, post an acceptance
+    comment, and return immediately. The task lifecycle is event-driven:
+      - Clone completes → pr/issue_prepare_completion creates build task
+      - Build completes → pr/issue_final_comment posts result
+      - Progress reported by github_progress_service every 5 min
+      - Worker death detected by task_reaper → requeue or fail with comment
+    """
+    github_issue_url = _build_github_issue_url(
+        context.repo_full_name, context.issue_number, context.pr_number
+    )
+
     if context.pr_number:
         pr = await github_json('GET', f'/repos/{context.repo_full_name}/pulls/{context.pr_number}', token)
         if pr['head']['repo']['full_name'] != context.repo_full_name:
             await post_issue_comment(context.repo_full_name, context.issue_number, token, f"## 🛠️ CodeTether Fix\n\nAuto-fix is not available for forked pull requests because I cannot safely push to `{pr['head']['repo']['full_name']}:{pr['head']['ref']}`.")
             return {'accepted': False, 'reason': 'forked-pr'}
         wid = await ensure_workspace(context, pr)
-        clone_task_id = await create_clone_task(context, pr, wid)
+        clone_task_id = await create_clone_task(
+            context, pr, wid,
+            github_issue_url=github_issue_url,
+            github_installation_id=context.installation_id,
+        )
         await post_issue_comment(context.repo_full_name, context.issue_number, token, accepted_message(pr))
-        asyncio.create_task(monitor_pr_fix(context, pr, clone_task_id, pr['head']['sha'], token))
         return {'accepted': True, 'workspace_id': wid, 'clone_task_id': clone_task_id}
+
     repo = await github_json('GET', f'/repos/{context.repo_full_name}', token)
     issue = await github_json('GET', f'/repos/{context.repo_full_name}/issues/{context.issue_number}', token)
     branch = issue_branch(context)
     checkout = {'head': {'repo': {'clone_url': repo['clone_url']}, 'ref': branch}, 'base': {'ref': repo['default_branch']}}
     wid = await ensure_workspace(context, checkout)
-    clone_task_id = await create_issue_clone_task(context, issue, repo, wid, branch)
+    clone_task_id = await create_issue_clone_task(
+        context, issue, repo, wid, branch,
+        github_issue_url=github_issue_url,
+        github_installation_id=context.installation_id,
+    )
     await post_issue_comment(context.repo_full_name, context.issue_number, token, accepted_issue_message(issue, branch))
     return {'accepted': True, 'workspace_id': wid, 'clone_task_id': clone_task_id}

--- a/a2a_server/github_app/issue_build_task.py
+++ b/a2a_server/github_app/issue_build_task.py
@@ -5,6 +5,8 @@ from .issue_prompt import issue_fix_prompt
 from .routing import resolve_task_target
 from .settings import MODEL_REF
 
+DEFAULT_TASK_TIMEOUT = 604800  # 7 days
+
 
 async def create_issue_build_task(
     context: MentionContext,
@@ -14,9 +16,13 @@ async def create_issue_build_task(
     branch: str,
     clone_worker_id: str | None,
 ) -> str:
-    """Queue the post-clone build task for an issue fix request."""
-    from ..monitor_api import AgentTaskCreate, create_agent_task
+    """Queue the post-clone build task for an issue fix request.
 
+    Dispatches as fire-and-forget with a 7-day timeout.
+    """
+    from ..persistent_worker_pool import create_and_dispatch_task
+
+    routing = await resolve_task_target()
     metadata = {
         'workspace_id': wid,
         'source': 'github-app',
@@ -24,18 +30,19 @@ async def create_issue_build_task(
         'issue_number': context.issue_number,
         'branch_name': branch,
         'default_branch': repo['default_branch'],
-        **(await resolve_task_target()),
+        'github_issue_url': f'https://github.com/{context.repo_full_name}/issues/{context.issue_number}',
+        'github_installation_id': context.installation_id,
+        **routing,
     }
     if clone_worker_id:
         metadata['target_worker_id'] = clone_worker_id
-    task = await create_agent_task(
-        wid,
-        AgentTaskCreate(
-            title=f'Work issue #{context.issue_number}',
-            prompt=issue_fix_prompt(context, issue, repo, branch),
-            agent_type='build',
-            metadata=metadata,
-            model_ref=MODEL_REF,
-        ),
+    return await create_and_dispatch_task(
+        workspace_id=wid,
+        title=f'Work issue #{context.issue_number}',
+        prompt=issue_fix_prompt(context, issue, repo, branch),
+        agent_type='build',
+        model_ref=MODEL_REF,
+        metadata=metadata,
+        task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
+        github_issue_url=f'https://github.com/{context.repo_full_name}/issues/{context.issue_number}',
     )
-    return getattr(task, 'id', None) or task.get('id')

--- a/a2a_server/github_app/issue_clone_task.py
+++ b/a2a_server/github_app/issue_clone_task.py
@@ -5,14 +5,44 @@ from .issue_prompt import issue_fix_prompt
 from .routing import resolve_task_target
 from .settings import MODEL_REF
 
+DEFAULT_TASK_TIMEOUT = 604800  # 7 days
+
 
 async def create_issue_clone_task(
-    context: MentionContext, issue: dict, repo: dict, wid: str, branch: str
+    context: MentionContext,
+    issue: dict,
+    repo: dict,
+    wid: str,
+    branch: str,
+    *,
+    github_issue_url: str = '',
+    github_installation_id: int = 0,
 ) -> str:
-    """Queue the branch preparation task for an issue fix request."""
-    from ..monitor_api import AgentTaskCreate, create_agent_task
+    """Queue the branch preparation task for an issue fix request.
+
+    Dispatches as fire-and-forget with a 7-day timeout so the persistent
+    worker (harvester) can claim it and run it on our compute.
+
+    The github_issue_url is propagated into the clone and follow-up build
+    task metadata so the progress reporter can post periodic comments.
+    """
+    from ..persistent_worker_pool import create_and_dispatch_task
 
     base_branch = repo['default_branch']
+
+    followup_metadata = {
+        'workspace_id': wid,
+        'source': 'github-app',
+        'repo': context.repo_full_name,
+        'issue_number': context.issue_number,
+        'branch_name': branch,
+        'default_branch': base_branch,
+        'github_issue_url': github_issue_url,
+        'github_installation_id': github_installation_id,
+    }
+
+    routing = await resolve_task_target()
+
     metadata = {
         'workspace_id': wid,
         'git_url': repo['clone_url'],
@@ -20,22 +50,23 @@ async def create_issue_clone_task(
         'source': 'github-app',
         'repo': context.repo_full_name,
         'issue_number': context.issue_number,
-        **(await resolve_task_target()),
+        'github_issue_url': github_issue_url,
+        'github_installation_id': github_installation_id,
+        **routing,
         'post_clone_task': {
             'title': f'Work issue #{context.issue_number}',
             'prompt': issue_fix_prompt(context, issue, repo, branch),
             'agent_type': 'build',
-            'metadata': {'workspace_id': wid, 'source': 'github-app', 'repo': context.repo_full_name, 'issue_number': context.issue_number, 'branch_name': branch, 'default_branch': repo['default_branch']},
+            'metadata': followup_metadata,
         },
     }
-    task = await create_agent_task(
-        wid,
-        AgentTaskCreate(
-            title=f'Prepare issue workspace #{context.issue_number}',
-            prompt=f'Clone or refresh {context.repo_full_name} on branch {base_branch} for issue automation.',
-            agent_type='clone_repo',
-            metadata=metadata,
-            model_ref=MODEL_REF,
-        ),
+    return await create_and_dispatch_task(
+        workspace_id=wid,
+        title=f'Prepare issue workspace #{context.issue_number}',
+        prompt=f'Clone or refresh {context.repo_full_name} on branch {base_branch} for issue automation.',
+        agent_type='clone_repo',
+        model_ref=MODEL_REF,
+        metadata=metadata,
+        task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
+        github_issue_url=github_issue_url,
     )
-    return getattr(task, 'id', None) or task.get('id')

--- a/a2a_server/github_app/issue_prepare_completion.py
+++ b/a2a_server/github_app/issue_prepare_completion.py
@@ -4,10 +4,12 @@ from .settings import MODEL_REF
 from .task_context import issue_task_context
 from .watch import post_issue_comment
 
+DEFAULT_TASK_TIMEOUT = 604800  # 7 days
+
 
 async def handle_issue_prepare_completion(task: dict, worker_id: str | None = None) -> None:
     """Create the issue build task or post a prepare failure."""
-    from ..monitor_api import AgentTaskCreate, create_agent_task
+    from ..persistent_worker_pool import create_and_dispatch_task
 
     metadata = task.get('metadata') or {}
     context = await issue_task_context(task)
@@ -25,7 +27,24 @@ async def handle_issue_prepare_completion(task: dict, worker_id: str | None = No
         await post_issue_comment(repo, issue_number, token, "## 🛠️ CodeTether Fix\n\nI prepared the workspace, but the follow-up task metadata was incomplete.")
         return
     followup_metadata = dict(followup.get('metadata') or {})
+
+    # Propagate github_issue_url and github_installation_id for progress reporting
+    for key in ('github_issue_url', 'github_installation_id'):
+        if key in metadata and key not in followup_metadata:
+            followup_metadata[key] = metadata[key]
+
     target_worker_id = str(worker_id or task.get('worker_id') or '').strip()
     if target_worker_id:
         followup_metadata['target_worker_id'] = target_worker_id
-    await create_agent_task(workspace_id, AgentTaskCreate(title=str(followup.get('title') or f'Work issue #{issue_number}'), prompt=prompt, agent_type=str(followup.get('agent_type') or 'build'), metadata=followup_metadata, model_ref=MODEL_REF))
+
+    github_issue_url = followup_metadata.get('github_issue_url') or metadata.get('github_issue_url')
+    await create_and_dispatch_task(
+        workspace_id=workspace_id,
+        title=str(followup.get('title') or f'Work issue #{issue_number}'),
+        prompt=prompt,
+        agent_type=str(followup.get('agent_type') or 'build'),
+        model_ref=MODEL_REF,
+        metadata=followup_metadata,
+        task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
+        github_issue_url=github_issue_url,
+    )

--- a/a2a_server/github_app/pr_prepare_completion.py
+++ b/a2a_server/github_app/pr_prepare_completion.py
@@ -4,10 +4,12 @@ from .settings import MODEL_REF
 from .task_context import github_app_task_context
 from .watch import post_issue_comment
 
+DEFAULT_TASK_TIMEOUT = 604800  # 7 days
+
 
 async def handle_pr_prepare_completion(task: dict, worker_id: str | None = None) -> None:
     """Create the PR branch edit task or post a prepare failure."""
-    from ..monitor_api import AgentTaskCreate, create_agent_task
+    from ..persistent_worker_pool import create_and_dispatch_task
 
     metadata = task.get('metadata') or {}
     context = await github_app_task_context(task)
@@ -41,16 +43,24 @@ async def handle_pr_prepare_completion(task: dict, worker_id: str | None = None)
         return
 
     followup_metadata = dict(followup.get('metadata') or {})
+
+    # Propagate github_issue_url and github_installation_id for progress reporting
+    for key in ('github_issue_url', 'github_installation_id'):
+        if key in metadata and key not in followup_metadata:
+            followup_metadata[key] = metadata[key]
+
     target_worker_id = str(worker_id or task.get('worker_id') or '').strip()
     if target_worker_id:
         followup_metadata['target_worker_id'] = target_worker_id
-    await create_agent_task(
-        workspace_id,
-        AgentTaskCreate(
-            title=str(followup.get('title') or f'Apply PR fix #{pr_number}'),
-            prompt=prompt,
-            agent_type=str(followup.get('agent_type') or 'build'),
-            metadata=followup_metadata,
-            model_ref=MODEL_REF,
-        ),
+
+    github_issue_url = followup_metadata.get('github_issue_url') or metadata.get('github_issue_url')
+    await create_and_dispatch_task(
+        workspace_id=workspace_id,
+        title=str(followup.get('title') or f'Apply PR fix #{pr_number}'),
+        prompt=prompt,
+        agent_type=str(followup.get('agent_type') or 'build'),
+        model_ref=MODEL_REF,
+        metadata=followup_metadata,
+        task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
+        github_issue_url=github_issue_url,
     )

--- a/a2a_server/github_app/watch.py
+++ b/a2a_server/github_app/watch.py
@@ -1,56 +1,38 @@
-"""Background monitoring for GitHub App-driven PR fix tasks."""
+"""GitHub issue comment utilities for the GitHub App webhook flow.
 
-import asyncio
+The synchronous monitor_pr_fix() / wait_for_task() polling path has been
+replaced by the event-driven task lifecycle:
+
+  1. Webhook → handler.py creates a clone task and returns immediately.
+  2. Clone task completes → pr_prepare_completion / issue_prepare_completion
+     creates the follow-up build task.
+  3. Build task completes → pr_final_comment / issue_final_comment posts the
+     result on the GitHub issue/PR.
+  4. For long-running tasks, github_progress_service posts periodic progress
+     comments on the issue (every 5 minutes) using the github_issue_url stored
+     in task metadata.
+  5. If a worker dies, task_reaper detects the missed heartbeat and requeues
+     the task (up to max_attempts). On permanent failure, it posts a comment.
+
+All orchestration is event-driven via task_status_hook.py, which is called from
+worker_sse.py / hosted_worker.py / monitor_api.py when tasks go terminal.
+"""
+
 import logging
 from typing import Any
 
 from .auth import github_json
-from .build_task import create_build_task
-from .context import MentionContext
-from .workspace import ensure_workspace
 
 logger = logging.getLogger(__name__)
 
 
-async def wait_for_task(task_id: str, attempts: int, delay_seconds: int) -> dict[str, Any]:
-    """Poll the task row until it reaches a terminal status."""
-    from .. import database as db
-
-    for _ in range(attempts):
-        task = await db.db_get_task(task_id)
-        if task and task.get('status') in {'completed', 'failed', 'cancelled', 'rejected'}:
-            return task
-        await asyncio.sleep(delay_seconds)
-    return {'id': task_id, 'status': 'timeout', 'error': 'Timed out waiting for task completion'}
-
-
-async def post_issue_comment(repo_full_name: str, issue_number: int, token: str, body: str) -> None:
+async def post_issue_comment(
+    repo_full_name: str, issue_number: int, token: str, body: str
+) -> None:
     """Post a status update back onto the PR issue timeline."""
-    await github_json('POST', f'/repos/{repo_full_name}/issues/{issue_number}/comments', token, {'body': body[:65000]})
-
-
-async def monitor_pr_fix(context: MentionContext, pr: dict[str, Any], clone_task_id: str, head_sha_before: str, token: str) -> None:
-    """Run the clone→build→comment loop after a webhook request returns."""
-    try:
-        wid = await ensure_workspace(context, pr)
-        clone_task = await wait_for_task(clone_task_id, 120, 5)
-        logger.info('GitHub App clone task finished: id=%s status=%s', clone_task_id, clone_task.get('status'))
-        if clone_task.get('status') != 'completed':
-            await post_issue_comment(context.repo_full_name, context.issue_number, token, f"## 🛠️ CodeTether Fix\n\nI couldn't prepare the repository workspace. Task `{clone_task_id}` ended with status `{clone_task.get('status')}`.")
-            return
-        clone_worker_id = clone_task.get('worker_id') or (clone_task.get('metadata') or {}).get('worker_id')
-        build_task_id = await create_build_task(context, pr, wid, clone_worker_id)
-        logger.info('GitHub App build task created: id=%s clone_worker_id=%s', build_task_id, clone_worker_id)
-        build_task = await wait_for_task(build_task_id, 240, 5)
-        if build_task.get('status') != 'completed':
-            body = build_task.get('error') or build_task.get('result') or f"I couldn't apply the requested changes automatically. Task `{build_task_id}` ended with status `{build_task.get('status')}`."
-            await post_issue_comment(context.repo_full_name, context.issue_number, token, f'## 🛠️ CodeTether Fix\n\n{body}')
-            return
-        updated_pr = await github_json('GET', f"/repos/{context.repo_full_name}/pulls/{context.pr_number}", token)
-        if updated_pr['head']['sha'] == head_sha_before:
-            await post_issue_comment(context.repo_full_name, context.issue_number, token, f"## 🛠️ CodeTether Fix\n\nThe build task completed, but the PR head did not change. I did not confirm a pushed fix on `{pr['head']['ref']}`.")
-            return
-        await post_issue_comment(context.repo_full_name, context.issue_number, token, f"## 🛠️ CodeTether Fix\n\n{(build_task.get('result') or 'Applied the requested changes.').strip()}")
-    except Exception as exc:
-        logger.exception('GitHub App PR-fix monitor failed for %s#%s', context.repo_full_name, context.pr_number)
-        await post_issue_comment(context.repo_full_name, context.issue_number, token, f'## 🛠️ CodeTether Fix\n\nThe follow-up monitor failed before I could apply the requested changes: `{exc}`')
+    await github_json(
+        'POST',
+        f'/repos/{repo_full_name}/issues/{issue_number}/comments',
+        token,
+        {'body': body[:65000]},
+    )

--- a/a2a_server/github_app/workspace.py
+++ b/a2a_server/github_app/workspace.py
@@ -7,6 +7,8 @@ from .context import MentionContext
 from .prompt import fix_prompt; from .routing import resolve_task_target
 from .settings import MODEL_REF, get_secret
 
+DEFAULT_TASK_TIMEOUT = 604800  # 7 days
+
 
 def workspace_id(git_url: str, git_branch: str) -> str:
     """Derive the deterministic branch-scoped workspace ID."""
@@ -34,9 +36,39 @@ async def ensure_workspace(context: MentionContext, pr: dict[str, Any]) -> str:
     return wid
 
 
-async def create_clone_task(context: MentionContext, pr: dict[str, Any], wid: str) -> str:
-    """Queue a targeted clone/refresh task for the PR branch."""
-    from ..monitor_api import AgentTaskCreate, create_agent_task
+async def create_clone_task(
+    context: MentionContext,
+    pr: dict[str, Any],
+    wid: str,
+    *,
+    github_issue_url: str = '',
+    github_installation_id: int = 0,
+) -> str:
+    """Queue a targeted clone/refresh task for the PR branch.
+
+    Dispatches as fire-and-forget with a 7-day timeout so the persistent
+    worker (harvester) can claim it and run it on our compute.
+
+    The github_issue_url is stored in the clone task's post_clone_task metadata
+    so it propagates to the follow-up build task, enabling the progress reporter
+    to post periodic comments on the GitHub issue/PR.
+    """
+    from ..persistent_worker_pool import create_and_dispatch_task
+
+    followup_metadata = {
+        'workspace_id': wid,
+        'source': 'github-app',
+        'repo': context.repo_full_name,
+        'pr_number': context.pr_number,
+        'pr_head': pr['head']['ref'],
+        'pr_base': pr['base']['ref'],
+        'comment_path': context.comment_path,
+        'comment_diff_hunk': context.comment_diff_hunk,
+        'github_issue_url': github_issue_url,
+        'github_installation_id': github_installation_id,
+    }
+
+    routing = await resolve_task_target()
 
     metadata = {
         'workspace_id': wid,
@@ -45,22 +77,23 @@ async def create_clone_task(context: MentionContext, pr: dict[str, Any], wid: st
         'source': 'github-app',
         'repo': context.repo_full_name,
         'pr_number': context.pr_number,
-        **(await resolve_task_target()),
+        'github_issue_url': github_issue_url,
+        'github_installation_id': github_installation_id,
+        **routing,
         'post_clone_task': {
             'title': f'Apply PR fix #{context.pr_number}',
             'prompt': fix_prompt(context, pr),
             'agent_type': 'build',
-            'metadata': {
-                'workspace_id': wid,
-                'source': 'github-app',
-                'repo': context.repo_full_name,
-                'pr_number': context.pr_number,
-                'pr_head': pr['head']['ref'],
-                'pr_base': pr['base']['ref'],
-                'comment_path': context.comment_path,
-                'comment_diff_hunk': context.comment_diff_hunk,
-            },
+            'metadata': followup_metadata,
         },
     }
-    task = await create_agent_task(wid, AgentTaskCreate(title=f'Prepare PR workspace #{context.pr_number}', prompt=f'Clone or refresh {context.repo_full_name} on branch {pr["head"]["ref"]} for PR fix execution.', agent_type='clone_repo', metadata=metadata, model_ref=MODEL_REF))
-    return getattr(task, 'id', None) or task.get('id')
+    return await create_and_dispatch_task(
+        workspace_id=wid,
+        title=f'Prepare PR workspace #{context.pr_number}',
+        prompt=f'Clone or refresh {context.repo_full_name} on branch {pr["head"]["ref"]} for PR fix execution.',
+        agent_type='clone_repo',
+        model_ref=MODEL_REF,
+        metadata=metadata,
+        task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
+        github_issue_url=github_issue_url,
+    )

--- a/a2a_server/github_progress_reporter.py
+++ b/a2a_server/github_progress_reporter.py
@@ -1,0 +1,171 @@
+"""
+GitHub Progress Reporter — Posts task progress as comments on GitHub issues.
+
+The server posts progress comments on behalf of workers every 5 minutes
+for fire-and-forget tasks with a github_issue_url.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+GITHUB_PROGRESS_ENABLED = os.environ.get(
+    'GITHUB_PROGRESS_ENABLED', 'true'
+).lower() == 'true'
+GITHUB_PROGRESS_INTERVAL_SECONDS = int(
+    os.environ.get('GITHUB_PROGRESS_INTERVAL_SECONDS', '300')
+)
+
+
+def _parse_issue_url(url: str) -> Optional[Dict[str, str]]:
+    """Parse a GitHub issue/PR URL into owner, repo, and number."""
+    if not url:
+        return None
+    m = re.match(
+        r'https://github\.com/([^/]+)/([^/]+)/(?:issues|pull)/(\d+)', url
+    )
+    if not m:
+        return None
+    return {'owner': m.group(1), 'repo': m.group(2), 'number': int(m.group(3))}
+
+
+def _format_progress_comment(
+    task_id: str,
+    progress_pct: float,
+    status_message: str,
+    elapsed_seconds: int,
+    resume_attempt: int,
+    checkpoint: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Format a progress comment for GitHub."""
+    elapsed_h = elapsed_seconds // 3600
+    elapsed_m = (elapsed_seconds % 3600) // 60
+    elapsed_s = elapsed_seconds % 60
+
+    if elapsed_h > 0:
+        elapsed_str = f"{elapsed_h}h {elapsed_m}m"
+    elif elapsed_m > 0:
+        elapsed_str = f"{elapsed_m}m {elapsed_s}s"
+    else:
+        elapsed_str = f"{elapsed_s}s"
+
+    filled = int(progress_pct / 100 * 20)
+    bar = '█' * filled + '░' * (20 - filled)
+
+    lines = [
+        f"### 🔄 Task Progress — `{task_id[:16]}…`",
+        "",
+        f"`{bar}` **{progress_pct:.0f}%** complete ({elapsed_str} elapsed)",
+        f"> {status_message}",
+    ]
+
+    if resume_attempt > 0:
+        lines.append(
+            f"\n> ℹ️ Resumed from checkpoint "
+            f"({resume_attempt} time{'s' if resume_attempt > 1 else ''})"
+        )
+
+    if checkpoint:
+        completed_steps = checkpoint.get('completed_steps', [])
+        if completed_steps:
+            lines.append("")
+            lines.append("<details><summary>Completed Steps</summary>")
+            lines.append("")
+            for step in completed_steps[-5:]:
+                icon = '✅' if step.get('status') == 'done' else '🔄'
+                lines.append(f"- {icon} {step.get('name', 'Unknown step')}")
+            total = len(completed_steps)
+            if total > 5:
+                lines.append(f"- … and {total - 5} more")
+            lines.append("")
+            lines.append("</details>")
+
+    lines.append("")
+    lines.append("_Updated automatically by CodeTether_")
+    return "\n".join(lines)
+
+
+async def post_github_progress_comment(
+    issue_url: str,
+    task_id: str,
+    progress_pct: float,
+    status_message: str,
+    elapsed_seconds: int,
+    resume_attempt: int = 0,
+    checkpoint: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Post a progress comment on a GitHub issue/PR."""
+    parsed = _parse_issue_url(issue_url)
+    if not parsed:
+        logger.warning(f'Cannot parse issue URL: {issue_url}')
+        return False
+
+    try:
+        from .github_app_auth import github_installation_request
+        from . import database as db
+
+        pool = await db.get_pool()
+        if not pool:
+            return False
+
+        # Get installation_id from task metadata
+        installation_id = None
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT metadata FROM tasks WHERE id = $1", task_id
+            )
+            if row and row['metadata']:
+                metadata = row['metadata']
+                if isinstance(metadata, str):
+                    metadata = json.loads(metadata)
+                installation_id = metadata.get('github_installation_id')
+
+        if not installation_id:
+            logger.debug(f'No installation_id for task {task_id}')
+            return False
+
+        comment_body = _format_progress_comment(
+            task_id=task_id,
+            progress_pct=progress_pct,
+            status_message=status_message,
+            elapsed_seconds=elapsed_seconds,
+            resume_attempt=resume_attempt,
+            checkpoint=checkpoint,
+        )
+
+        api_url = (
+            f"https://api.github.com/repos/{parsed['owner']}/{parsed['repo']}"
+            f"/issues/{parsed['number']}/comments"
+        )
+
+        response = await github_installation_request(
+            installation_id=str(installation_id),
+            owner=parsed['owner'],
+            repo=parsed['repo'],
+            method='POST',
+            url=api_url,
+            json={'body': comment_body},
+        )
+
+        if response.status_code in (200, 201):
+            logger.info(f'Posted progress on {issue_url} for task {task_id}')
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    'SELECT record_github_comment($1)', task_id
+                )
+            return True
+        else:
+            logger.warning(
+                f'GitHub comment failed: {response.status_code}'
+            )
+            return False
+
+    except Exception as e:
+        logger.error(f'Error posting GitHub progress: {e}')
+        return False

--- a/a2a_server/github_progress_service.py
+++ b/a2a_server/github_progress_service.py
@@ -1,0 +1,120 @@
+"""Background service that posts progress comments on GitHub issues."""
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+from .github_progress_reporter import (
+    GITHUB_PROGRESS_ENABLED,
+    GITHUB_PROGRESS_INTERVAL_SECONDS,
+    post_github_progress_comment,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubProgressReporter:
+    """Background service that posts progress comments on GitHub issues."""
+
+    def __init__(
+        self,
+        interval_seconds: int = GITHUB_PROGRESS_INTERVAL_SECONDS,
+    ):
+        self._interval = interval_seconds
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        if not GITHUB_PROGRESS_ENABLED:
+            logger.info('GitHub progress reporter disabled')
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._report_loop())
+        logger.info(
+            f'GitHub progress reporter started (interval={self._interval}s)'
+        )
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _report_loop(self) -> None:
+        await asyncio.sleep(15)
+        while self._running:
+            try:
+                await self._report_all_pending()
+            except Exception as e:
+                logger.error(f'GitHub progress reporter error: {e}')
+            await asyncio.sleep(self._interval)
+
+    async def _report_all_pending(self) -> int:
+        """Find all fire-and-forget runs needing comments and post them."""
+        from . import database as db
+
+        pool = await db.get_pool()
+        if not pool:
+            return 0
+
+        try:
+            async with pool.acquire() as conn:
+                rows = await conn.fetch(
+                    'SELECT * FROM find_runs_needing_github_comment($1)',
+                    self._interval,
+                )
+        except Exception as e:
+            logger.debug(f'Failed to query runs needing comments: {e}')
+            return 0
+
+        posted = 0
+        for row in rows:
+            try:
+                checkpoint = row['checkpoint']
+                if isinstance(checkpoint, str):
+                    checkpoint = json.loads(checkpoint)
+
+                success = await post_github_progress_comment(
+                    issue_url=row['github_issue_url'],
+                    task_id=row['task_id'],
+                    progress_pct=row['progress_pct'] or 0,
+                    status_message=row['status_message'] or 'Working...',
+                    elapsed_seconds=row['elapsed_seconds'] or 0,
+                    resume_attempt=row['resume_attempt'] or 0,
+                    checkpoint=checkpoint,
+                )
+                if success:
+                    posted += 1
+            except Exception as e:
+                logger.warning(
+                    f'Failed to post comment for task {row["task_id"]}: {e}'
+                )
+
+        if posted > 0:
+            logger.info(f'Posted {posted} progress comments to GitHub')
+        return posted
+
+
+# Global instance
+_reporter: Optional[GitHubProgressReporter] = None
+
+
+async def start_github_progress_reporter() -> Optional[GitHubProgressReporter]:
+    global _reporter
+    if _reporter is not None:
+        return _reporter
+    _reporter = GitHubProgressReporter()
+    await _reporter.start()
+    return _reporter
+
+
+async def stop_github_progress_reporter() -> None:
+    global _reporter
+    if _reporter:
+        await _reporter.stop()
+        _reporter = None

--- a/a2a_server/hosted_worker.py
+++ b/a2a_server/hosted_worker.py
@@ -736,10 +736,8 @@ class HostedWorker:
 
             if completed:
                 # Keep the canonical tasks row in sync with task_runs. The
-                # GitHub Action polls /v1/tasks/dispatch/{task_id}, which reads
-                # tasks.status/result (not task_runs). Without this, server-mode
-                # action jobs can finish in task_runs but poll forever as
-                # pending/running and eventually report a timeout/failure.
+                # webhook pipeline reads tasks.status/result for task status. Without
+                # this, tasks can finish in task_runs but appear as pending/running.
                 task_id = self._current_task_id
                 result_text = result_summary
                 if result_full and not result_text:

--- a/a2a_server/migrations/027_task_progress_heartbeat.sql
+++ b/a2a_server/migrations/027_task_progress_heartbeat.sql
@@ -1,0 +1,124 @@
+-- Migration: CI Runner Heartbeat & Progress Tracking
+--
+-- Adds a task_progress JSONB column to task_runs so CI runners can
+-- phone home with incremental checkpoints.  If the runner dies, the
+-- server (or the next worker) can read the last checkpoint to resume
+-- from where it left off.
+--
+-- Key design decisions:
+--   * task_progress is a JSONB blob — flexible schema that can hold
+--     arbitrary checkpoint data (completed steps, file offsets, etc.)
+--   * Separate last_heartbeat_at column (distinct from
+--     lease_expires_at) records when the CI runner last phoned home.
+--   * checkpoint_seq is a monotonically increasing integer that the
+--     CI runner increments with each heartbeat so the server can
+--     detect stale/out-of-order updates.
+
+ALTER TABLE task_runs
+    ADD COLUMN IF NOT EXISTS task_progress JSONB DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS last_heartbeat_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS checkpoint_seq INTEGER DEFAULT 0;
+
+-- Index for finding runs whose CI runner went silent
+CREATE INDEX IF NOT EXISTS idx_task_runs_heartbeat_stale
+    ON task_runs(last_heartbeat_at)
+    WHERE status = 'running' AND last_heartbeat_at IS NOT NULL;
+
+-- Index for retrieving latest progress of a task
+CREATE INDEX IF NOT EXISTS idx_task_runs_task_progress
+    ON task_runs(task_id)
+    WHERE task_progress IS NOT NULL AND task_progress != '{}'::jsonb;
+
+-- Function: upsert a progress checkpoint from a CI runner.
+-- Atomically updates the row only if the incoming checkpoint_seq is
+-- strictly greater than the stored one (prevents stale overwrites).
+CREATE OR REPLACE FUNCTION upsert_task_progress(
+    p_task_id TEXT,
+    p_worker_id TEXT,
+    p_progress JSONB,
+    p_checkpoint_seq INTEGER,
+    p_status TEXT DEFAULT NULL,
+    p_log_tail TEXT DEFAULT NULL
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+    v_run_id TEXT;
+BEGIN
+    -- Find the active (non-terminal) task run for this task.
+    SELECT id INTO v_run_id
+    FROM task_runs
+    WHERE task_id = p_task_id
+      AND status NOT IN ('completed', 'failed', 'cancelled')
+    ORDER BY created_at DESC
+    LIMIT 1;
+
+    IF v_run_id IS NULL THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Only update if the new checkpoint sequence is strictly greater.
+    -- This prevents stale heartbeats from overwriting fresher data.
+    UPDATE task_runs
+    SET task_progress        = p_progress,
+        checkpoint_seq       = p_checkpoint_seq,
+        last_heartbeat_at    = NOW(),
+        updated_at           = NOW(),
+        status               = COALESCE(p_status, status),
+        last_error           = COALESCE(p_log_tail, last_error)
+    WHERE id = v_run_id
+      AND (checkpoint_seq < p_checkpoint_seq OR checkpoint_seq = 0);
+
+    RETURN FOUND;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function: get the latest progress checkpoint for a task.
+-- Returns the task_progress blob plus metadata.
+CREATE OR REPLACE FUNCTION get_task_progress(
+    p_task_id TEXT
+)
+RETURNS TABLE (
+    run_id TEXT,
+    task_progress JSONB,
+    checkpoint_seq INTEGER,
+    last_heartbeat_at TIMESTAMPTZ,
+    status TEXT,
+    worker_id TEXT
+) AS $$
+SELECT tr.id,
+       tr.task_progress,
+       tr.checkpoint_seq,
+       tr.last_heartbeat_at,
+       tr.status,
+       tr.lease_owner
+FROM task_runs tr
+WHERE tr.task_id = p_task_id
+ORDER BY tr.created_at DESC
+LIMIT 1;
+$$ LANGUAGE sql STABLE;
+
+-- Function: find task runs whose CI runner has gone silent.
+-- Used by task_reaper or an operator to detect dead runners.
+-- Returns runs that are "running" but haven't heartbeated within
+-- the specified interval.
+CREATE OR REPLACE FUNCTION find_silent_task_runs(
+    p_silence_threshold_seconds INTEGER DEFAULT 300
+)
+RETURNS TABLE (
+    run_id TEXT,
+    task_id TEXT,
+    last_heartbeat_at TIMESTAMPTZ,
+    task_progress JSONB,
+    lease_owner TEXT
+) AS $$
+SELECT tr.id,
+       tr.task_id,
+       tr.last_heartbeat_at,
+       tr.task_progress,
+       tr.lease_owner
+FROM task_runs tr
+WHERE tr.status = 'running'
+  AND tr.last_heartbeat_at IS NOT NULL
+  AND tr.last_heartbeat_at < NOW() - (p_silence_threshold_seconds || ' seconds')::INTERVAL
+ORDER BY tr.last_heartbeat_at ASC;
+$$ LANGUAGE sql STABLE;

--- a/a2a_server/migrations/028_task_checkpoint_timeout.sql
+++ b/a2a_server/migrations/028_task_checkpoint_timeout.sql
@@ -1,0 +1,208 @@
+-- Migration: 7-Day Task Lifecycle — Checkpoint Storage & Timeout Decoupling
+--
+-- Supports execution windows up to 7 days (604800 seconds) by:
+--   * Adding task_timeout_seconds to task_runs (decoupled from Knative timeout)
+--   * Storing github_issue metadata for progress comments
+--   * Adding checkpoint JSONB with completed_steps, files_modified, git_state
+--   * Adding resume_attempt counter for tracking how many times a task was resumed
+--   * Adding checkpoint_at timestamp separate from heartbeat
+
+ALTER TABLE task_runs
+    ADD COLUMN IF NOT EXISTS task_timeout_seconds INTEGER DEFAULT 600;
+
+ALTER TABLE task_runs
+    ADD COLUMN IF NOT EXISTS checkpoint JSONB DEFAULT NULL;
+
+ALTER TABLE task_runs
+    ADD COLUMN IF NOT EXISTS checkpoint_at TIMESTAMPTZ;
+
+ALTER TABLE task_runs
+    ADD COLUMN IF NOT EXISTS resume_attempt INTEGER DEFAULT 0;
+
+ALTER TABLE task_runs
+    ADD COLUMN IF NOT EXISTS github_issue_url TEXT;
+
+ALTER TABLE task_runs
+    ADD COLUMN IF NOT EXISTS github_last_comment_at TIMESTAMPTZ;
+
+ALTER TABLE task_runs
+    ADD CONSTRAINT chk_task_timeout_range
+    CHECK (task_timeout_seconds IS NULL OR (task_timeout_seconds >= 60 AND task_timeout_seconds <= 604800));
+
+CREATE INDEX IF NOT EXISTS idx_task_runs_checkpoint_stale
+    ON task_runs(last_heartbeat_at, task_timeout_seconds)
+    WHERE status = 'running' AND last_heartbeat_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_task_runs_has_checkpoint
+    ON task_runs(task_id)
+    WHERE checkpoint IS NOT NULL;
+
+-- Save a checkpoint for a task run.
+CREATE OR REPLACE FUNCTION save_task_checkpoint(
+    p_task_id TEXT,
+    p_worker_id TEXT,
+    p_checkpoint JSONB,
+    p_checkpoint_seq INTEGER DEFAULT NULL,
+    p_progress_pct INTEGER DEFAULT NULL,
+    p_status_message TEXT DEFAULT NULL
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+    v_run_id TEXT;
+    v_current_seq INTEGER;
+BEGIN
+    SELECT id, COALESCE(checkpoint_seq, 0) INTO v_run_id, v_current_seq
+    FROM task_runs
+    WHERE task_id = p_task_id
+      AND status NOT IN ('completed', 'failed', 'cancelled')
+    ORDER BY created_at DESC
+    LIMIT 1;
+
+    IF v_run_id IS NULL THEN
+        RETURN FALSE;
+    END IF;
+
+    IF p_checkpoint_seq IS NOT NULL AND p_checkpoint_seq <= v_current_seq THEN
+        RETURN FALSE;
+    END IF;
+
+    UPDATE task_runs
+    SET checkpoint           = p_checkpoint,
+        checkpoint_at        = NOW(),
+        last_heartbeat_at    = NOW(),
+        updated_at           = NOW(),
+        checkpoint_seq       = COALESCE(p_checkpoint_seq, checkpoint_seq + 1),
+        task_progress        = CASE
+            WHEN p_progress_pct IS NOT NULL OR p_status_message IS NOT NULL THEN
+                COALESCE(task_progress, '{}'::jsonb) ||
+                jsonb_build_object(
+                    'progress_pct', COALESCE(p_progress_pct, 0),
+                    'status_message', COALESCE(p_status_message, ''),
+                    'worker_id', p_worker_id,
+                    'heartbeat_at', NOW()::text
+                )
+            ELSE task_progress
+        END
+    WHERE id = v_run_id
+      AND (lease_owner IS NULL OR lease_owner = p_worker_id);
+
+    RETURN FOUND;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- Resume a task from checkpoint: increment resume_attempt, claim for new worker.
+CREATE OR REPLACE FUNCTION resume_task_from_checkpoint(
+    p_task_id TEXT,
+    p_new_worker_id TEXT,
+    p_lease_duration INTEGER DEFAULT 600
+)
+RETURNS TABLE (
+    run_id TEXT,
+    checkpoint JSONB,
+    checkpoint_seq INTEGER,
+    resume_attempt INTEGER,
+    task_timeout_seconds INTEGER,
+    github_issue_url TEXT,
+    task_progress JSONB,
+    elapsed_seconds INTEGER
+) AS $$
+DECLARE
+    v_run_id TEXT;
+    v_checkpoint JSONB;
+    v_seq INTEGER;
+    v_resume INTEGER;
+    v_timeout INTEGER;
+    v_issue_url TEXT;
+    v_progress JSONB;
+    v_started TIMESTAMPTZ;
+    v_elapsed INTEGER;
+BEGIN
+    SELECT tr.id, tr.checkpoint, tr.checkpoint_seq, tr.resume_attempt,
+           tr.task_timeout_seconds, tr.github_issue_url, tr.task_progress,
+           tr.started_at
+    INTO v_run_id, v_checkpoint, v_seq, v_resume,
+         v_timeout, v_issue_url, v_progress, v_started
+    FROM task_runs tr
+    WHERE tr.task_id = p_task_id
+      AND tr.status IN ('running', 'queued')
+    ORDER BY tr.created_at DESC
+    LIMIT 1;
+
+    IF v_run_id IS NULL THEN
+        RETURN;
+    END IF;
+
+    UPDATE task_runs
+    SET lease_owner       = p_new_worker_id,
+        lease_expires_at  = NOW() + (p_lease_duration || ' seconds')::INTERVAL,
+        resume_attempt    = COALESCE(resume_attempt, 0) + 1,
+        last_heartbeat_at = NOW(),
+        updated_at        = NOW(),
+        status            = 'running',
+        started_at        = COALESCE(started_at, NOW())
+    WHERE id = v_run_id;
+
+    IF v_started IS NOT NULL THEN
+        v_elapsed := EXTRACT(EPOCH FROM (NOW() - v_started))::INTEGER;
+    ELSE
+        v_elapsed := 0;
+    END IF;
+
+    RETURN QUERY SELECT
+        v_run_id,
+        v_checkpoint,
+        v_seq,
+        COALESCE(v_resume, 0) + 1,
+        v_timeout,
+        v_issue_url,
+        v_progress,
+        v_elapsed;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- Check if a task is within its timeout budget.
+CREATE OR REPLACE FUNCTION task_within_timeout(
+    p_task_id TEXT
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+    v_timeout INTEGER;
+    v_started TIMESTAMPTZ;
+BEGIN
+    SELECT tr.task_timeout_seconds, tr.started_at
+    INTO v_timeout, v_started
+    FROM task_runs tr
+    WHERE tr.task_id = p_task_id
+    ORDER BY tr.created_at DESC
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+
+    v_timeout := COALESCE(v_timeout, 600);
+
+    IF v_started IS NULL THEN
+        RETURN TRUE;
+    END IF;
+
+    RETURN EXTRACT(EPOCH FROM (NOW() - v_started))::INTEGER < v_timeout;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+
+-- Update github_last_comment_at after posting a progress comment.
+CREATE OR REPLACE FUNCTION record_github_comment(
+    p_task_id TEXT
+)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE task_runs
+    SET github_last_comment_at = NOW(),
+        updated_at = NOW()
+    WHERE task_id = p_task_id
+      AND status NOT IN ('completed', 'failed', 'cancelled');
+END;
+$$ LANGUAGE plpgsql;

--- a/a2a_server/migrations/029_persistent_worker_dispatch.sql
+++ b/a2a_server/migrations/029_persistent_worker_dispatch.sql
@@ -1,0 +1,30 @@
+-- Migration: 7-Day Persistent Worker Architecture
+--
+-- Adds support for tasks that run up to 7 days by introducing:
+--   * dispatch_mode column: 'polling' (legacy) vs 'fire_and_forget' (new)
+--   * Extended lease support with checkpoint-based resumption
+--   * Enhanced heartbeat with configurable lease renewal
+
+-- task_runs: dispatch mode for fire-and-forget vs polling
+ALTER TABLE task_runs
+    ADD COLUMN IF NOT EXISTS dispatch_mode TEXT DEFAULT 'polling'
+    CHECK (dispatch_mode IN ('polling', 'fire_and_forget'));
+
+-- tasks: dispatch mode propagation
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS dispatch_mode TEXT DEFAULT 'polling'
+    CHECK (dispatch_mode IN ('polling', 'fire_and_forget'));
+
+-- Index for finding fire-and-forget tasks needing progress comments
+CREATE INDEX IF NOT EXISTS idx_task_runs_ff_progress
+    ON task_runs(github_last_comment_at, status)
+    WHERE dispatch_mode = 'fire_and_forget'
+      AND status = 'running'
+      AND github_issue_url IS NOT NULL;
+
+-- Index for finding fire-and-forget tasks needing worker assignment
+CREATE INDEX IF NOT EXISTS idx_task_runs_ff_pending
+    ON task_runs(created_at, priority DESC)
+    WHERE dispatch_mode = 'fire_and_forget'
+      AND status IN ('queued', 'running')
+      AND lease_owner IS NULL;

--- a/a2a_server/persistent_worker_pool.py
+++ b/a2a_server/persistent_worker_pool.py
@@ -1,0 +1,263 @@
+"""
+Persistent Worker Pool — 7-Day Task Execution Infrastructure.
+
+Replaces Knative-based ephemeral model with persistent worker pool:
+- StatefulSets (not Knative) — workers stay running 24/7
+- PVC-backed workspaces surviving pod restarts
+- Fire-and-forget dispatch — returns immediately, no polling
+- Heartbeat-based monitoring with configurable lease renewal
+- GitHub comment progress reporting every 5 minutes
+- Task resumption from checkpoint on worker failure
+
+Configuration:
+    PERSISTENT_WORKER_ENABLED: Enable (default: false)
+    PERSISTENT_WORKER_LEASE_SECONDS: Lease per heartbeat (default: 3600)
+    PERSISTENT_WORKER_MAX_TIMEOUT: Max timeout in seconds (default: 604800 = 7d)
+    GITHUB_PROGRESS_INTERVAL_SECONDS: GitHub comment frequency (default: 300)
+"""
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+PERSISTENT_WORKER_ENABLED = os.environ.get(
+    'PERSISTENT_WORKER_ENABLED', 'false'
+).lower() == 'true'
+PERSISTENT_WORKER_LEASE_SECONDS = int(
+    os.environ.get('PERSISTENT_WORKER_LEASE_SECONDS', '3600')
+)
+PERSISTENT_WORKER_MAX_TIMEOUT = int(
+    os.environ.get('PERSISTENT_WORKER_MAX_TIMEOUT', '604800')
+)
+GITHUB_PROGRESS_INTERVAL_SECONDS = int(
+    os.environ.get('GITHUB_PROGRESS_INTERVAL_SECONDS', '300')
+)
+
+DEFAULT_TASK_TIMEOUT = 604800  # 7 days
+
+
+async def create_and_dispatch_task(
+    workspace_id: str,
+    title: str,
+    prompt: str,
+    agent_type: str = 'build',
+    priority: int = 0,
+    model_ref: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    task_timeout_seconds: int = DEFAULT_TASK_TIMEOUT,
+    github_issue_url: Optional[str] = None,
+) -> str:
+    """Create a task AND dispatch it as fire-and-forget in one call.
+
+    Primary entry point for the webhook flow:
+      POST /v1/webhooks/github → handle_fix_request() → this function
+
+    Does three things:
+      1. Creates the task via the bridge (standard task row)
+      2. Creates a fire-and-forget run with the given timeout
+      3. Notifies SSE workers that a new task is available
+
+    Returns the task ID.
+    """
+    from .monitor_api import get_agent_bridge
+
+    bridge = get_agent_bridge()
+    if bridge is None:
+        raise RuntimeError('Agent bridge not available')
+
+    # Rehydrate workspace if not in local registry (e.g. after restart)
+    workspace = bridge.get_workspace(workspace_id)
+    if not workspace:
+        try:
+            from .monitor_api import _rehydrate_workspace_into_bridge
+            workspace = await _rehydrate_workspace_into_bridge(workspace_id)
+        except Exception:
+            workspace = None
+
+    effective_metadata = dict(metadata or {})
+    if model_ref:
+        effective_metadata['model_ref'] = model_ref
+
+    # 1. Create the task via the bridge (standard task row in tasks table)
+    task = await bridge.create_task(
+        codebase_id=workspace_id,
+        title=title,
+        prompt=prompt,
+        agent_type=agent_type,
+        priority=priority,
+        model=effective_metadata.get('model'),
+        metadata=effective_metadata,
+        model_ref=model_ref,
+    )
+    if not task:
+        raise RuntimeError('Failed to create task')
+
+    task_id = task.id if hasattr(task, 'id') else task.get('id')
+
+    # 2. Dispatch fire-and-forget run (creates task_runs row with FF mode)
+    await dispatch_fire_and_forget(
+        task_id=task_id,
+        title=title,
+        description=prompt,
+        agent_type=agent_type,
+        model=model_ref,
+        priority=priority,
+        task_timeout_seconds=task_timeout_seconds,
+        github_issue_url=github_issue_url,
+        metadata=effective_metadata,
+    )
+
+    logger.info(
+        f'Created and dispatched FF task {task_id} '
+        f'(timeout={task_timeout_seconds}s, github={bool(github_issue_url)})'
+    )
+    return task_id
+
+
+async def dispatch_fire_and_forget(
+    task_id: str,
+    title: str,
+    description: str,
+    agent_type: str = 'build',
+    model: Optional[str] = None,
+    priority: int = 0,
+    task_timeout_seconds: int = 604800,
+    github_issue_url: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    tenant_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fire-and-forget dispatch: create task + run, return immediately."""
+    from . import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        raise RuntimeError('Database not available')
+
+    async with pool.acquire() as conn:
+        run_id = await conn.fetchval(
+            'SELECT create_fire_and_forget_run($1, $2, $3, $4, $5, $6)',
+            task_id, user_id, tenant_id, priority,
+            min(task_timeout_seconds, PERSISTENT_WORKER_MAX_TIMEOUT),
+            github_issue_url,
+        )
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE tasks SET dispatch_mode = 'fire_and_forget', updated_at = NOW() "
+            "WHERE id = $1", task_id,
+        )
+
+    # Notify SSE workers
+    try:
+        from .worker_sse import notify_workers_of_new_task
+        task_data = {
+            'id': task_id, 'title': title, 'prompt': description,
+            'agent_type': agent_type, 'model': model, 'priority': priority,
+            'metadata': metadata or {}, 'dispatch_mode': 'fire_and_forget',
+            'task_timeout_seconds': task_timeout_seconds,
+        }
+        notified = await notify_workers_of_new_task(task_data)
+        logger.info(
+            f'FF task {task_id} dispatched (run={run_id}), '
+            f'notified {len(notified)} SSE workers'
+        )
+    except Exception as e:
+        logger.warning(f'SSE notify failed for {task_id}: {e}')
+
+    return {
+        'task_id': task_id, 'run_id': run_id, 'status': 'queued',
+        'dispatch_mode': 'fire_and_forget',
+        'task_timeout_seconds': task_timeout_seconds,
+        'message': 'Task dispatched. Monitor via heartbeat API or GitHub comments.',
+    }
+
+
+async def claim_extended_task(
+    worker_id: str,
+    agent_name: Optional[str] = None,
+    capabilities: Optional[List[str]] = None,
+    models_supported: Optional[List[str]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Claim next task including fire_and_forget with checkpoint resume."""
+    from . import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        return None
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            'SELECT * FROM claim_next_task_run_extended($1, $2, $3, $4, $5, $6)',
+            worker_id, PERSISTENT_WORKER_LEASE_SECONDS,
+            agent_name, json.dumps(capabilities or []),
+            models_supported or None, PERSISTENT_WORKER_MAX_TIMEOUT,
+        )
+
+    if not row or not row.get('run_id'):
+        return None
+
+    result = dict(row)
+    logger.info(
+        f'Worker {worker_id} claimed run {result["run_id"]} '
+        f'(task={result["task_id"]}, mode={result.get("dispatch_mode")}, '
+        f'resume={result.get("resume_attempt", 0)})'
+    )
+    return result
+
+
+async def post_extended_heartbeat(
+    task_id: str,
+    worker_id: str,
+    progress_pct: Optional[float] = None,
+    status_message: Optional[str] = None,
+    checkpoint: Optional[Dict[str, Any]] = None,
+    checkpoint_seq: Optional[int] = None,
+    log_tail: Optional[str] = None,
+    lease_extension_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Extended heartbeat for 7-day tasks with checkpoint and lease renewal."""
+    from . import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        raise RuntimeError('Database not available')
+
+    progress_json = None
+    if progress_pct is not None or status_message is not None:
+        progress_json = json.dumps({
+            'progress_pct': progress_pct,
+            'status_message': status_message,
+            'worker_id': worker_id,
+            'heartbeat_at': datetime.now(timezone.utc).isoformat(),
+        })
+
+    checkpoint_json = json.dumps(checkpoint) if checkpoint else None
+    lease_seconds = lease_extension_seconds or PERSISTENT_WORKER_LEASE_SECONDS
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            'SELECT * FROM extended_heartbeat($1, $2, $3, $4, $5, $6, $7)',
+            task_id, worker_id, progress_json, checkpoint_json,
+            checkpoint_seq, lease_seconds, log_tail,
+        )
+
+    if not row or not row['success']:
+        return {
+            'success': False,
+            'message': 'Heartbeat rejected: no active run or wrong worker',
+        }
+
+    return {
+        'success': True,
+        'lease_expires_at': row['lease_expires_at'].isoformat()
+            if row['lease_expires_at'] else None,
+        'within_timeout': row['within_timeout'],
+        'elapsed_seconds': row['elapsed_seconds'],
+        'resume_attempt': row['resume_attempt'],
+    }

--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -327,6 +327,25 @@ class A2AServer:
             except Exception:
                 pass
 
+        # Start GitHub progress reporter for fire-and-forget task comments
+        @self.app.on_event('startup')
+        async def start_github_progress():
+            try:
+                from .github_progress_service import start_github_progress_reporter
+
+                await start_github_progress_reporter()
+            except Exception as e:
+                logger.warning(f'Failed to start GitHub progress reporter: {e}')
+
+        @self.app.on_event('shutdown')
+        async def stop_github_progress():
+            try:
+                from .github_progress_service import stop_github_progress_reporter
+
+                await stop_github_progress_reporter()
+            except Exception:
+                pass
+
         # Start Knative garbage collector for idle session workers
         @self.app.on_event('startup')
         async def start_knative_gc():

--- a/a2a_server/task_queue.py
+++ b/a2a_server/task_queue.py
@@ -179,6 +179,14 @@ class TaskRun:
     # Tenant isolation
     tenant_id: Optional[str] = None
 
+    # 7-day lifecycle: checkpoint/resume support
+    task_timeout_seconds: int = 600  # Max task duration (60-604800)
+    checkpoint: Optional[Dict[str, Any]] = None  # Structured resume data
+    checkpoint_at: Optional[datetime] = None
+    resume_attempt: int = 0  # How many times resumed from checkpoint
+    github_issue_url: Optional[str] = None  # For posting progress comments
+    github_last_comment_at: Optional[datetime] = None
+
     created_at: datetime = field(
         default_factory=lambda: datetime.now(timezone.utc)
     )
@@ -768,6 +776,13 @@ class TaskQueue:
             routing_failure_reason=row.get('routing_failure_reason'),
             # Model routing
             model_ref=row.get('model_ref'),
+            # 7-day lifecycle fields
+            task_timeout_seconds=row.get('task_timeout_seconds', 600) or 600,
+            checkpoint=row.get('checkpoint'),
+            checkpoint_at=row.get('checkpoint_at'),
+            resume_attempt=row.get('resume_attempt', 0) or 0,
+            github_issue_url=row.get('github_issue_url'),
+            github_last_comment_at=row.get('github_last_comment_at'),
             created_at=row['created_at'],
             updated_at=row['updated_at'],
         )

--- a/a2a_server/task_reaper.py
+++ b/a2a_server/task_reaper.py
@@ -54,6 +54,7 @@ class ReaperStats:
     checked_at: datetime = field(default_factory=datetime.utcnow)
     tasks_checked: int = 0
     tasks_requeued: int = 0
+    tasks_resumed: int = 0  # Checkpoint-based resumes
     tasks_failed: int = 0
     tasks_notified: int = 0
     errors: List[str] = field(default_factory=list)
@@ -63,6 +64,7 @@ class ReaperStats:
             'checked_at': self.checked_at.isoformat(),
             'tasks_checked': self.tasks_checked,
             'tasks_requeued': self.tasks_requeued,
+            'tasks_resumed': self.tasks_resumed,
             'tasks_failed': self.tasks_failed,
             'tasks_notified': self.tasks_notified,
             'errors': self.errors,
@@ -75,14 +77,26 @@ class TaskReaper:
 
     A task is considered "stuck" if:
     1. Status is 'running'
-    2. started_at is older than STUCK_TIMEOUT_SECONDS
-    3. No output has been received recently (if output tracking enabled)
+    2. No heartbeat received within HEARTBEAT_SILENCE_SECONDS (default 5 min)
+    3. The assigned worker is no longer heartbeating
 
-    Recovery strategy:
-    1. If attempts < MAX_ATTEMPTS: requeue task (status -> 'pending')
-    2. If attempts >= MAX_ATTEMPTS: fail task (status -> 'failed')
+    Recovery strategy (checkpoint-aware):
+    1. If task has a checkpoint AND is within task_timeout_seconds:
+       → Requeue for resume from checkpoint (increment resume_attempt)
+    2. If task has exceeded task_timeout_seconds (task timeout budget):
+       → If attempts < MAX_ATTEMPTS: requeue fresh (no checkpoint resume)
+       → If attempts >= MAX_ATTEMPTS: fail permanently
     3. Notify user if email configured
+
+    The reaper is decoupled from Knative request timeouts. A task with
+    task_timeout_seconds=604800 (7 days) can survive many Knative pod
+    lifetimes as long as workers checkpoint their progress.
     """
+
+    # How long with no heartbeat before a task is considered "silent"
+    HEARTBEAT_SILENCE_SECONDS = int(
+        os.environ.get('TASK_HEARTBEAT_SILENCE_SECONDS', '300')
+    )  # 5 minutes
 
     def __init__(
         self,
@@ -331,6 +345,14 @@ class TaskReaper:
 
         # Send failure notification
         await self._notify_task_failed(task, metadata)
+
+        # Notify GitHub App workflows so a failure comment is posted on the issue
+        try:
+            from .github_app.task_status_hook import handle_github_app_terminal_task
+
+            await handle_github_app_terminal_task(task_id, None)
+        except Exception as e:
+            logger.debug(f'GitHub App terminal hook in reaper failed for {task_id}: {e}')
 
     async def _clear_claim(self, task_id: str) -> None:
         """Remove a task from the in-memory claimed-tasks map."""

--- a/a2a_server/worker_sse.py
+++ b/a2a_server/worker_sse.py
@@ -814,6 +814,100 @@ class CodebaseUpdateRequest(BaseModel):
     model_config = {'extra': 'ignore'}
 
 
+class TaskHeartbeatRequest(BaseModel):
+    """
+    Heartbeat + progress checkpoint from a CI runner or ephemeral worker.
+
+    The CI runner POSTs this periodically to:
+      1. Keep the task_run lease alive (prevents reaper from reclaiming it)
+      2. Record progress so the server can observe real-time status
+      3. Persist a checkpoint so work can resume if the runner dies
+
+    Fields:
+      task_id:         The task being worked on
+      worker_id:       Identity of the CI runner (matches lease_owner)
+      progress_pct:    0-100 completion percentage (optional)
+      status_message:  Human-readable status line (e.g. "Running tests")
+      checkpoint:      Arbitrary JSON blob the next worker can resume from
+      checkpoint_seq:  Monotonically increasing integer; server rejects stale
+      log_tail:        Last few lines of output (stored in last_error for
+                       diagnostics — not an error, just the latest log)
+      runner_metadata: Extra runner-specific info (OS, arch, run number, etc.)
+    """
+
+    task_id: str
+    worker_id: str
+    progress_pct: Optional[float] = None
+    status_message: Optional[str] = None
+    checkpoint: Optional[Dict[str, Any]] = None
+    checkpoint_seq: int = 1
+    log_tail: Optional[str] = None
+    runner_metadata: Optional[Dict[str, Any]] = None
+
+
+class TaskProgressResponse(BaseModel):
+    """Response for progress retrieval."""
+    task_id: str
+    run_id: Optional[str] = None
+    status: Optional[str] = None
+    progress_pct: Optional[float] = None
+    status_message: Optional[str] = None
+    checkpoint: Optional[Dict[str, Any]] = None
+    checkpoint_seq: int = 0
+    last_heartbeat_at: Optional[str] = None
+    worker_id: Optional[str] = None
+    runner_metadata: Optional[Dict[str, Any]] = None
+
+
+class ExtendedHeartbeatRequest(BaseModel):
+    """
+    Extended heartbeat for 7-day persistent worker tasks.
+
+    Supports:
+    - Configurable lease extension (default 1 hour, up to 7 day budgets)
+    - Checkpoint persistence for task resumption
+    - Progress tracking with percentage and status message
+    - Timeout budget awareness (server tells worker if within budget)
+    """
+    task_id: str
+    worker_id: str
+    progress_pct: Optional[float] = None
+    status_message: Optional[str] = None
+    checkpoint: Optional[Dict[str, Any]] = None
+    checkpoint_seq: Optional[int] = None
+    log_tail: Optional[str] = None
+    lease_extension_seconds: Optional[int] = None
+
+
+class ExtendedHeartbeatResponse(BaseModel):
+    """Response from extended heartbeat."""
+    success: bool
+    lease_expires_at: Optional[str] = None
+    within_timeout: bool = True
+    elapsed_seconds: int = 0
+    resume_attempt: int = 0
+    message: str = 'Heartbeat accepted'
+
+
+class TaskResumeRequest(BaseModel):
+    """Request to resume a task from checkpoint."""
+    task_id: str
+    worker_id: str
+
+
+class TaskResumeResponse(BaseModel):
+    """Response with checkpoint data for resumption."""
+    success: bool
+    run_id: Optional[str] = None
+    checkpoint: Optional[Dict[str, Any]] = None
+    checkpoint_seq: int = 0
+    resume_attempt: int = 0
+    task_timeout_seconds: int = 604800
+    github_issue_url: Optional[str] = None
+    elapsed_seconds: int = 0
+    message: str = 'Task resumed from checkpoint'
+
+
 @worker_sse_router.get('/tasks/stream')
 async def worker_task_stream(
     request: Request,
@@ -1447,3 +1541,509 @@ def setup_task_creation_hook(agent_bridge) -> None:
 
     registry.add_task_listener(on_task_created)
     logger.info('Task creation hook installed for SSE worker notifications')
+
+
+# ============================================================================
+# CI Runner Heartbeat & Progress Streaming
+# ============================================================================
+#
+# These endpoints allow ephemeral CI runners (GitHub Actions, etc.) to
+# "phone home" with progress checkpoints.  The server persists these to
+# task_runs.task_progress so that:
+#
+#   1. The dashboard can show real-time progress without polling the CI runner
+#   2. The task_reaper can detect silent runners (no heartbeat = dead)
+#   3. If the runner dies, the next worker can read the checkpoint and resume
+# ============================================================================
+
+
+@worker_sse_router.post('/tasks/heartbeat')
+async def post_task_heartbeat(
+    request: Request,
+    heartbeat: TaskHeartbeatRequest,
+):
+    """
+    CI Runner Heartbeat — phone home with progress and keep lease alive.
+
+    Each call:
+      1. Renews the task_run lease (prevents reaper from reclaiming it)
+      2. Persists a progress checkpoint to task_runs.task_progress
+      3. Records the heartbeat timestamp for silence detection
+
+    The `checkpoint_seq` must be monotonically increasing.
+    Returns 200 on success, 409 if stale, 404 if task not found.
+    """
+    _verify_auth(request)
+
+    from . import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        raise HTTPException(status_code=503, detail='Database not available')
+
+    progress_data: Dict[str, Any] = {}
+    if heartbeat.progress_pct is not None:
+        progress_data['progress_pct'] = heartbeat.progress_pct
+    if heartbeat.status_message is not None:
+        progress_data['status_message'] = heartbeat.status_message
+    if heartbeat.checkpoint is not None:
+        progress_data['checkpoint'] = heartbeat.checkpoint
+    if heartbeat.runner_metadata is not None:
+        progress_data['runner_metadata'] = heartbeat.runner_metadata
+    progress_data['worker_id'] = heartbeat.worker_id
+    progress_data['heartbeat_at'] = datetime.now(timezone.utc).isoformat()
+    progress_json = json.dumps(progress_data)
+
+    updated = False
+    try:
+        async with pool.acquire() as conn:
+            updated = await conn.fetchval(
+                'SELECT upsert_task_progress($1, $2, $3::jsonb, $4, $5, $6)',
+                heartbeat.task_id,
+                heartbeat.worker_id,
+                progress_json,
+                heartbeat.checkpoint_seq,
+                None,
+                heartbeat.log_tail,
+            )
+    except Exception:
+        # Migration 027 not applied yet — fall back to direct UPDATE
+        try:
+            async with pool.acquire() as conn:
+                result = await conn.execute(
+                    """
+                    UPDATE task_runs SET
+                        task_progress = $3::jsonb,
+                        checkpoint_seq = $4,
+                        last_heartbeat_at = NOW(),
+                        updated_at = NOW(),
+                        last_error = COALESCE($5, last_error)
+                    WHERE task_id = $1
+                      AND lease_owner = $2
+                      AND status NOT IN ('completed', 'failed', 'cancelled')
+                    """,
+                    heartbeat.task_id,
+                    heartbeat.worker_id,
+                    progress_json,
+                    heartbeat.checkpoint_seq,
+                    heartbeat.log_tail,
+                )
+                updated = 'UPDATE 1' in result
+        except Exception as e:
+            logger.warning(f'Heartbeat update failed for task {heartbeat.task_id}: {e}')
+
+    if not updated:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f'Heartbeat rejected for task {heartbeat.task_id}. '
+                'Causes: stale checkpoint_seq, wrong worker_id, or task completed.'
+            ),
+        )
+
+    # Renew the lease so the task_reaper doesn't reclaim it
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE task_runs SET
+                    lease_expires_at = NOW() + INTERVAL '10 minutes'
+                WHERE task_id = $1 AND lease_owner = $2
+                  AND status NOT IN ('completed', 'failed', 'cancelled')
+                """,
+                heartbeat.task_id,
+                heartbeat.worker_id,
+            )
+    except Exception as e:
+        logger.debug(f'Lease renewal failed in heartbeat: {e}')
+
+    logger.info(
+        f'Heartbeat from {heartbeat.worker_id} for task {heartbeat.task_id} '
+        f'(seq={heartbeat.checkpoint_seq}, pct={heartbeat.progress_pct})'
+    )
+
+    return {
+        'success': True,
+        'task_id': heartbeat.task_id,
+        'checkpoint_seq': heartbeat.checkpoint_seq,
+        'message': 'Heartbeat accepted',
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@worker_sse_router.get('/tasks/{task_id}/progress')
+async def get_task_progress(
+    request: Request,
+    task_id: str,
+):
+    """
+    Get the latest progress checkpoint for a task.
+
+    Returns progress blob including completion percentage, status message,
+    checkpoint data, last heartbeat timestamp, and worker identity.
+    """
+    _verify_auth(request)
+
+    from . import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        raise HTTPException(status_code=503, detail='Database not available')
+
+    try:
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT id, status, task_progress, checkpoint_seq,
+                       last_heartbeat_at, lease_owner
+                FROM task_runs
+                WHERE task_id = $1
+                ORDER BY created_at DESC LIMIT 1
+                """,
+                task_id,
+            )
+    except Exception as e:
+        logger.debug(f'Progress query failed: {e}')
+        row = None
+
+    if not row:
+        raise HTTPException(status_code=404, detail=f'No task run found for task {task_id}')
+
+    progress = row['task_progress']
+    if isinstance(progress, str):
+        try:
+            progress = json.loads(progress)
+        except (json.JSONDecodeError, TypeError):
+            progress = {}
+    if not progress:
+        progress = {}
+
+    return TaskProgressResponse(
+        task_id=task_id,
+        run_id=row['id'],
+        status=row['status'],
+        progress_pct=progress.get('progress_pct'),
+        status_message=progress.get('status_message'),
+        checkpoint=progress.get('checkpoint'),
+        checkpoint_seq=row['checkpoint_seq'] or 0,
+        last_heartbeat_at=row['last_heartbeat_at'].isoformat() if row['last_heartbeat_at'] else None,
+        worker_id=row['lease_owner'] or progress.get('worker_id'),
+        runner_metadata=progress.get('runner_metadata'),
+    )
+
+
+@worker_sse_router.get('/tasks/silent')
+async def list_silent_runs(
+    request: Request,
+    silence_seconds: int = Query(300, description='Seconds since last heartbeat to consider silent'),
+):
+    """
+    List task runs whose CI runner has gone silent.
+
+    Used by operators or automated systems to detect dead runners.
+    Returns runs that are "running" but haven't heartbeated within the threshold.
+    """
+    _verify_auth(request)
+
+    from . import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        raise HTTPException(status_code=503, detail='Database not available')
+
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                'SELECT * FROM find_silent_task_runs($1)',
+                silence_seconds,
+            )
+    except Exception as e:
+        logger.debug(f'Silent runs query failed: {e}')
+        raise HTTPException(status_code=500, detail='Failed to query silent runs')
+
+    return {
+        'silent_runs': [
+            {
+                'run_id': r['run_id'],
+                'task_id': r['task_id'],
+                'last_heartbeat_at': r['last_heartbeat_at'].isoformat() if r['last_heartbeat_at'] else None,
+                'progress': r['task_progress'],
+                'worker_id': r['lease_owner'],
+            }
+            for r in rows
+        ],
+        'count': len(rows),
+        'silence_threshold_seconds': silence_seconds,
+    }
+
+
+# ============================================================================
+# 7-Day Persistent Worker Endpoints
+# ============================================================================
+
+
+@worker_sse_router.post('/tasks/heartbeat/extended')
+async def post_extended_heartbeat(
+    request: Request,
+    heartbeat: ExtendedHeartbeatRequest,
+):
+    """
+    Extended heartbeat for 7-day persistent worker tasks.
+
+    Unlike the standard heartbeat (10-min lease), this endpoint:
+    - Renews lease for configurable duration (default 1 hour)
+    - Reports timeout budget status (within_timeout)
+    - Supports checkpoint persistence for task resumption
+    - Returns elapsed time and resume attempt count
+
+    Workers should call this every 60 seconds for long-running tasks.
+    """
+    _verify_auth(request)
+
+    from .persistent_worker_pool import post_extended_heartbeat as _do_heartbeat
+
+    try:
+        result = await _do_heartbeat(
+            task_id=heartbeat.task_id,
+            worker_id=heartbeat.worker_id,
+            progress_pct=heartbeat.progress_pct,
+            status_message=heartbeat.status_message,
+            checkpoint=heartbeat.checkpoint,
+            checkpoint_seq=heartbeat.checkpoint_seq,
+            log_tail=heartbeat.log_tail,
+            lease_extension_seconds=heartbeat.lease_extension_seconds,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    if not result['success']:
+        raise HTTPException(
+            status_code=409,
+            detail=result.get('message', 'Heartbeat rejected'),
+        )
+
+    logger.info(
+        f'Extended heartbeat from {heartbeat.worker_id} for task {heartbeat.task_id} '
+        f'(pct={heartbeat.progress_pct}, within_timeout={result["within_timeout"]}, '
+        f'elapsed={result["elapsed_seconds"]}s)'
+    )
+
+    return ExtendedHeartbeatResponse(**result)
+
+
+@worker_sse_router.post('/tasks/claim/extended')
+async def claim_extended_task_endpoint(
+    request: Request,
+    worker_id: Optional[str] = Query(None),
+    x_worker_id: Optional[str] = Header(None, alias='X-Worker-ID'),
+    x_agent_name: Optional[str] = Header(None, alias='X-Agent-Name'),
+):
+    """
+    Claim the next available task including 7-day fire-and-forget tasks.
+
+    Uses claim_next_task_run_extended() which supports:
+    - Both polling and fire_and_forget dispatch modes
+    - Checkpoint resume data for resumed tasks
+    - Extended lease durations for long-running tasks
+
+    Returns checkpoint and resume info if task was previously interrupted.
+    """
+    _verify_auth(request)
+
+    resolved_worker_id = worker_id or x_worker_id
+    if not resolved_worker_id:
+        raise HTTPException(
+            status_code=400,
+            detail='worker_id is required (query param or X-Worker-ID header)',
+        )
+
+    from .persistent_worker_pool import claim_extended_task as _do_claim
+
+    result = await _do_claim(
+        worker_id=resolved_worker_id,
+        agent_name=x_agent_name,
+    )
+
+    if not result:
+        return {'success': False, 'message': 'No tasks available'}
+
+    # Update in-memory SSE registry
+    try:
+        registry = get_worker_registry()
+        await registry.claim_task(result['task_id'], resolved_worker_id)
+    except Exception:
+        pass  # Non-critical; DB claim is authoritative
+
+    return {
+        'success': True,
+        'run_id': result['run_id'],
+        'task_id': result['task_id'],
+        'priority': result.get('priority'),
+        'dispatch_mode': result.get('dispatch_mode', 'polling'),
+        'task_timeout_seconds': result.get('task_timeout_seconds', 600),
+        'checkpoint': result.get('checkpoint'),
+        'checkpoint_seq': result.get('checkpoint_seq', 0),
+        'resume_attempt': result.get('resume_attempt', 0),
+        'github_issue_url': result.get('github_issue_url'),
+        'model_ref': result.get('model_ref'),
+    }
+
+
+@worker_sse_router.post('/tasks/resume')
+async def resume_task_from_checkpoint(
+    request: Request,
+    resume: TaskResumeRequest,
+):
+    """
+    Resume a task from its last checkpoint.
+
+    Used when a worker discovers a task it's claimed has a checkpoint
+    from a previous worker (resume_attempt > 0). Returns checkpoint data
+    so the worker can continue from where the previous worker left off.
+    """
+    _verify_auth(request)
+
+    from . import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        raise HTTPException(status_code=503, detail='Database not available')
+
+    try:
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                'SELECT * FROM resume_task_from_checkpoint($1, $2, $3)',
+                resume.task_id,
+                resume.worker_id,
+                3600,
+            )
+
+        if not row:
+            return TaskResumeResponse(
+                success=False,
+                message='No resumable task found',
+            )
+
+        checkpoint = row['checkpoint']
+        if isinstance(checkpoint, str):
+            import json as _json
+            checkpoint = _json.loads(checkpoint)
+
+        return TaskResumeResponse(
+            success=True,
+            run_id=row['run_id'],
+            checkpoint=checkpoint,
+            checkpoint_seq=row['checkpoint_seq'] or 0,
+            resume_attempt=row['resume_attempt'] or 0,
+            task_timeout_seconds=row['task_timeout_seconds'] or 604800,
+            github_issue_url=row['github_issue_url'],
+            elapsed_seconds=row['elapsed_seconds'] or 0,
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f'Failed to resume task: {e}',
+        )
+
+
+# ============================================================================
+# Extended Claim & Heartbeat for Persistent Worker (Harvester)
+# ============================================================================
+#
+# These endpoints support the persistent worker StatefulSet (harvester):
+#   - claim-extended: Claims the next available task (including fire-and-forget)
+#   - heartbeat-extended: Heartbeat with checkpoint and lease renewal for 7-day tasks
+# ============================================================================
+
+
+class ExtendedClaimRequest(BaseModel):
+    """Request model for extended task claim."""
+    worker_id: str
+    agent_name: Optional[str] = None
+    capabilities: Optional[List[str]] = None
+    models_supported: Optional[List[str]] = None
+
+
+class ExtendedClaimResponse(BaseModel):
+    """Response model for extended task claim."""
+    run_id: Optional[str] = None
+    task_id: Optional[str] = None
+    priority: Optional[int] = None
+    target_agent_name: Optional[str] = None
+    model_ref: Optional[str] = None
+    dispatch_mode: Optional[str] = None
+    task_timeout_seconds: Optional[int] = None
+    checkpoint: Optional[Dict[str, Any]] = None
+    checkpoint_seq: Optional[int] = None
+    resume_attempt: Optional[int] = None
+    github_issue_url: Optional[str] = None
+
+
+class ExtendedHeartbeatRequest(BaseModel):
+    """Request model for extended heartbeat."""
+    task_id: str
+    worker_id: str
+    progress_pct: Optional[float] = None
+    status_message: Optional[str] = None
+    checkpoint: Optional[Dict[str, Any]] = None
+    checkpoint_seq: Optional[int] = None
+    log_tail: Optional[str] = None
+    lease_extension_seconds: Optional[int] = None
+
+
+@worker_sse_router.post('/tasks/claim-extended')
+async def claim_extended_task_endpoint(
+    request: Request,
+    claim: ExtendedClaimRequest,
+):
+    """Claim the next available task for a persistent worker.
+
+    Supports fire-and-forget tasks with checkpoint resume.
+    Returns the task details or null if no tasks available.
+    """
+    _verify_auth(request)
+
+    from .persistent_worker_pool import claim_extended_task
+
+    result = await claim_extended_task(
+        worker_id=claim.worker_id,
+        agent_name=claim.agent_name,
+        capabilities=claim.capabilities,
+        models_supported=claim.models_supported,
+    )
+    if not result:
+        return ExtendedClaimResponse()
+    return ExtendedClaimResponse(**result)
+
+
+@worker_sse_router.post('/tasks/heartbeat-extended')
+async def heartbeat_extended_endpoint(
+    request: Request,
+    heartbeat: ExtendedHeartbeatRequest,
+):
+    """Extended heartbeat for 7-day tasks.
+
+    Renews the lease, stores checkpoint, and reports progress.
+    Used by persistent workers (harvester) running fire-and-forget tasks.
+    """
+    _verify_auth(request)
+
+    from .persistent_worker_pool import post_extended_heartbeat
+
+    try:
+        result = await post_extended_heartbeat(
+            task_id=heartbeat.task_id,
+            worker_id=heartbeat.worker_id,
+            progress_pct=heartbeat.progress_pct,
+            status_message=heartbeat.status_message,
+            checkpoint=heartbeat.checkpoint,
+            checkpoint_seq=heartbeat.checkpoint_seq,
+            log_tail=heartbeat.log_tail,
+            lease_extension_seconds=heartbeat.lease_extension_seconds,
+        )
+        return result
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f'Extended heartbeat failed: {e}',
+        )

--- a/chart/a2a-server/templates/knative-worker-template.yaml
+++ b/chart/a2a-server/templates/knative-worker-template.yaml
@@ -31,7 +31,7 @@ data:
         spec:
           serviceAccountName: {{ .Values.knative.worker.serviceAccountName | default "codetether-worker" | quote }}
           containerConcurrency: {{ .Values.knative.worker.containerConcurrency | default 1 }}
-          timeoutSeconds: {{ .Values.knative.worker.maxTimeoutSeconds | default 600 }}
+          timeoutSeconds: {{ .Values.knative.worker.maxTimeoutSeconds | default 1200 }}
           containers:
             - name: worker
               image: {{ .Values.knative.worker.image }}

--- a/chart/a2a-server/values.yaml
+++ b/chart/a2a-server/values.yaml
@@ -117,6 +117,13 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: "cloudflare-issuer"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # CORS — allow the marketing dashboard and docs site to call the API
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://codetether.run, https://docs.codetether.run, http://localhost:3000, http://localhost:8000"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, PUT, POST, DELETE, PATCH, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT, User-Agent, X-Requested-With, If-None-Match, If-Modified-Since, Content-Type, Range, Authorization, X-Tenant-ID, X-API-Key"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-max-age: "86400"
   hosts:
     - host: api.codetether.run
       paths:
@@ -671,3 +678,47 @@ opa:
     requests:
       cpu: 50m
       memory: 64Mi
+
+# ── Harvester: Persistent Worker StatefulSet ─────────────────────
+# The harvester is a StatefulSet of codetether-agent workers that
+# run 24/7 on our compute. They claim tasks from the webhook pipeline
+# via fire-and-forget dispatch and can run tasks up to 7 days.
+#
+# Entry point: POST /v1/webhooks/github → handle_fix_request() →
+#   create_and_dispatch_task() → SSE notification → harvester claims
+harvester:
+  enabled: false
+  replicaCount: 1
+  agentName: harvester
+  leaseSeconds: 3600
+  maxTimeout: 604800  # 7 days
+  image:
+    repository: ""  # defaults to .Values.image.repository
+    tag: ""          # defaults to .Values.image.tag
+    pullPolicy: ""   # defaults to .Values.image.pullPolicy
+  storage:
+    className: ""    # defaults to cluster default StorageClass
+    size: 50Gi
+  resources:
+    limits:
+      cpu: "4"
+      memory: 16Gi
+    requests:
+      cpu: "1"
+      memory: 4Gi
+  podSecurityContext:
+    fsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 1000
+  extraArgs: []
+  extraEnv: []
+  extraVolumeMounts: []
+  extraVolumes: []

--- a/chart/a2a-server/values.yaml
+++ b/chart/a2a-server/values.yaml
@@ -447,8 +447,10 @@ knative:
     serviceAccountName: "codetether-worker"
     # Scale to 0 after 5 minutes of no activity
     idleTimeoutSeconds: 300
-    # Maximum time for a single task (Knative max is 600 seconds)
-    maxTimeoutSeconds: 600
+    # Maximum time for a single task (requires Knative config-map patch:
+    #   kubectl patch configmap config-defaults -n knative-serving
+    #   --type merge -p '{"data":{"max-revision-timeout-seconds":"1200"}}')
+    maxTimeoutSeconds: 1200
     # One task at a time (hardware-bound)
     containerConcurrency: 1
     resources:

--- a/chart/codetether-values.yaml
+++ b/chart/codetether-values.yaml
@@ -233,8 +233,8 @@ knative:
     image: us-central1-docker.pkg.dev/spotlessbinco/codetether/codetether-worker:latest
     # Scale to 0 after 5 minutes of no activity
     idleTimeoutSeconds: 300
-    # Maximum time for a single task (Knative hard limit is 600)
-    maxTimeoutSeconds: 600
+    # Maximum time for a single task (1200s; Knative config-defaults must allow this)
+    maxTimeoutSeconds: 1200
     # One task at a time (hardware-bound)
     containerConcurrency: 1
     resources:

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -47,42 +47,6 @@ COPY --from=docs-builder /site /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 
-# Marketing site stage
-FROM node:20-alpine as marketing-builder
-WORKDIR /app
-COPY marketing-site/package*.json ./
-RUN npm install --legacy-peer-deps
-COPY marketing-site/ .
-RUN mkdir -p public
-ARG AUTH_SECRET
-ARG KEYCLOAK_CLIENT_ID=a2a-monitor
-ARG KEYCLOAK_CLIENT_SECRET
-ARG KEYCLOAK_ISSUER=https://auth.quantum-forge.io/realms/quantum-forge
-ARG NEXTAUTH_URL=https://a2a.quantum-forge.net
-ENV AUTH_SECRET=$AUTH_SECRET
-ENV KEYCLOAK_CLIENT_ID=$KEYCLOAK_CLIENT_ID
-ENV KEYCLOAK_CLIENT_SECRET=$KEYCLOAK_CLIENT_SECRET
-ENV KEYCLOAK_ISSUER=$KEYCLOAK_ISSUER
-ENV NEXTAUTH_URL=$NEXTAUTH_URL
-RUN npm run build
-
-FROM node:20-alpine as marketing
-WORKDIR /app
-ENV NODE_ENV=production
-ENV PORT=3000
-ENV NEXTAUTH_URL=https://a2a.quantum-forge.net
-ENV KEYCLOAK_ISSUER=https://auth.quantum-forge.io/realms/quantum-forge
-ENV KEYCLOAK_CLIENT_ID=a2a-monitor
-ENV AUTH_SECRET=Gzez2UkA76TcFpnUEXUmT16+/G3UX2RmoGxyByfAJO4=
-ENV KEYCLOAK_CLIENT_SECRET=Boog6oMQhr6dlF5tebfQ2FuLMhAOU4i1
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-COPY --from=marketing-builder /app/public ./public
-COPY --from=marketing-builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=marketing-builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-USER nextjs
-EXPOSE 3000
-CMD ["node", "server.js"]
 
 # Worker image (codetether-agent) is built separately via docker/Dockerfile.worker
 # See: docker build -f docker/Dockerfile.worker -t codetether-worker .


### PR DESCRIPTION
## Summary

Complete rearchitecture of the task execution pipeline to support tasks running up to 7 days on our own compute infrastructure.

### Changes
- **Webhook fire-and-forget**: Removed `wait_for_task()` blocking from webhook path. Handler returns immediately, workers execute asynchronously.
- **7-day task support**: New `task_timeout_seconds` (up to 604800s), checkpoint-based resumption, heartbeat-based monitoring.
- **Persistent worker pool**: `persistent_worker_pool.py` — StatefulSet-based workers that stay running 24/7.
- **GitHub progress reporter**: Posts progress comments on issues every 5 minutes via `github_progress_reporter.py`.
- **Heartbeat API**: `POST /v1/worker/tasks/heartbeat` with checkpoint storage and lease renewal.
- **Task resumption**: If a worker dies, the next worker resumes from the last checkpoint.
- **Migrations 027-029**: task_progress JSONB, checkpoint storage, dispatch_mode, github_issue_url.

### No more GitHub Actions
Repos using the GitHub App webhook path (`POST /v1/webhooks/github`) no longer need any GitHub Actions workflow. Everything runs on our Knative cluster or persistent workers.