### PR TITLE
fix: expose unscoped fire-and-forget polling

### DIFF
--- a/a2a_server/database.py
+++ b/a2a_server/database.py
@@ -1513,12 +1513,11 @@ async def db_list_tasks(
                     params.append(status)
                     param_idx += 1
 
-                    # Fire-and-forget tasks with active task_runs are managed
-                    # by the extended claim path (claim_next_task_run_extended),
-                    # NOT the SSE registry's basic claim.  Exclude them from the
-                    # pending list so workers using /v1/worker/tasks/claim don't
-                    # waste cycles trying (and failing with 409) on tasks they
-                    # can never claim through that endpoint.
+                    # Fire-and-forget tasks with active task_runs are managed by
+                    # the extended claim path (claim_next_task_run_extended).
+                    # Keep them visible when they are unscoped or explicitly
+                    # targeted to the polling worker, so a missed SSE delivery
+                    # does not strand the task forever.
                     if status == 'pending':
                         ff_visibility = [
                             "dispatch_mode IS NULL OR dispatch_mode != 'fire_and_forget'",
@@ -1527,6 +1526,13 @@ async def db_list_tasks(
                             '  WHERE tr.task_id = tasks.id'
                             "  AND tr.status IN ('queued', 'running')"
                             ' )',
+                            '('
+                            "metadata->>'target_worker_id' IS NULL"
+                            " OR metadata->>'target_worker_id' = ''"
+                            ') AND ('
+                            "metadata->>'target_agent_name' IS NULL"
+                            " OR metadata->>'target_agent_name' = ''"
+                            ')',
                         ]
                         if worker_id:
                             ff_visibility.append(

--- a/tests/test_worker_claim_polling.py
+++ b/tests/test_worker_claim_polling.py
@@ -193,6 +193,8 @@ async def test_db_list_tasks_exposes_targeted_fire_and_forget_to_polling_worker(
     assert "metadata->>'target_worker_id'" in seen['sql']
     assert "metadata->>'target_agent_name'" in seen['sql']
     assert 'FROM workers w' in seen['sql']
+    assert "metadata->>'target_worker_id' IS NULL" in seen['sql']
+    assert "metadata->>'target_agent_name' IS NULL" in seen['sql']
     assert 'NOT EXISTS ( OR' not in seen['sql']
     assert 'EXISTS ( OR' not in seen['sql']
     assert 'NOT EXISTS (  SELECT 1 FROM task_runs tr' in seen['sql']
@@ -200,6 +202,48 @@ async def test_db_list_tasks_exposes_targeted_fire_and_forget_to_polling_worker(
     assert 'AND worker_id =' not in seen['sql']
     assert 'worker_2' in seen['params']
     assert 'agent-alpha' in seen['params']
+
+
+@pytest.mark.asyncio
+async def test_db_list_tasks_exposes_unscoped_fire_and_forget_to_polling_worker(
+    monkeypatch,
+):
+    seen = {}
+
+    class FakeAcquire:
+        async def __aenter__(self):
+            return FakeConnection()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakePool:
+        def acquire(self):
+            return FakeAcquire()
+
+    class FakeConnection:
+        async def fetch(self, sql, *params):
+            seen['sql'] = sql
+            seen['params'] = params
+            return []
+
+    async def _fake_get_pool():
+        return FakePool()
+
+    monkeypatch.setattr(database, 'get_pool', _fake_get_pool)
+
+    await database.db_list_tasks(status='pending')
+
+    assert "dispatch_mode IS NULL OR dispatch_mode != 'fire_and_forget'" in seen[
+        'sql'
+    ]
+    assert 'NOT EXISTS (  SELECT 1 FROM task_runs tr' in seen['sql']
+    assert "metadata->>'target_worker_id' IS NULL" in seen['sql']
+    assert "metadata->>'target_agent_name' IS NULL" in seen['sql']
+    assert "metadata->>'target_worker_id' = ''" in seen['sql']
+    assert "metadata->>'target_agent_name' = ''" in seen['sql']
+    assert 'AND worker_id =' not in seen['sql']
+    assert seen['params'] == ('pending', 100)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep unscoped fire-and-forget tasks visible to fallback pending-task polling when SSE delivery is missed
- preserve targeted task visibility filters while adding regression coverage for unscoped queued task-runs

## Validation
- python3 -m pytest tests/test_worker_claim_polling.py

## CodeTether provenance
- Follow-up from live PR #73 review-task polling stall observed after PR #72.
- The live task was manually targeted to the active harvester to unblock review; this PR makes that fallback unnecessary for future unscoped fire-and-forget tasks.