### PR TITLE
feat: add GitHub App review merge stewardship

### DIFF
--- a/a2a_server/github_app/issue_clone_task.py
+++ b/a2a_server/github_app/issue_clone_task.py
@@ -33,12 +33,27 @@ async def create_issue_clone_task(
     followup_metadata = {
         'workspace_id': wid,
         'source': 'github-app',
+        'workflow_stage': 'code',
         'repo': context.repo_full_name,
         'issue_number': context.issue_number,
         'branch_name': branch,
         'default_branch': base_branch,
         'github_issue_url': github_issue_url,
         'github_installation_id': github_installation_id,
+        'worker_personality': 'builder',
+        'personality': {
+            'name': 'CodeTether',
+            'avatar': 'codetether-avatar',
+            'tone': 'concise, implementation-focused, provenance-aware',
+        },
+        'codetether_provenance': {
+            'workflow': 'github-issue-code-pr-review-merge',
+            'stage': 'code',
+            'repo': context.repo_full_name,
+            'issue_number': context.issue_number,
+            'branch': branch,
+            'installation_id': github_installation_id,
+        },
     }
 
     routing = await resolve_task_target()

--- a/a2a_server/github_app/issue_final_comment.py
+++ b/a2a_server/github_app/issue_final_comment.py
@@ -90,9 +90,44 @@ async def notify_issue_final_comment(task: dict) -> None:
         body = str(task.get('result') or '').strip()
 
         if pr:
+            metadata = task.get('metadata') or {}
+            review_task_id = None
+            review_status = ''
+            try:
+                from .issue_review_task import create_issue_review_task, provenance_footer, issue_pr_provenance
+
+                review_task_id = await create_issue_review_task(
+                    workspace_id=str(metadata.get('workspace_id') or ''),
+                    repo=repo,
+                    issue_number=issue_number,
+                    branch=branch,
+                    pr=pr,
+                    github_issue_url=metadata.get('github_issue_url'),
+                    github_installation_id=metadata.get('github_installation_id'),
+                    parent_task_id=str(task_id),
+                )
+                if review_task_id:
+                    review_status = f"\n\nQueued CodeTether reviewer task `{review_task_id}`. If review passes, a merge-steward task will enforce policy gates before merging."
+                else:
+                    review_status = "\n\nCodeTether review automation was not queued because the local provenance/policy gate denied it."
+                provenance = issue_pr_provenance(
+                    repo=repo,
+                    issue_number=issue_number,
+                    branch=branch,
+                    pr=pr,
+                    installation_id=metadata.get('github_installation_id'),
+                    action='github:review_pr',
+                    parent_task_id=str(task_id),
+                )
+                review_status += provenance_footer(provenance, action='github:review_pr')
+            except Exception as exc:
+                logger.exception('Failed to enqueue issue PR review for task %s: %s', task_id, exc)
+                review_status = f"\n\n⚠️ CodeTether could not queue the reviewer task: `{exc}`"
+
             message = f"## 🛠️ CodeTether Fix\n\nOpened PR #{pr['number']}: {pr['html_url']}"
             if body:
                 message += f"\n\n{body}"
+            message += review_status
             await post_issue_comment(repo, issue_number, token, message)
             return
 

--- a/a2a_server/github_app/issue_prompt.py
+++ b/a2a_server/github_app/issue_prompt.py
@@ -24,7 +24,7 @@ def issue_fix_prompt(
     body = issue.get('body') or 'No issue description was provided.'
     return f"""You are implementing issue #{issue['number']}: "{issue['title']}" in {context.repo_full_name}.
 
-Work from the checked-out repository, create or reuse branch `{branch}`, apply the requested changes, run the smallest relevant validation, commit, push, and open a pull request against `{repo['default_branch']}`.
+Work from the checked-out repository, create or reuse branch `{branch}`, apply the requested changes, run the smallest relevant validation, commit, push, and open a pull request against `{repo['default_branch']}`. Add a PR body section titled `CodeTether provenance` that states the issue number, branch, validation run, and that the follow-up reviewer/merge-steward agents will enforce policy gates. Use CodeTether's concise, provenance-aware personality/avatar in GitHub-facing text.
 
 Do not stay in analysis mode. Use at most 5 discovery reads or searches before your first code edit. Prefer editing the most obvious matching files first, especially files whose names or paths match the requested feature area. If a transient provider or network error occurs, continue and finish the implementation instead of restarting the task from scratch.
 

--- a/a2a_server/github_app/issue_review_task.py
+++ b/a2a_server/github_app/issue_review_task.py
@@ -1,0 +1,418 @@
+"""Review and merge task creation for issue-driven GitHub App PRs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+from ..provenance import verify_provenance
+from .settings import MODEL_REF
+
+DEFAULT_TASK_TIMEOUT = 604800  # 7 days
+
+CODETETHER_PERSONALITY = {
+    'name': 'CodeTether',
+    'avatar': 'codetether-avatar',
+    'tone': 'concise, safety-first, provenance-aware',
+}
+
+
+def issue_pr_provenance(
+    *,
+    repo: str,
+    issue_number: int,
+    branch: str,
+    pr: dict[str, Any],
+    installation_id: int | str | None,
+    action: str,
+    parent_task_id: str | None = None,
+) -> dict[str, Any]:
+    """Build an APF-compatible provenance envelope for GitHub issue automation.
+
+    The local provenance verifier is intentionally deterministic. We bind the
+    delegated action to the exact repo, issue, PR, branch, and head SHA and carry
+    that envelope through the reviewer/merger tasks.
+    """
+    pr_number = int(pr.get('number') or 0)
+    head = pr.get('head') or {}
+    base = pr.get('base') or {}
+    head_sha = str(head.get('sha') or '')
+    base_sha = str(base.get('sha') or '')
+    intent_material = {
+        'repo': repo,
+        'issue_number': issue_number,
+        'pr_number': pr_number,
+        'branch': branch,
+        'head_sha': head_sha,
+        'action': action,
+    }
+    intent_hash = hashlib.sha256(
+        json.dumps(intent_material, sort_keys=True, separators=(',', ':')).encode()
+    ).hexdigest()
+    return {
+        'ap_origin': {
+            'system': 'codetether-github-app',
+            'intent_hash': intent_hash,
+            'intent': f'{action} issue #{issue_number} PR #{pr_number} in {repo}',
+            'trigger': 'github-issue-automation',
+        },
+        'ap_inputs': [
+            {
+                'id': f'github:{repo}#issue-{issue_number}',
+                'source': 'github-webhook',
+                'sensitivity': 'repository-write',
+                'applied_at_turn': 0,
+            },
+            {
+                'id': f'github:{repo}#pr-{pr_number}@{head_sha}',
+                'source': 'github-rest',
+                'sensitivity': 'repository-write',
+                'applied_at_turn': 1,
+            },
+        ],
+        'ap_delegation': {
+            'chain': [
+                {
+                    'actor': 'codetether-github-app',
+                    'capability': {
+                        'root': False,
+                        'operations': ['github:review_pr', 'github:request_changes', 'github:merge_pr'],
+                        'spawn': {'max_depth': 2, 'max_fanout': 2},
+                        'budget': {'github_api_calls': 200},
+                    },
+                },
+                {
+                    'actor': 'codetether-merge-steward' if action == 'github:merge_pr' else 'codetether-reviewer',
+                    'capability': {
+                        'root': False,
+                        'operations': [action],
+                        'spawn': {'max_depth': 1, 'max_fanout': 1},
+                        'budget': {'github_api_calls': 100},
+                    },
+                },
+            ]
+        },
+        'ap_runtime': {
+            'service': 'a2a-server',
+            'workflow': 'github-issue-review-merge',
+            'parent_task_id': parent_task_id,
+        },
+        'ap_output': {
+            'repo': repo,
+            'issue_number': issue_number,
+            'pr_number': pr_number,
+            'branch': branch,
+            'head_sha': head_sha,
+            'base_sha': base_sha,
+            'installation_id': str(installation_id or ''),
+            'action': action,
+        },
+    }
+
+
+def provenance_footer(provenance: dict[str, Any], *, action: str) -> str:
+    """Render a compact GitHub-visible provenance footer."""
+    output = provenance.get('ap_output') or {}
+    origin = provenance.get('ap_origin') or {}
+    return (
+        "\n\n---\n"
+        "Automation provenance:\n"
+        f"- CodeTether workflow: `github-issue-review-merge`\n"
+        f"- Action: `{action}`\n"
+        f"- Intent hash: `{origin.get('intent_hash', '')}`\n"
+        f"- PR: `#{output.get('pr_number', '')}`\n"
+        f"- Head SHA: `{output.get('head_sha', '')}`\n"
+        f"- Personality/avatar: `{CODETETHER_PERSONALITY['name']}` / `{CODETETHER_PERSONALITY['avatar']}`"
+    )
+
+
+def policy_decision(provenance: dict[str, Any], action: str) -> dict[str, Any]:
+    """Evaluate the local provenance gate for a GitHub automation action."""
+    resource = {
+        'session_origin_intent_hash': (provenance.get('ap_origin') or {}).get('intent_hash'),
+        'session_taints': provenance.get('ap_inputs') or [],
+    }
+    decision = verify_provenance(provenance, action, resource)
+    return {
+        'allowed': decision.allowed_by_provenance and not decision.partial,
+        'provenance': decision.as_dict(),
+        'action': action,
+    }
+
+
+def _repo_parts(repo_full_name: str) -> tuple[str, str]:
+    owner, _, repo = repo_full_name.partition('/')
+    return owner, repo
+
+
+async def record_automation_decision(
+    *,
+    provenance: dict[str, Any],
+    decision: dict[str, Any],
+    task_id: str | None = None,
+    github_request_id: str | None = None,
+    github_status: int | None = None,
+) -> None:
+    """Persist a GitHub automation policy/provenance decision if the DB is available."""
+    try:
+        from .. import database as db
+
+        pool = await db.get_pool()
+        if not pool:
+            return
+        output = provenance.get('ap_output') or {}
+        owner, repo_name = _repo_parts(str(output.get('repo') or ''))
+        policy = decision.get('provenance') or {}
+        personality = dict(CODETETHER_PERSONALITY)
+        policy_decision_value = 'allow' if decision.get('allowed') else 'deny'
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO github_automation_decisions (
+                    id, action, owner, repo, pull_number, issue_number,
+                    branch_name, head_sha, base_sha, installation_id, actor,
+                    personality, policy_decision, policy_reasons, provenance,
+                    task_id, github_request_id, github_status
+                ) VALUES (
+                    $1, $2, $3, $4, $5, $6,
+                    $7, $8, $9, NULLIF($10, '')::BIGINT, $11,
+                    $12::jsonb, $13, $14::jsonb, $15::jsonb,
+                    $16, $17, $18
+                )
+                """,
+                str(uuid.uuid4()),
+                str(decision.get('action') or output.get('action') or ''),
+                owner,
+                repo_name,
+                int(output.get('pr_number') or 0) or None,
+                int(output.get('issue_number') or 0) or None,
+                str(output.get('branch') or ''),
+                str(output.get('head_sha') or ''),
+                str(output.get('base_sha') or ''),
+                str(output.get('installation_id') or ''),
+                str(((provenance.get('ap_delegation') or {}).get('chain') or [{}])[-1].get('actor') or 'codetether-github-app'),
+                json.dumps(personality),
+                policy_decision_value,
+                json.dumps(policy.get('failures') or []),
+                json.dumps(provenance),
+                task_id,
+                github_request_id,
+                github_status,
+            )
+    except Exception as exc:
+        logger.warning('Failed to record GitHub automation decision: %s', exc)
+
+
+def reviewer_allows_merge(review_task: dict[str, Any]) -> bool:
+    """Return True only when the reviewer explicitly approved the PR."""
+    result = str(review_task.get('result') or '').upper()
+    if 'CHANGES_REQUESTED' in result or 'BLOCKED' in result:
+        return False
+    return 'APPROVED' in result
+
+
+def review_prompt(repo: str, issue_number: int, branch: str, pr: dict[str, Any], provenance: dict[str, Any]) -> str:
+    pr_number = pr.get('number')
+    pr_url = pr.get('html_url') or f'https://github.com/{repo}/pull/{pr_number}'
+    footer = provenance_footer(provenance, action='github:review_pr')
+    return f"""You are the CodeTether reviewer agent for issue #{issue_number} in {repo}.
+
+Review PR #{pr_number}: {pr_url}
+Branch: {branch}
+Head SHA: {(pr.get('head') or {}).get('sha', '')}
+
+Personality/avatar: {CODETETHER_PERSONALITY['name']} using {CODETETHER_PERSONALITY['avatar']} — concise, safety-first, provenance-aware.
+
+End-to-end responsibilities:
+1. Fetch the PR branch and inspect the diff.
+2. Run the smallest relevant validation for the changed files.
+3. Do not approve your own unsafe work. If tests fail, scope drifts, secrets appear, or provenance does not match the current head SHA, request changes with clear remediation.
+4. If the PR is safe, leave an approving review or success comment.
+5. Include this exact provenance footer in any GitHub review/comment you create:{footer}
+
+Final response must state one of: APPROVED, CHANGES_REQUESTED, or BLOCKED, plus the PR URL and validation summary."""
+
+
+def merge_prompt(repo: str, issue_number: int, branch: str, pr: dict[str, Any], provenance: dict[str, Any]) -> str:
+    pr_number = pr.get('number')
+    pr_url = pr.get('html_url') or f'https://github.com/{repo}/pull/{pr_number}'
+    footer = provenance_footer(provenance, action='github:merge_pr')
+    return f"""You are the CodeTether merge steward for issue #{issue_number} in {repo}.
+
+Target PR #{pr_number}: {pr_url}
+Branch: {branch}
+Expected head SHA: {(pr.get('head') or {}).get('sha', '')}
+
+Personality/avatar: {CODETETHER_PERSONALITY['name']} using {CODETETHER_PERSONALITY['avatar']} — concise, safety-first, provenance-aware.
+
+Before merging, enforce these policy gates with fresh GitHub state:
+- PR is open and current head SHA exactly matches the expected head SHA above.
+- Required checks are green or branch protection reports mergeable.
+- There are no unresolved requested-changes reviews.
+- The diff remains scoped to issue #{issue_number}; no secrets or destructive changes.
+- CodeTether provenance footer is present on the review/comment trail or you add a status comment with it.
+- Never force-push or bypass branch protection.
+
+If every gate passes, merge the PR using the repository's normal merge method. If any gate fails, do not merge; comment with the blocked reason and final response BLOCKED.{footer}
+
+Final response must state MERGED or BLOCKED, plus the PR URL and policy-gate summary."""
+
+
+async def create_issue_review_task(
+    *,
+    workspace_id: str,
+    repo: str,
+    issue_number: int,
+    branch: str,
+    pr: dict[str, Any],
+    github_issue_url: str | None,
+    github_installation_id: int | str | None,
+    parent_task_id: str | None = None,
+    target_worker_id: str | None = None,
+) -> str | None:
+    """Queue a reviewer task for an issue PR if provenance policy allows it."""
+    from ..persistent_worker_pool import create_and_dispatch_task
+
+    provenance = issue_pr_provenance(
+        repo=repo,
+        issue_number=issue_number,
+        branch=branch,
+        pr=pr,
+        installation_id=github_installation_id,
+        action='github:review_pr',
+        parent_task_id=parent_task_id,
+    )
+    decision = policy_decision(provenance, 'github:review_pr')
+    if not decision['allowed']:
+        await record_automation_decision(provenance=provenance, decision=decision, task_id=parent_task_id)
+        return None
+
+    metadata = {
+        'workspace_id': workspace_id,
+        'source': 'github-app',
+        'workflow_stage': 'review',
+        'repo': repo,
+        'issue_number': issue_number,
+        'pr_number': pr.get('number'),
+        'branch_name': branch,
+        'pr_head_sha': (pr.get('head') or {}).get('sha'),
+        'github_issue_url': github_issue_url,
+        'github_installation_id': github_installation_id,
+        'worker_personality': 'reviewer',
+        'personality': CODETETHER_PERSONALITY,
+        'codetether_provenance': provenance,
+        'policy_decision': decision,
+        'post_review_task': {
+            'title': f'Merge issue PR #{pr.get("number")}',
+            'agent_type': 'merge',
+        },
+    }
+    task_id = await create_and_dispatch_task(
+        workspace_id=workspace_id,
+        title=f'Review issue PR #{pr.get("number")}',
+        prompt=review_prompt(repo, issue_number, branch, pr, provenance),
+        agent_type='review',
+        model_ref=MODEL_REF,
+        metadata=metadata,
+        task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
+        github_issue_url=github_issue_url,
+    )
+    await record_automation_decision(provenance=provenance, decision=decision, task_id=task_id)
+    return task_id
+
+
+async def create_issue_merge_task(
+    *,
+    review_task: dict[str, Any],
+    token: str,
+) -> str | None:
+    """Queue a merge-steward task after a successful review task."""
+    from ..persistent_worker_pool import create_and_dispatch_task
+    from .auth import github_json
+
+    if not reviewer_allows_merge(review_task):
+        return None
+
+    metadata = review_task.get('metadata') or {}
+    repo = str(metadata.get('repo') or '')
+    issue_number = int(metadata.get('issue_number') or 0)
+    pr_number = int(metadata.get('pr_number') or 0)
+    branch = str(metadata.get('branch_name') or '')
+    workspace_id = str(metadata.get('workspace_id') or '')
+    if not (repo and issue_number and pr_number and branch and workspace_id):
+        return None
+
+    pr = await github_json('GET', f'/repos/{repo}/pulls/{pr_number}', token)
+    expected_sha = str(metadata.get('pr_head_sha') or '')
+    current_sha = str((pr.get('head') or {}).get('sha') or '')
+    if expected_sha and current_sha != expected_sha:
+        stale_provenance = issue_pr_provenance(
+            repo=repo,
+            issue_number=issue_number,
+            branch=branch,
+            pr=pr,
+            installation_id=metadata.get('github_installation_id'),
+            action='github:merge_pr',
+            parent_task_id=str(review_task.get('id') or ''),
+        )
+        await record_automation_decision(
+            provenance=stale_provenance,
+            decision={
+                'allowed': False,
+                'action': 'github:merge_pr',
+                'provenance': {
+                    'complete': True,
+                    'dimensions': {},
+                    'missing_dimensions': [],
+                    'failures': [f'PR head SHA changed: expected {expected_sha}, got {current_sha}'],
+                    'partial': False,
+                },
+            },
+            task_id=str(review_task.get('id') or ''),
+        )
+        return None
+
+    provenance = issue_pr_provenance(
+        repo=repo,
+        issue_number=issue_number,
+        branch=branch,
+        pr=pr,
+        installation_id=metadata.get('github_installation_id'),
+        action='github:merge_pr',
+        parent_task_id=str(review_task.get('id') or ''),
+    )
+    decision = policy_decision(provenance, 'github:merge_pr')
+    if not decision['allowed']:
+        await record_automation_decision(
+            provenance=provenance,
+            decision=decision,
+            task_id=str(review_task.get('id') or ''),
+        )
+        return None
+
+    merge_metadata = dict(metadata)
+    merge_metadata.update({
+        'workflow_stage': 'merge',
+        'worker_personality': 'merge-steward',
+        'codetether_provenance': provenance,
+        'policy_decision': decision,
+        'pr_head_sha': current_sha,
+    })
+
+    task_id = await create_and_dispatch_task(
+        workspace_id=workspace_id,
+        title=f'Merge issue PR #{pr_number}',
+        prompt=merge_prompt(repo, issue_number, branch, pr, provenance),
+        agent_type='merge',
+        model_ref=MODEL_REF,
+        metadata=merge_metadata,
+        task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
+        github_issue_url=metadata.get('github_issue_url'),
+    )
+    await record_automation_decision(provenance=provenance, decision=decision, task_id=task_id)
+    return task_id

--- a/a2a_server/github_app/task_completion.py
+++ b/a2a_server/github_app/task_completion.py
@@ -12,6 +12,19 @@ async def notify_issue_task_completion(task: dict, worker_id: str | None = None)
     if metadata.get('source') != 'github-app':
         return
     title = str(task.get('title') or '')
+    stage = metadata.get('workflow_stage')
+    if stage == 'review' or title.startswith('Review issue PR #'):
+        from .issue_review_task import create_issue_merge_task
+        from .task_context import github_app_task_context
+
+        if str(task.get('status')) != 'completed':
+            return
+        context = await github_app_task_context(task)
+        if context is None:
+            return
+        _, _, _, token = context
+        await create_issue_merge_task(review_task=task, token=token)
+        return
     if metadata.get('pr_number'):
         if title.startswith('Prepare PR workspace #'):
             await handle_pr_prepare_completion(task, worker_id)

--- a/a2a_server/migrations/031_github_automation_decisions.sql
+++ b/a2a_server/migrations/031_github_automation_decisions.sql
@@ -1,0 +1,35 @@
+-- Migration 031: GitHub App automation policy/provenance audit trail
+-- Records issue -> code -> review -> merge decisions made by CodeTether agents.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS github_automation_decisions (
+    id                  TEXT PRIMARY KEY,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    action              TEXT NOT NULL,
+    owner               TEXT NOT NULL DEFAULT '',
+    repo                TEXT NOT NULL DEFAULT '',
+    pull_number         INTEGER,
+    issue_number        INTEGER,
+    branch_name         TEXT NOT NULL DEFAULT '',
+    head_sha            TEXT NOT NULL DEFAULT '',
+    base_sha            TEXT NOT NULL DEFAULT '',
+    installation_id     BIGINT,
+    actor               TEXT NOT NULL DEFAULT 'codetether-github-app',
+    personality         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    policy_decision     TEXT NOT NULL CHECK (policy_decision IN ('allow', 'deny')),
+    policy_reasons      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    provenance          JSONB NOT NULL DEFAULT '{}'::jsonb,
+    task_id             TEXT,
+    github_request_id   TEXT,
+    github_status       INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_automation_decisions_repo_pr
+    ON github_automation_decisions(owner, repo, pull_number);
+CREATE INDEX IF NOT EXISTS idx_github_automation_decisions_created
+    ON github_automation_decisions(created_at);
+CREATE INDEX IF NOT EXISTS idx_github_automation_decisions_action
+    ON github_automation_decisions(action);
+
+COMMIT;

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -1,0 +1,265 @@
+import pytest
+
+from a2a_server.github_app import issue_final_comment, issue_review_task, task_completion, task_context
+
+
+@pytest.fixture
+def pr_payload():
+    return {
+        'number': 77,
+        'html_url': 'https://github.com/acme/widgets/pull/77',
+        'head': {'sha': 'abc123'},
+        'base': {'sha': 'def456'},
+    }
+
+
+def test_issue_pr_provenance_allows_review(pr_payload):
+    provenance = issue_review_task.issue_pr_provenance(
+        repo='acme/widgets',
+        issue_number=12,
+        branch='codetether/issue-12',
+        pr=pr_payload,
+        installation_id=123,
+        action='github:review_pr',
+        parent_task_id='task-code',
+    )
+
+    decision = issue_review_task.policy_decision(provenance, 'github:review_pr')
+
+    assert decision['allowed'] is True
+    assert decision['provenance']['complete'] is True
+    assert provenance['ap_output']['head_sha'] == 'abc123'
+    assert 'github:review_pr' in provenance['ap_delegation']['chain'][1]['capability']['operations']
+
+
+def test_issue_pr_provenance_denies_wrong_action(pr_payload):
+    provenance = issue_review_task.issue_pr_provenance(
+        repo='acme/widgets',
+        issue_number=12,
+        branch='codetether/issue-12',
+        pr=pr_payload,
+        installation_id=123,
+        action='github:review_pr',
+    )
+
+    decision = issue_review_task.policy_decision(provenance, 'github:merge_pr')
+
+    assert decision['allowed'] is False
+    assert 'action outside delegated capability envelope' in decision['provenance']['failures']
+
+
+@pytest.mark.asyncio
+async def test_issue_final_comment_queues_review_task(monkeypatch, pr_payload):
+    comments = []
+    created = []
+
+    async def fake_context(task):
+        return 'acme/widgets', 12, 'codetether/issue-12', 'token'
+
+    async def fake_verify(repo, branch, token):
+        return {'branch_exists': True, 'has_commits': True, 'error': None}
+
+    async def fake_open_pr(repo, branch, token):
+        return pr_payload
+
+    async def fake_create_review_task(**kwargs):
+        created.append(kwargs)
+        return 'task-review-1'
+
+    async def fake_post(repo, issue_number, token, body):
+        comments.append(body)
+
+    monkeypatch.setattr(issue_final_comment, 'issue_task_context', fake_context)
+    monkeypatch.setattr(issue_final_comment, '_verify_branch_and_commits', fake_verify)
+    monkeypatch.setattr(issue_final_comment, 'open_issue_pr', fake_open_pr)
+    monkeypatch.setattr(issue_final_comment, 'post_issue_comment', fake_post)
+    monkeypatch.setattr(issue_review_task, 'create_issue_review_task', fake_create_review_task)
+
+    await issue_final_comment.notify_issue_final_comment({
+        'id': 'task-code',
+        'status': 'completed',
+        'result': 'done',
+        'metadata': {
+            'workspace_id': 'ws1',
+            'github_issue_url': 'https://github.com/acme/widgets/issues/12',
+            'github_installation_id': 123,
+            'target_worker_id': 'wrk1',
+        },
+    })
+
+    assert created
+    assert created[0]['parent_task_id'] == 'task-code'
+    assert created[0]['pr']['number'] == 77
+    assert 'target_worker_id' not in created[0]
+    assert 'Queued CodeTether reviewer task `task-review-1`' in comments[0]
+    assert 'Automation provenance:' in comments[0]
+
+
+@pytest.mark.asyncio
+async def test_review_completion_queues_merge_task(monkeypatch):
+    calls = []
+
+    async def fake_context(task):
+        return 'acme/widgets', 77, 'codetether/issue-12', 'token'
+
+    async def fake_create_merge_task(review_task, token):
+        calls.append((review_task, token))
+        return 'task-merge-1'
+
+    monkeypatch.setattr(task_context, 'github_app_task_context', fake_context)
+    monkeypatch.setattr(issue_review_task, 'create_issue_merge_task', fake_create_merge_task)
+
+    task = {
+        'id': 'task-review-1',
+        'title': 'Review issue PR #77',
+        'status': 'completed',
+        'metadata': {'source': 'github-app', 'workflow_stage': 'review'},
+    }
+
+    await task_completion.notify_issue_task_completion(task)
+
+    assert calls == [(task, 'token')]
+
+
+@pytest.mark.asyncio
+async def test_create_review_task_records_allow_decision_without_builder_target(monkeypatch, pr_payload):
+    created = []
+    decisions = []
+
+    async def fake_dispatch(**kwargs):
+        created.append(kwargs)
+        return 'task-review-1'
+
+    async def fake_record(**kwargs):
+        decisions.append(kwargs)
+
+    monkeypatch.setattr('a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_dispatch)
+    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
+
+    task_id = await issue_review_task.create_issue_review_task(
+        workspace_id='ws1',
+        repo='acme/widgets',
+        issue_number=12,
+        branch='codetether/issue-12',
+        pr=pr_payload,
+        github_issue_url='https://github.com/acme/widgets/issues/12',
+        github_installation_id=123,
+        parent_task_id='task-code',
+        target_worker_id='builder-worker',
+    )
+
+    assert task_id == 'task-review-1'
+    assert created[0]['metadata']['worker_personality'] == 'reviewer'
+    assert 'target_worker_id' not in created[0]['metadata']
+    assert decisions[0]['decision']['allowed'] is True
+    assert decisions[0]['task_id'] == 'task-review-1'
+
+
+@pytest.mark.asyncio
+async def test_create_review_task_records_deny_decision(monkeypatch, pr_payload):
+    decisions = []
+
+    def fake_policy(provenance, action):
+        return {'allowed': False, 'action': action, 'provenance': {'failures': ['denied']}}
+
+    async def fake_record(**kwargs):
+        decisions.append(kwargs)
+
+    monkeypatch.setattr(issue_review_task, 'policy_decision', fake_policy)
+    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
+
+    task_id = await issue_review_task.create_issue_review_task(
+        workspace_id='ws1',
+        repo='acme/widgets',
+        issue_number=12,
+        branch='codetether/issue-12',
+        pr=pr_payload,
+        github_issue_url='https://github.com/acme/widgets/issues/12',
+        github_installation_id=123,
+        parent_task_id='task-code',
+    )
+
+    assert task_id is None
+    assert decisions[0]['decision']['allowed'] is False
+    assert decisions[0]['task_id'] == 'task-code'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('review_result', ['CHANGES_REQUESTED: tests failed', 'BLOCKED: provenance mismatch', 'completed without verdict'])
+async def test_create_merge_task_requires_explicit_approval(monkeypatch, review_result):
+    called = False
+
+    async def fake_github_json(*args, **kwargs):
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
+
+    task_id = await issue_review_task.create_issue_merge_task(
+        review_task={
+            'id': 'task-review-1',
+            'result': review_result,
+            'metadata': {
+                'workspace_id': 'ws1',
+                'repo': 'acme/widgets',
+                'issue_number': 12,
+                'pr_number': 77,
+                'branch_name': 'codetether/issue-12',
+            },
+        },
+        token='token',
+    )
+
+    assert task_id is None
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_create_merge_task_records_sha_mismatch(monkeypatch, pr_payload):
+    decisions = []
+
+    async def fake_github_json(method, path, token):
+        updated = dict(pr_payload)
+        updated['head'] = {'sha': 'newsha'}
+        return updated
+
+    async def fake_record(**kwargs):
+        decisions.append(kwargs)
+
+    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
+    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
+
+    task_id = await issue_review_task.create_issue_merge_task(
+        review_task={
+            'id': 'task-review-1',
+            'result': 'APPROVED: looks safe',
+            'metadata': {
+                'workspace_id': 'ws1',
+                'repo': 'acme/widgets',
+                'issue_number': 12,
+                'pr_number': 77,
+                'branch_name': 'codetether/issue-12',
+                'pr_head_sha': 'abc123',
+                'github_installation_id': 123,
+            },
+        },
+        token='token',
+    )
+
+    assert task_id is None
+    assert decisions[0]['decision']['allowed'] is False
+    assert 'PR head SHA changed' in decisions[0]['decision']['provenance']['failures'][0]
+
+
+def test_merge_provenance_uses_merge_steward_actor(pr_payload):
+    provenance = issue_review_task.issue_pr_provenance(
+        repo='acme/widgets',
+        issue_number=12,
+        branch='codetether/issue-12',
+        pr=pr_payload,
+        installation_id=123,
+        action='github:merge_pr',
+    )
+
+    assert provenance['ap_delegation']['chain'][1]['actor'] == 'codetether-merge-steward'


### PR DESCRIPTION
## Summary
- add issue PR reviewer and merge-steward task orchestration with CodeTether provenance footers
- persist GitHub automation policy/provenance allow/deny decisions
- gate merge-steward queueing on explicit reviewer approval and fresh PR head SHA
- avoid inheriting builder target_worker_id for reviewer tasks

## Validation
- python3 -m compileall -q a2a_server/github_app
- PYTHONPATH=. pytest -q tests/test_github_app_issue_review_flow.py tests/test_github_app_task_completion.py::test_issue_prepare_task_still_uses_issue_followup tests/test_github_app_task_completion.py::test_pr_prepare_task_creates_pr_followup tests/test_github_app_task_completion.py::test_pr_build_task_posts_pr_final_comment
