### PR TITLE
fix: gate auto-merge on PR status checks

### DIFF
--- a/a2a_server/github_app/issue_review_task.py
+++ b/a2a_server/github_app/issue_review_task.py
@@ -9,10 +9,10 @@ import re
 import uuid
 from typing import Any
 
-logger = logging.getLogger(__name__)
-
 from ..provenance import verify_provenance
 from .settings import AUTO_MERGE_ENABLED, MERGE_METHOD, MODEL_REF
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
@@ -57,7 +57,9 @@ def issue_pr_provenance(
         'action': action,
     }
     intent_hash = hashlib.sha256(
-        json.dumps(intent_material, sort_keys=True, separators=(',', ':')).encode()
+        json.dumps(
+            intent_material, sort_keys=True, separators=(',', ':')
+        ).encode()
     ).hexdigest()
     return {
         'ap_origin': {
@@ -86,13 +88,20 @@ def issue_pr_provenance(
                     'actor': 'codetether-github-app',
                     'capability': {
                         'root': False,
-                        'operations': ['github:review_pr', 'github:request_changes', 'github:merge_pr'],
+                        'operations': [
+                            'github:review_pr',
+                            'github:request_changes',
+                            'github:fix_pr',
+                            'github:merge_pr',
+                        ],
                         'spawn': {'max_depth': 2, 'max_fanout': 2},
                         'budget': {'github_api_calls': 200},
                     },
                 },
                 {
-                    'actor': 'codetether-merge-steward' if action == 'github:merge_pr' else 'codetether-reviewer',
+                    'actor': 'codetether-merge-steward'
+                    if action == 'github:merge_pr'
+                    else 'codetether-reviewer',
                     'capability': {
                         'root': False,
                         'operations': [action],
@@ -125,21 +134,23 @@ def provenance_footer(provenance: dict[str, Any], *, action: str) -> str:
     output = provenance.get('ap_output') or {}
     origin = provenance.get('ap_origin') or {}
     return (
-        "\n\n---\n"
-        "Automation provenance:\n"
-        f"- CodeTether workflow: `github-issue-review-merge`\n"
-        f"- Action: `{action}`\n"
-        f"- Intent hash: `{origin.get('intent_hash', '')}`\n"
-        f"- PR: `#{output.get('pr_number', '')}`\n"
-        f"- Head SHA: `{output.get('head_sha', '')}`\n"
-        f"- Personality/avatar: `{CODETETHER_PERSONALITY['name']}` / `{CODETETHER_PERSONALITY['avatar']}`"
+        '\n\n---\n'
+        'Automation provenance:\n'
+        f'- CodeTether workflow: `github-issue-review-merge`\n'
+        f'- Action: `{action}`\n'
+        f'- Intent hash: `{origin.get("intent_hash", "")}`\n'
+        f'- PR: `#{output.get("pr_number", "")}`\n'
+        f'- Head SHA: `{output.get("head_sha", "")}`\n'
+        f'- Personality/avatar: `{CODETETHER_PERSONALITY["name"]}` / `{CODETETHER_PERSONALITY["avatar"]}`'
     )
 
 
 def policy_decision(provenance: dict[str, Any], action: str) -> dict[str, Any]:
     """Evaluate the local provenance gate for a GitHub automation action."""
     resource = {
-        'session_origin_intent_hash': (provenance.get('ap_origin') or {}).get('intent_hash'),
+        'session_origin_intent_hash': (provenance.get('ap_origin') or {}).get(
+            'intent_hash'
+        ),
         'session_taints': provenance.get('ap_inputs') or [],
     }
     decision = verify_provenance(provenance, action, resource)
@@ -180,20 +191,24 @@ def _truncate_for_comment(value: str, *, limit: int = 4000) -> str:
     return value[: limit - 20].rstrip() + '\n\n...[truncated]'
 
 
-def change_request_action_line(verdict: str, *, task_id: str | None = None) -> str:
+def change_request_action_line(
+    verdict: str, *, task_id: str | None = None
+) -> str:
     """Render the actionable change-request line with the worker mention.
 
     Any CodeTether GitHub-facing review/follow-up that asks for code changes
     must tag the app handle in the action sentence so mention-based workers can
     pick it up. Approval and informational comments should not use this helper.
     """
-    normalized_verdict = str(verdict or 'CHANGES_REQUESTED').strip() or 'CHANGES_REQUESTED'
+    normalized_verdict = (
+        str(verdict or 'CHANGES_REQUESTED').strip() or 'CHANGES_REQUESTED'
+    )
     if task_id:
         return (
-            f"{CHANGE_REQUEST_MENTION} follow-up required: protocol-native fix task "
-            f"`{task_id}` is queued for `{normalized_verdict}`."
+            f'{CHANGE_REQUEST_MENTION} follow-up required: protocol-native fix task '
+            f'`{task_id}` is queued for `{normalized_verdict}`.'
         )
-    return f"{CHANGE_REQUEST_MENTION} please address the requested PR changes."
+    return f'{CHANGE_REQUEST_MENTION} please address the requested PR changes.'
 
 
 async def record_automation_decision(
@@ -241,7 +256,13 @@ async def record_automation_decision(
                 str(output.get('head_sha') or ''),
                 str(output.get('base_sha') or ''),
                 str(output.get('installation_id') or ''),
-                str(((provenance.get('ap_delegation') or {}).get('chain') or [{}])[-1].get('actor') or 'codetether-github-app'),
+                str(
+                    (
+                        (provenance.get('ap_delegation') or {}).get('chain')
+                        or [{}]
+                    )[-1].get('actor')
+                    or 'codetether-github-app'
+                ),
                 json.dumps(personality),
                 policy_decision_value,
                 json.dumps(policy.get('failures') or []),
@@ -321,14 +342,22 @@ def fix_followup_prompt(
     )
     files_section = ''
     if changed_files:
-        files_section = '\n\nFiles changed in this PR:\n' + '\n'.join(f'- `{f}`' for f in changed_files[:30])
+        files_section = '\n\nFiles changed in this PR:\n' + '\n'.join(
+            f'- `{f}`' for f in changed_files[:30]
+        )
     blockers_section = ''
     if blockers:
-        blockers_section = '\n\nSpecific blockers to address:\n' + _format_blockers(blockers)
+        blockers_section = (
+            '\n\nSpecific blockers to address:\n' + _format_blockers(blockers)
+        )
     validation_section = ''
     if last_validation_errors:
         validation_section = f'\n\nLast validation errors:\n```\n{_truncate_for_comment(last_validation_errors, limit=2000)}\n```'
-    attempt_line = f'\n\nFix attempt {attempt} of {MAX_FIX_ATTEMPTS_PER_SHA}.' if attempt > 1 else ''
+    attempt_line = (
+        f'\n\nFix attempt {attempt} of {MAX_FIX_ATTEMPTS_PER_SHA}.'
+        if attempt > 1
+        else ''
+    )
     return f"""You are editing the existing PR branch for PR #{pr_number}: {pr_url}
 Branch: {branch}
 Head SHA: {head_sha}
@@ -355,6 +384,7 @@ async def _count_fix_attempts(repo: str, pr_number: int, head_sha: str) -> int:
     """Count existing fix follow-up tasks for this repo/PR/head SHA combination."""
     try:
         from .. import database as db
+
         pool = await db.get_pool()
         if not pool:
             return 0
@@ -371,7 +401,9 @@ async def _count_fix_attempts(repo: str, pr_number: int, head_sha: str) -> int:
                         AND metadata->>'fix_followup' IS NOT NULL
                      ) sub
                 """,
-                repo, str(pr_number), head_sha,
+                repo,
+                str(pr_number),
+                head_sha,
             )
             return int((row or {}).get('cnt') or 0)
     except Exception:
@@ -412,7 +444,14 @@ async def create_fix_followup_task(
     review_task_id = str(review_task.get('id') or '')
     review_summary = str(review_task.get('result') or '').strip()
 
-    if not (repo and issue_number and pr_number and branch and workspace_id and expected_sha):
+    if not (
+        repo
+        and issue_number
+        and pr_number
+        and branch
+        and workspace_id
+        and expected_sha
+    ):
         logger.warning(
             'fix_followup: skipping due to missing metadata for review task %s',
             review_task_id,
@@ -427,25 +466,39 @@ async def create_fix_followup_task(
     try:
         pr = await github_json('GET', f'/repos/{repo}/pulls/{pr_number}', token)
     except Exception as exc:
-        logger.warning('fix_followup: could not fetch PR %s/%s: %s', repo, pr_number, exc)
+        logger.warning(
+            'fix_followup: could not fetch PR %s/%s: %s', repo, pr_number, exc
+        )
         return None
 
     if str(pr.get('state') or '').upper() != 'OPEN':
-        logger.info('fix_followup: PR %s/%s is not open, skipping', repo, pr_number)
+        logger.info(
+            'fix_followup: PR %s/%s is not open, skipping', repo, pr_number
+        )
         return None
 
     current_sha = str((pr.get('head') or {}).get('sha') or '')
     if current_sha != expected_sha:
         logger.info(
             'fix_followup: PR %s/%s head SHA changed (%s -> %s), skipping',
-            repo, pr_number, expected_sha, current_sha,
+            repo,
+            pr_number,
+            expected_sha,
+            current_sha,
         )
         return None
 
     # Guard: check for forked PRs
-    head_repo = ((pr.get('head') or {}).get('repo') or {}).get('full_name') or ''
+    head_repo = ((pr.get('head') or {}).get('repo') or {}).get(
+        'full_name'
+    ) or ''
     if head_repo and head_repo != repo:
-        logger.info('fix_followup: PR %s/%s is forked (%s), skipping', repo, pr_number, head_repo)
+        logger.info(
+            'fix_followup: PR %s/%s is forked (%s), skipping',
+            repo,
+            pr_number,
+            head_repo,
+        )
         return None
 
     # Loop guard: cap attempts per PR/head SHA
@@ -454,13 +507,18 @@ async def create_fix_followup_task(
     if attempt > MAX_FIX_ATTEMPTS_PER_SHA:
         logger.warning(
             'fix_followup: max attempts (%d) reached for %s/%s @ %s, skipping',
-            MAX_FIX_ATTEMPTS_PER_SHA, repo, pr_number, expected_sha,
+            MAX_FIX_ATTEMPTS_PER_SHA,
+            repo,
+            pr_number,
+            expected_sha,
         )
         await post_issue_comment(
-            repo, pr_number, token,
-            "## 🛠️ CodeTether Fix Follow-up\n\n"
-            f"Maximum fix attempts ({MAX_FIX_ATTEMPTS_PER_SHA}) reached for this PR head SHA. "
-            "Manual intervention may be required.",
+            repo,
+            pr_number,
+            token,
+            '## 🛠️ CodeTether Fix Follow-up\n\n'
+            f'Maximum fix attempts ({MAX_FIX_ATTEMPTS_PER_SHA}) reached for this PR head SHA. '
+            'Manual intervention may be required.',
         )
         return None
 
@@ -479,7 +537,9 @@ async def create_fix_followup_task(
     decision = policy_decision(provenance, 'github:fix_pr')
     if not decision['allowed']:
         await record_automation_decision(
-            provenance=provenance, decision=decision, task_id=review_task_id,
+            provenance=provenance,
+            decision=decision,
+            task_id=review_task_id,
         )
         logger.info('fix_followup: policy denied for %s/%s', repo, pr_number)
         return None
@@ -487,6 +547,7 @@ async def create_fix_followup_task(
     # Idempotency: check if a fix follow-up task already exists for this review task
     try:
         from .. import database as db
+
         pool = await db.get_pool()
         if pool:
             async with pool.acquire() as conn:
@@ -503,14 +564,17 @@ async def create_fix_followup_task(
                 if existing:
                     logger.info(
                         'fix_followup: existing fix task %s for review %s, skipping duplicate',
-                        existing, review_task_id,
+                        existing,
+                        review_task_id,
                     )
                     return None
     except Exception as exc:
         logger.warning('fix_followup: idempotency check failed: %s', exc)
 
     # Parse review context
-    pr_url = str(pr.get('html_url') or f'https://github.com/{repo}/pull/{pr_number}')
+    pr_url = str(
+        pr.get('html_url') or f'https://github.com/{repo}/pull/{pr_number}'
+    )
 
     # Extract changed files from provenance or review metadata
     changed_files = metadata.get('changed_files') or None
@@ -571,25 +635,32 @@ async def create_fix_followup_task(
     )
 
     await record_automation_decision(
-        provenance=provenance, decision=decision, task_id=task_id,
+        provenance=provenance,
+        decision=decision,
+        task_id=task_id,
     )
 
     logger.info(
         'fix_followup: created fix task %s for review %s (%s), attempt %d',
-        task_id, review_task_id, verdict, attempt,
+        task_id,
+        review_task_id,
+        verdict,
+        attempt,
     )
 
     # Post a comment indicating the protocol-native follow-up. Keep the
     # @codetether mention in the actionable sentence for compatibility with
     # mention-based worker pickup while protocol-native follow-up rolls out.
     comment_body = (
-        "## 🛠️ CodeTether Fix Follow-up\n\n"
-        f"{change_request_action_line(verdict or '', task_id=task_id)}\n\n"
-        f"Reviewer verdict: `{verdict}`.\n\n"
-        f"Fix attempt {attempt} of {MAX_FIX_ATTEMPTS_PER_SHA}."
+        '## 🛠️ CodeTether Fix Follow-up\n\n'
+        f'{change_request_action_line(verdict or "", task_id=task_id)}\n\n'
+        f'Reviewer verdict: `{verdict}`.\n\n'
+        f'Fix attempt {attempt} of {MAX_FIX_ATTEMPTS_PER_SHA}.'
     )
     if review_summary:
-        comment_body += f"\n\nReviewer summary:\n\n{_truncate_for_comment(review_summary)}"
+        comment_body += (
+            f'\n\nReviewer summary:\n\n{_truncate_for_comment(review_summary)}'
+        )
     comment_body += provenance_footer(provenance, action='github:fix_pr')
     await post_issue_comment(repo, pr_number, token, comment_body)
 
@@ -624,24 +695,28 @@ async def post_change_request_followup_if_needed(
     from .watch import post_issue_comment
 
     body = (
-        "## 🛠️ CodeTether Review Follow-up\n\n"
-        f"{change_request_action_line(verdict)}\n\n"
-        f"Reviewer verdict: `{verdict}`."
+        '## 🛠️ CodeTether Review Follow-up\n\n'
+        f'{change_request_action_line(verdict)}\n\n'
+        f'Reviewer verdict: `{verdict}`.'
     )
     if result:
-        body += f"\n\nReviewer summary:\n\n{_truncate_for_comment(result)}"
+        body += f'\n\nReviewer summary:\n\n{_truncate_for_comment(result)}'
     await post_issue_comment(repo, pr_number, token, body)
     return True
 
 
-def feedback_blockers_from_pull_request(pull_request: dict[str, Any] | None) -> list[str]:
+def feedback_blockers_from_pull_request(
+    pull_request: dict[str, Any] | None,
+) -> list[str]:
     """Return review-feedback blockers from GitHub GraphQL pull request state."""
     if not pull_request:
         return ['Pull request was not found in GitHub GraphQL response']
 
     blockers: list[str] = []
     if pull_request.get('state') != 'OPEN':
-        blockers.append(f"PR is not open: {pull_request.get('state') or 'unknown'}")
+        blockers.append(
+            f'PR is not open: {pull_request.get("state") or "unknown"}'
+        )
     if pull_request.get('isDraft'):
         blockers.append('PR is still marked as draft')
 
@@ -655,20 +730,28 @@ def feedback_blockers_from_pull_request(pull_request: dict[str, Any] | None) -> 
             continue
         comments = (thread.get('comments') or {}).get('nodes') or []
         latest = comments[-1] if comments else {}
-        author = ((latest.get('author') or {}).get('login') or 'unknown').strip()
+        author = (
+            (latest.get('author') or {}).get('login') or 'unknown'
+        ).strip()
         path = str(latest.get('path') or thread.get('path') or '').strip()
         line = latest.get('line') or thread.get('line')
-        location = f'{path}:{line}' if path and line else path or 'unknown location'
+        location = (
+            f'{path}:{line}' if path and line else path or 'unknown location'
+        )
         blockers.append(f'Unresolved review thread at {location} by {author}')
 
     page_info = (pull_request.get('reviewThreads') or {}).get('pageInfo') or {}
     if page_info.get('hasNextPage'):
-        blockers.append('More than 100 review threads exist; refusing to merge without a complete review-thread scan')
+        blockers.append(
+            'More than 100 review threads exist; refusing to merge without a complete review-thread scan'
+        )
 
     return blockers
 
 
-async def review_feedback_status(repo: str, pr_number: int, token: str) -> dict[str, Any]:
+async def review_feedback_status(
+    repo: str, pr_number: int, token: str
+) -> dict[str, Any]:
     """Fetch GitHub review-thread state and summarize whether feedback is addressed."""
     from .auth import github_graphql
 
@@ -707,12 +790,90 @@ async def review_feedback_status(repo: str, pr_number: int, token: str) -> dict[
         {'owner': owner, 'name': repo_name, 'number': pr_number},
         token,
     )
-    pull_request = ((data.get('repository') or {}).get('pullRequest') or None)
+    pull_request = (data.get('repository') or {}).get('pullRequest') or None
     blockers = feedback_blockers_from_pull_request(pull_request)
     return {
         'feedback_addressed': not blockers,
         'blockers': blockers,
         'pull_request': pull_request,
+    }
+
+
+def _latest_by_name(
+    items: list[dict[str, Any]], name_key: str
+) -> list[dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for item in items:
+        name = str(item.get(name_key) or '').strip()
+        if not name:
+            continue
+        current = latest.get(name)
+        item_time = str(
+            item.get('completed_at')
+            or item.get('started_at')
+            or item.get('updated_at')
+            or item.get('created_at')
+            or ''
+        )
+        current_time = ''
+        if current:
+            current_time = str(
+                current.get('completed_at')
+                or current.get('started_at')
+                or current.get('updated_at')
+                or current.get('created_at')
+                or ''
+            )
+        if current is None or item_time >= current_time:
+            latest[name] = item
+    return list(latest.values())
+
+
+async def status_check_status(
+    repo: str, sha: str, token: str
+) -> dict[str, Any]:
+    """Fetch commit statuses/check-runs and return blockers for non-green checks."""
+    from .auth import github_json
+
+    blockers: list[str] = []
+
+    status_payload = await github_json(
+        'GET', f'/repos/{repo}/commits/{sha}/status', token
+    )
+    statuses = _latest_by_name(status_payload.get('statuses') or [], 'context')
+    for status in statuses:
+        state = str(status.get('state') or '').lower()
+        context = str(status.get('context') or 'status').strip()
+        if state != 'success':
+            blockers.append(f'Status `{context}` is {state or "unknown"}')
+
+    check_payload = await github_json(
+        'GET', f'/repos/{repo}/commits/{sha}/check-runs?per_page=100', token
+    )
+    check_runs = _latest_by_name(check_payload.get('check_runs') or [], 'name')
+    passing_conclusions = {'success', 'neutral', 'skipped'}
+    for run in check_runs:
+        name = str(run.get('name') or 'check').strip()
+        status = str(run.get('status') or '').lower()
+        conclusion = str(run.get('conclusion') or '').lower()
+        if status != 'completed':
+            blockers.append(f'Check `{name}` is {status or "pending"}')
+        elif conclusion not in passing_conclusions:
+            blockers.append(
+                f'Check `{name}` concluded {conclusion or "unknown"}'
+            )
+
+    total_count = int(check_payload.get('total_count') or len(check_runs))
+    if total_count > len(check_payload.get('check_runs') or []):
+        blockers.append(
+            'More than 100 check runs exist; refusing to merge without a complete status scan'
+        )
+
+    return {
+        'checks_green': not blockers,
+        'blockers': blockers,
+        'statuses': statuses,
+        'check_runs': check_runs,
     }
 
 
@@ -783,14 +944,22 @@ async def enable_pull_request_auto_merge(
         },
         token,
     )
-    pull_request = (data.get('enablePullRequestAutoMerge') or {}).get('pullRequest') or {}
+    pull_request = (data.get('enablePullRequestAutoMerge') or {}).get(
+        'pullRequest'
+    ) or {}
     auto_merge_request = pull_request.get('autoMergeRequest')
     if not auto_merge_request:
         raise RuntimeError('GitHub did not return an auto-merge request')
     return auto_merge_request
 
 
-def review_prompt(repo: str, issue_number: int, branch: str, pr: dict[str, Any], provenance: dict[str, Any]) -> str:
+def review_prompt(
+    repo: str,
+    issue_number: int,
+    branch: str,
+    pr: dict[str, Any],
+    provenance: dict[str, Any],
+) -> str:
     pr_number = pr.get('number')
     pr_url = pr.get('html_url') or f'https://github.com/{repo}/pull/{pr_number}'
     footer = provenance_footer(provenance, action='github:review_pr')
@@ -813,7 +982,13 @@ End-to-end responsibilities:
 Final response must state one of: APPROVED, CHANGES_REQUESTED, or BLOCKED, plus the PR URL and validation summary."""
 
 
-def merge_prompt(repo: str, issue_number: int, branch: str, pr: dict[str, Any], provenance: dict[str, Any]) -> str:
+def merge_prompt(
+    repo: str,
+    issue_number: int,
+    branch: str,
+    pr: dict[str, Any],
+    provenance: dict[str, Any],
+) -> str:
     pr_number = pr.get('number')
     pr_url = pr.get('html_url') or f'https://github.com/{repo}/pull/{pr_number}'
     footer = provenance_footer(provenance, action='github:merge_pr')
@@ -864,7 +1039,9 @@ async def create_issue_review_task(
     )
     decision = policy_decision(provenance, 'github:review_pr')
     if not decision['allowed']:
-        await record_automation_decision(provenance=provenance, decision=decision, task_id=parent_task_id)
+        await record_automation_decision(
+            provenance=provenance, decision=decision, task_id=parent_task_id
+        )
         return None
 
     metadata = {
@@ -897,7 +1074,9 @@ async def create_issue_review_task(
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
         github_issue_url=github_issue_url,
     )
-    await record_automation_decision(provenance=provenance, decision=decision, task_id=task_id)
+    await record_automation_decision(
+        provenance=provenance, decision=decision, task_id=task_id
+    )
     return task_id
 
 
@@ -913,15 +1092,20 @@ async def create_issue_merge_task(
 
     if not reviewer_allows_merge(review_task):
         # Primary path: protocol-native A2A fix follow-up
-        fix_task_id = await create_fix_followup_task(review_task=review_task, token=token)
+        fix_task_id = await create_fix_followup_task(
+            review_task=review_task, token=token
+        )
         if fix_task_id:
             logger.info(
                 'Protocol-native fix follow-up %s enqueued for review %s',
-                fix_task_id, review_task.get('id'),
+                fix_task_id,
+                review_task.get('id'),
             )
         else:
             # Compatibility fallback: @codetether mention comment
-            await post_change_request_followup_if_needed(review_task=review_task, token=token)
+            await post_change_request_followup_if_needed(
+                review_task=review_task, token=token
+            )
         return None
 
     metadata = review_task.get('metadata') or {}
@@ -947,7 +1131,9 @@ async def create_issue_merge_task(
             action='github:merge_pr',
             parent_task_id=parent_task_id,
         )
-        failures = [f'PR head SHA changed: expected {expected_sha}, got {current_sha}']
+        failures = [
+            f'PR head SHA changed: expected {expected_sha}, got {current_sha}'
+        ]
         await record_automation_decision(
             provenance=stale_provenance,
             decision=_failure_decision('github:merge_pr', failures),
@@ -957,9 +1143,9 @@ async def create_issue_merge_task(
             repo,
             pr_number,
             token,
-            "## 🛠️ CodeTether Auto-Merge\n\n"
-            "Blocked because the PR changed after the approved review.\n\n"
-            f"{_format_blockers(failures)}",
+            '## 🛠️ CodeTether Auto-Merge\n\n'
+            'Blocked because the PR changed after the approved review.\n\n'
+            f'{_format_blockers(failures)}',
         )
         return None
 
@@ -983,7 +1169,10 @@ async def create_issue_merge_task(
 
     feedback_status = await review_feedback_status(repo, pr_number, token)
     if not feedback_status['feedback_addressed']:
-        failures = list(feedback_status.get('blockers') or ['GitHub review feedback is not fully addressed'])
+        failures = list(
+            feedback_status.get('blockers')
+            or ['GitHub review feedback is not fully addressed']
+        )
         await record_automation_decision(
             provenance=provenance,
             decision=_failure_decision('github:merge_pr', failures),
@@ -993,26 +1182,54 @@ async def create_issue_merge_task(
             repo,
             pr_number,
             token,
-            "## 🛠️ CodeTether Auto-Merge\n\n"
-            "Blocked because review feedback is not fully addressed.\n\n"
-            f"{_format_blockers(failures)}",
+            '## 🛠️ CodeTether Auto-Merge\n\n'
+            'Blocked because review feedback is not fully addressed.\n\n'
+            f'{_format_blockers(failures)}',
+        )
+        return None
+
+    try:
+        checks_status = await status_check_status(repo, current_sha, token)
+        checks_green = bool(checks_status.get('checks_green'))
+        check_blockers = list(checks_status.get('blockers') or [])
+    except Exception as exc:
+        checks_green = False
+        check_blockers = [f'Unable to verify PR status checks: {exc}']
+    if not checks_green:
+        failures = check_blockers or ['PR status checks are not green']
+        await record_automation_decision(
+            provenance=provenance,
+            decision=_failure_decision('github:merge_pr', failures),
+            task_id=parent_task_id,
+        )
+        await post_issue_comment(
+            repo,
+            pr_number,
+            token,
+            '## 🛠️ CodeTether Auto-Merge\n\n'
+            'Blocked because PR status checks are not green.\n\n'
+            f'{_format_blockers(failures)}',
         )
         return None
 
     merge_metadata = dict(metadata)
-    merge_metadata.update({
-        'workflow_stage': 'merge',
-        'worker_personality': 'merge-steward',
-        'codetether_provenance': provenance,
-        'policy_decision': decision,
-        'pr_head_sha': current_sha,
-    })
+    merge_metadata.update(
+        {
+            'workflow_stage': 'merge',
+            'worker_personality': 'merge-steward',
+            'codetether_provenance': provenance,
+            'policy_decision': decision,
+            'pr_head_sha': current_sha,
+        }
+    )
 
     if AUTO_MERGE_ENABLED:
         repo_info = await github_json('GET', f'/repos/{repo}', token)
         merge_method = choose_merge_method(repo_info)
         if not merge_method:
-            failures = ['Repository does not allow merge, squash, or rebase merging for this GitHub App flow']
+            failures = [
+                'Repository does not allow merge, squash, or rebase merging for this GitHub App flow'
+            ]
             await record_automation_decision(
                 provenance=provenance,
                 decision=_failure_decision('github:merge_pr', failures),
@@ -1022,9 +1239,9 @@ async def create_issue_merge_task(
                 repo,
                 pr_number,
                 token,
-                "## 🛠️ CodeTether Auto-Merge\n\n"
-                "Blocked because no allowed repository merge method is available.\n\n"
-                f"{_format_blockers(failures)}",
+                '## 🛠️ CodeTether Auto-Merge\n\n'
+                'Blocked because no allowed repository merge method is available.\n\n'
+                f'{_format_blockers(failures)}',
             )
             return None
 
@@ -1064,32 +1281,36 @@ async def create_issue_merge_task(
                     repo,
                     pr_number,
                     token,
-                    "## 🛠️ CodeTether Auto-Merge\n\n"
-                    "Blocked by GitHub while attempting to merge.\n\n"
-                    f"{_format_blockers(failures)}",
+                    '## 🛠️ CodeTether Auto-Merge\n\n'
+                    'Blocked by GitHub while attempting to merge.\n\n'
+                    f'{_format_blockers(failures)}',
                 )
                 return None
 
-            await record_automation_decision(provenance=provenance, decision=decision, task_id=parent_task_id)
+            await record_automation_decision(
+                provenance=provenance, decision=decision, task_id=parent_task_id
+            )
             enabled_at = str(auto_merge_request.get('enabledAt') or '').strip()
             message = (
-                "## 🛠️ CodeTether Auto-Merge\n\n"
-                f"Enabled GitHub auto-merge for PR #{pr_number} using `{merge_method}` after reviewer approval and resolved-feedback checks."
+                '## 🛠️ CodeTether Auto-Merge\n\n'
+                f'Enabled GitHub auto-merge for PR #{pr_number} using `{merge_method}` after reviewer approval and resolved-feedback checks.'
             )
             if enabled_at:
-                message += f"\n\nEnabled at: `{enabled_at}`"
+                message += f'\n\nEnabled at: `{enabled_at}`'
             message += provenance_footer(provenance, action='github:merge_pr')
             await post_issue_comment(repo, pr_number, token, message)
             return 'auto_merge_enabled'
 
         merged_sha = str(merge_result.get('sha') or '').strip()
-        await record_automation_decision(provenance=provenance, decision=decision, task_id=parent_task_id)
+        await record_automation_decision(
+            provenance=provenance, decision=decision, task_id=parent_task_id
+        )
         message = (
-            "## 🛠️ CodeTether Auto-Merge\n\n"
-            f"Merged PR #{pr_number} using `{merge_method}` after reviewer approval and resolved-feedback checks."
+            '## 🛠️ CodeTether Auto-Merge\n\n'
+            f'Merged PR #{pr_number} using `{merge_method}` after reviewer approval and resolved-feedback checks.'
         )
         if merged_sha:
-            message += f"\n\nMerge SHA: `{merged_sha}`"
+            message += f'\n\nMerge SHA: `{merged_sha}`'
         message += provenance_footer(provenance, action='github:merge_pr')
         await post_issue_comment(repo, pr_number, token, message)
         return merged_sha or 'merged'
@@ -1104,5 +1325,7 @@ async def create_issue_merge_task(
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
         github_issue_url=metadata.get('github_issue_url'),
     )
-    await record_automation_decision(provenance=provenance, decision=decision, task_id=task_id)
+    await record_automation_decision(
+        provenance=provenance, decision=decision, task_id=task_id
+    )
     return task_id

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -1,14 +1,20 @@
 import pytest
 
-from a2a_server.github_app import issue_final_comment, issue_review_task, task_completion, task_context
+from a2a_server.github_app import (
+    issue_final_comment,
+    issue_review_task,
+    task_completion,
+    task_context,
+)
 
 
 @pytest.fixture
 def pr_payload():
     return {
         'number': 77,
+        'state': 'open',
         'html_url': 'https://github.com/acme/widgets/pull/77',
-        'head': {'sha': 'abc123'},
+        'head': {'sha': 'abc123', 'repo': {'full_name': 'acme/widgets'}},
         'base': {'sha': 'def456'},
     }
 
@@ -29,7 +35,10 @@ def test_issue_pr_provenance_allows_review(pr_payload):
     assert decision['allowed'] is True
     assert decision['provenance']['complete'] is True
     assert provenance['ap_output']['head_sha'] == 'abc123'
-    assert 'github:review_pr' in provenance['ap_delegation']['chain'][1]['capability']['operations']
+    assert (
+        'github:review_pr'
+        in provenance['ap_delegation']['chain'][1]['capability']['operations']
+    )
 
 
 def test_issue_pr_provenance_denies_wrong_action(pr_payload):
@@ -45,7 +54,10 @@ def test_issue_pr_provenance_denies_wrong_action(pr_payload):
     decision = issue_review_task.policy_decision(provenance, 'github:merge_pr')
 
     assert decision['allowed'] is False
-    assert 'action outside delegated capability envelope' in decision['provenance']['failures']
+    assert (
+        'action outside delegated capability envelope'
+        in decision['provenance']['failures']
+    )
 
 
 @pytest.mark.asyncio
@@ -70,22 +82,28 @@ async def test_issue_final_comment_queues_review_task(monkeypatch, pr_payload):
         comments.append(body)
 
     monkeypatch.setattr(issue_final_comment, 'issue_task_context', fake_context)
-    monkeypatch.setattr(issue_final_comment, '_verify_branch_and_commits', fake_verify)
+    monkeypatch.setattr(
+        issue_final_comment, '_verify_branch_and_commits', fake_verify
+    )
     monkeypatch.setattr(issue_final_comment, 'open_issue_pr', fake_open_pr)
     monkeypatch.setattr(issue_final_comment, 'post_issue_comment', fake_post)
-    monkeypatch.setattr(issue_review_task, 'create_issue_review_task', fake_create_review_task)
+    monkeypatch.setattr(
+        issue_review_task, 'create_issue_review_task', fake_create_review_task
+    )
 
-    await issue_final_comment.notify_issue_final_comment({
-        'id': 'task-code',
-        'status': 'completed',
-        'result': 'done',
-        'metadata': {
-            'workspace_id': 'ws1',
-            'github_issue_url': 'https://github.com/acme/widgets/issues/12',
-            'github_installation_id': 123,
-            'target_worker_id': 'wrk1',
-        },
-    })
+    await issue_final_comment.notify_issue_final_comment(
+        {
+            'id': 'task-code',
+            'status': 'completed',
+            'result': 'done',
+            'metadata': {
+                'workspace_id': 'ws1',
+                'github_issue_url': 'https://github.com/acme/widgets/issues/12',
+                'github_installation_id': 123,
+                'target_worker_id': 'wrk1',
+            },
+        }
+    )
 
     assert created
     assert created[0]['parent_task_id'] == 'task-code'
@@ -107,7 +125,9 @@ async def test_review_completion_queues_merge_task(monkeypatch):
         return 'task-merge-1'
 
     monkeypatch.setattr(task_context, 'github_app_task_context', fake_context)
-    monkeypatch.setattr(issue_review_task, 'create_issue_merge_task', fake_create_merge_task)
+    monkeypatch.setattr(
+        issue_review_task, 'create_issue_merge_task', fake_create_merge_task
+    )
 
     task = {
         'id': 'task-review-1',
@@ -122,7 +142,9 @@ async def test_review_completion_queues_merge_task(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_create_review_task_records_allow_decision_without_builder_target(monkeypatch, pr_payload):
+async def test_create_review_task_records_allow_decision_without_builder_target(
+    monkeypatch, pr_payload
+):
     created = []
     decisions = []
 
@@ -133,8 +155,13 @@ async def test_create_review_task_records_allow_decision_without_builder_target(
     async def fake_record(**kwargs):
         decisions.append(kwargs)
 
-    monkeypatch.setattr('a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_dispatch)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
 
     task_id = await issue_review_task.create_issue_review_task(
         workspace_id='ws1',
@@ -158,17 +185,25 @@ async def test_create_review_task_records_allow_decision_without_builder_target(
 
 
 @pytest.mark.asyncio
-async def test_create_review_task_records_deny_decision(monkeypatch, pr_payload):
+async def test_create_review_task_records_deny_decision(
+    monkeypatch, pr_payload
+):
     decisions = []
 
     def fake_policy(provenance, action):
-        return {'allowed': False, 'action': action, 'provenance': {'failures': ['denied']}}
+        return {
+            'allowed': False,
+            'action': action,
+            'provenance': {'failures': ['denied']},
+        }
 
     async def fake_record(**kwargs):
         decisions.append(kwargs)
 
     monkeypatch.setattr(issue_review_task, 'policy_decision', fake_policy)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
 
     task_id = await issue_review_task.create_issue_review_task(
         workspace_id='ws1',
@@ -187,8 +222,17 @@ async def test_create_review_task_records_deny_decision(monkeypatch, pr_payload)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('review_result', ['CHANGES_REQUESTED: tests failed', 'BLOCKED: provenance mismatch', 'completed without verdict'])
-async def test_create_merge_task_requires_explicit_approval(monkeypatch, review_result):
+@pytest.mark.parametrize(
+    'review_result',
+    [
+        'CHANGES_REQUESTED: tests failed',
+        'BLOCKED: provenance mismatch',
+        'completed without verdict',
+    ],
+)
+async def test_create_merge_task_requires_explicit_approval(
+    monkeypatch, review_result
+):
     called = False
     comments = []
 
@@ -203,9 +247,15 @@ async def test_create_merge_task_requires_explicit_approval(monkeypatch, review_
     async def fake_fix_followup(*, review_task, token):
         return None  # simulate fix follow-up unable to create task
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
-    monkeypatch.setattr(issue_review_task, 'create_fix_followup_task', fake_fix_followup)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'create_fix_followup_task', fake_fix_followup
+    )
 
     task_id = await issue_review_task.create_issue_merge_task(
         review_task={
@@ -224,7 +274,9 @@ async def test_create_merge_task_requires_explicit_approval(monkeypatch, review_
 
     assert task_id is None
     if review_result.startswith(('CHANGES_REQUESTED', 'BLOCKED')):
-        assert '@codetether please address the requested PR changes' in comments[0]
+        assert (
+            '@codetether please address the requested PR changes' in comments[0]
+        )
     else:
         assert comments == []
 
@@ -243,8 +295,12 @@ async def test_change_request_followup_skips_duplicate_tag(monkeypatch):
         # is posted.
         return 'task-fix-dup'
 
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
-    monkeypatch.setattr(issue_review_task, 'create_fix_followup_task', fake_fix_followup)
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'create_fix_followup_task', fake_fix_followup
+    )
 
     task_id = await issue_review_task.create_issue_merge_task(
         review_task={
@@ -267,13 +323,18 @@ async def test_change_request_followup_skips_duplicate_tag(monkeypatch):
 
 
 def test_reviewer_approval_ignores_blocked_prose():
-    assert issue_review_task.reviewer_allows_merge({
-        'result': (
-            'Self-approval is blocked by GitHub, so I left an approving comment instead.\n'
-            '## Final Verdict: **APPROVED**\n\n'
-            'Validation passed.'
+    assert (
+        issue_review_task.reviewer_allows_merge(
+            {
+                'result': (
+                    'Self-approval is blocked by GitHub, so I left an approving comment instead.\n'
+                    '## Final Verdict: **APPROVED**\n\n'
+                    'Validation passed.'
+                )
+            }
         )
-    }) is True
+        is True
+    )
 
 
 @pytest.mark.asyncio
@@ -292,9 +353,15 @@ async def test_create_merge_task_records_sha_mismatch(monkeypatch, pr_payload):
     async def fake_post(repo, issue_number, token, body):
         comments.append((repo, issue_number, body))
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
 
     task_id = await issue_review_task.create_issue_merge_task(
         review_task={
@@ -315,12 +382,17 @@ async def test_create_merge_task_records_sha_mismatch(monkeypatch, pr_payload):
 
     assert task_id is None
     assert decisions[0]['decision']['allowed'] is False
-    assert 'PR head SHA changed' in decisions[0]['decision']['provenance']['failures'][0]
+    assert (
+        'PR head SHA changed'
+        in decisions[0]['decision']['provenance']['failures'][0]
+    )
     assert 'Blocked because the PR changed' in comments[0][2]
 
 
 @pytest.mark.asyncio
-async def test_create_merge_task_blocks_unresolved_review_feedback(monkeypatch, pr_payload):
+async def test_create_merge_task_blocks_unresolved_review_feedback(
+    monkeypatch, pr_payload
+):
     decisions = []
     comments = []
 
@@ -332,7 +404,9 @@ async def test_create_merge_task_blocks_unresolved_review_feedback(monkeypatch, 
     async def fake_feedback_status(repo, pr_number, token):
         return {
             'feedback_addressed': False,
-            'blockers': ['Unresolved review thread at src/app.py:10 by reviewer'],
+            'blockers': [
+                'Unresolved review thread at src/app.py:10 by reviewer'
+            ],
         }
 
     async def fake_record(**kwargs):
@@ -341,10 +415,18 @@ async def test_create_merge_task_blocks_unresolved_review_feedback(monkeypatch, 
     async def fake_post(repo, issue_number, token, body):
         comments.append(body)
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
-    monkeypatch.setattr(issue_review_task, 'review_feedback_status', fake_feedback_status)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'review_feedback_status', fake_feedback_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
 
     task_id = await issue_review_task.create_issue_merge_task(
         review_task={
@@ -365,12 +447,17 @@ async def test_create_merge_task_blocks_unresolved_review_feedback(monkeypatch, 
 
     assert task_id is None
     assert decisions[0]['decision']['allowed'] is False
-    assert 'Unresolved review thread' in decisions[0]['decision']['provenance']['failures'][0]
+    assert (
+        'Unresolved review thread'
+        in decisions[0]['decision']['provenance']['failures'][0]
+    )
     assert 'review feedback is not fully addressed' in comments[0]
 
 
 @pytest.mark.asyncio
-async def test_create_merge_task_auto_merges_when_feedback_addressed(monkeypatch, pr_payload):
+async def test_create_merge_task_auto_merges_when_feedback_addressed(
+    monkeypatch, pr_payload
+):
     decisions = []
     comments = []
     calls = []
@@ -394,16 +481,30 @@ async def test_create_merge_task_auto_merges_when_feedback_addressed(monkeypatch
     async def fake_feedback_status(repo, pr_number, token):
         return {'feedback_addressed': True, 'blockers': []}
 
+    async def fake_status_check_status(repo, sha, token):
+        return {'checks_green': True, 'blockers': []}
+
     async def fake_record(**kwargs):
         decisions.append(kwargs)
 
     async def fake_post(repo, issue_number, token, body):
         comments.append(body)
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
-    monkeypatch.setattr(issue_review_task, 'review_feedback_status', fake_feedback_status)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'review_feedback_status', fake_feedback_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'status_check_status', fake_status_check_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
 
     result = await issue_review_task.create_issue_merge_task(
         review_task={
@@ -423,13 +524,17 @@ async def test_create_merge_task_auto_merges_when_feedback_addressed(monkeypatch
     )
 
     assert result == 'merge123'
-    assert any(call[1] == '/repos/acme/widgets/pulls/77/merge' for call in calls)
+    assert any(
+        call[1] == '/repos/acme/widgets/pulls/77/merge' for call in calls
+    )
     assert decisions[-1]['decision']['allowed'] is True
     assert 'Merged PR #77 using `squash`' in comments[0]
 
 
 @pytest.mark.asyncio
-async def test_create_merge_task_enables_github_auto_merge_when_direct_merge_blocked(monkeypatch, pr_payload):
+async def test_create_merge_task_enables_github_auto_merge_when_direct_merge_blocked(
+    monkeypatch, pr_payload
+):
     decisions = []
     comments = []
     graphql_calls = []
@@ -446,7 +551,9 @@ async def test_create_merge_task_enables_github_auto_merge_when_direct_merge_blo
                 'allow_merge_commit': True,
             }
         if method == 'PUT' and path == '/repos/acme/widgets/pulls/77/merge':
-            raise RuntimeError('Repository rule violations found: Cannot update this protected ref.')
+            raise RuntimeError(
+                'Repository rule violations found: Cannot update this protected ref.'
+            )
         raise AssertionError(f'unexpected GitHub call: {method} {path}')
 
     async def fake_github_graphql(query, variables, token):
@@ -466,17 +573,33 @@ async def test_create_merge_task_enables_github_auto_merge_when_direct_merge_blo
     async def fake_feedback_status(repo, pr_number, token):
         return {'feedback_addressed': True, 'blockers': []}
 
+    async def fake_status_check_status(repo, sha, token):
+        return {'checks_green': True, 'blockers': []}
+
     async def fake_record(**kwargs):
         decisions.append(kwargs)
 
     async def fake_post(repo, issue_number, token, body):
         comments.append(body)
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
-    monkeypatch.setattr('a2a_server.github_app.auth.github_graphql', fake_github_graphql)
-    monkeypatch.setattr(issue_review_task, 'review_feedback_status', fake_feedback_status)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_graphql', fake_github_graphql
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'review_feedback_status', fake_feedback_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'status_check_status', fake_status_check_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
 
     result = await issue_review_task.create_issue_merge_task(
         review_task={
@@ -503,6 +626,76 @@ async def test_create_merge_task_enables_github_auto_merge_when_direct_merge_blo
     assert 'Enabled GitHub auto-merge for PR #77 using `squash`' in comments[0]
 
 
+@pytest.mark.asyncio
+async def test_create_merge_task_blocks_failed_status_checks(
+    monkeypatch, pr_payload
+):
+    decisions = []
+    comments = []
+    calls = []
+
+    async def fake_github_json(method, path, token, payload=None):
+        calls.append((method, path, payload))
+        if path == '/repos/acme/widgets/pulls/77':
+            return pr_payload
+        raise AssertionError(f'unexpected GitHub call: {method} {path}')
+
+    async def fake_feedback_status(repo, pr_number, token):
+        return {'feedback_addressed': True, 'blockers': []}
+
+    async def fake_status_check_status(repo, sha, token):
+        return {
+            'checks_green': False,
+            'blockers': ['Check `Lint Code Base` concluded failure'],
+        }
+
+    async def fake_record(**kwargs):
+        decisions.append(kwargs)
+
+    async def fake_post(repo, issue_number, token, body):
+        comments.append(body)
+
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'review_feedback_status', fake_feedback_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'status_check_status', fake_status_check_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
+    monkeypatch.setattr(issue_review_task, 'AUTO_MERGE_ENABLED', True)
+
+    result = await issue_review_task.create_issue_merge_task(
+        review_task={
+            'id': 'task-review-1',
+            'result': 'APPROVED: looks safe',
+            'metadata': {
+                'workspace_id': 'ws1',
+                'repo': 'acme/widgets',
+                'issue_number': 12,
+                'pr_number': 77,
+                'branch_name': 'codetether/issue-12',
+                'pr_head_sha': 'abc123',
+                'github_installation_id': 123,
+            },
+        },
+        token='token',
+    )
+
+    assert result is None
+    assert all('/merge' not in call[1] for call in calls)
+    assert decisions[-1]['decision']['allowed'] is False
+    assert 'PR status checks are not green' in comments[0]
+    assert 'Lint Code Base' in comments[0]
+
+
 def test_merge_provenance_uses_merge_steward_actor(pr_payload):
     provenance = issue_review_task.issue_pr_provenance(
         repo='acme/widgets',
@@ -513,7 +706,10 @@ def test_merge_provenance_uses_merge_steward_actor(pr_payload):
         action='github:merge_pr',
     )
 
-    assert provenance['ap_delegation']['chain'][1]['actor'] == 'codetether-merge-steward'
+    assert (
+        provenance['ap_delegation']['chain'][1]['actor']
+        == 'codetether-merge-steward'
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -521,7 +717,9 @@ def test_merge_provenance_uses_merge_steward_actor(pr_payload):
 # ---------------------------------------------------------------------------
 
 
-def _make_review_task(verdict_text, *, pr_head_sha='abc123', extra_metadata=None):
+def _make_review_task(
+    verdict_text, *, pr_head_sha='abc123', extra_metadata=None
+):
     """Build a review task dict with the given verdict in the result field."""
     metadata = {
         'workspace_id': 'ws1',
@@ -544,7 +742,9 @@ def _make_review_task(verdict_text, *, pr_head_sha='abc123', extra_metadata=None
 
 
 @pytest.mark.asyncio
-async def test_fix_followup_creates_task_on_changes_requested(monkeypatch, pr_payload):
+async def test_fix_followup_creates_task_on_changes_requested(
+    monkeypatch, pr_payload
+):
     """CHANGES_REQUESTED verdict enqueues a protocol-native fix task."""
     dispatched = []
     comments = []
@@ -565,10 +765,19 @@ async def test_fix_followup_creates_task_on_changes_requested(monkeypatch, pr_pa
     async def fake_count(*args, **kwargs):
         return 0
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
-    monkeypatch.setattr('a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_dispatch)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
     monkeypatch.setattr(issue_review_task, '_count_fix_attempts', fake_count)
 
     task_id = await issue_review_task.create_fix_followup_task(
@@ -585,11 +794,16 @@ async def test_fix_followup_creates_task_on_changes_requested(monkeypatch, pr_pa
     assert meta['workflow_stage'] == 'fix'
     assert meta['pr_head_sha'] == 'abc123'
     assert 'Reviewer verdict: `CHANGES_REQUESTED`' in comments[0]
-    assert '@codetether follow-up required: protocol-native fix task `task-fix-1`' in comments[0]
+    assert (
+        '@codetether follow-up required: protocol-native fix task `task-fix-1`'
+        in comments[0]
+    )
 
 
 def test_change_request_action_line_tags_only_change_requests():
-    action_line = issue_review_task.change_request_action_line('CHANGES_REQUESTED', task_id='task-fix-1')
+    action_line = issue_review_task.change_request_action_line(
+        'CHANGES_REQUESTED', task_id='task-fix-1'
+    )
 
     assert action_line.startswith('@codetether follow-up required')
     assert '`CHANGES_REQUESTED`' in action_line
@@ -616,10 +830,19 @@ async def test_fix_followup_creates_task_on_blocked(monkeypatch, pr_payload):
     async def fake_count(*args, **kwargs):
         return 0
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
-    monkeypatch.setattr('a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_dispatch)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
     monkeypatch.setattr(issue_review_task, '_count_fix_attempts', fake_count)
 
     task_id = await issue_review_task.create_fix_followup_task(
@@ -665,7 +888,9 @@ async def test_fix_followup_skips_closed_pr(monkeypatch):
     async def fake_github_json(method, path, token):
         return closed_pr
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
 
     task_id = await issue_review_task.create_fix_followup_task(
         review_task=_make_review_task('CHANGES_REQUESTED: tests failed'),
@@ -683,7 +908,9 @@ async def test_fix_followup_skips_sha_mismatch(monkeypatch, pr_payload):
     async def fake_github_json(method, path, token):
         return changed_pr
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
 
     task_id = await issue_review_task.create_fix_followup_task(
         review_task=_make_review_task('CHANGES_REQUESTED: tests failed'),
@@ -702,7 +929,10 @@ async def test_fix_followup_skips_forked_pr(monkeypatch):
         'head': {
             'sha': 'abc123',
             'ref': 'codetether/issue-12',
-            'repo': {'full_name': 'other-user/widgets', 'clone_url': 'https://github.com/other-user/widgets.git'},
+            'repo': {
+                'full_name': 'other-user/widgets',
+                'clone_url': 'https://github.com/other-user/widgets.git',
+            },
         },
         'base': {'sha': 'def456'},
     }
@@ -710,7 +940,9 @@ async def test_fix_followup_skips_forked_pr(monkeypatch):
     async def fake_github_json(method, path, token):
         return forked_pr
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
 
     task_id = await issue_review_task.create_fix_followup_task(
         review_task=_make_review_task('CHANGES_REQUESTED: tests failed'),
@@ -726,7 +958,10 @@ async def test_fix_followup_skips_missing_metadata(monkeypatch):
         'id': 'task-review-1',
         'status': 'completed',
         'result': 'CHANGES_REQUESTED: fix tests',
-        'metadata': {'source': 'github-app', 'repo': 'acme/widgets'},  # missing most fields
+        'metadata': {
+            'source': 'github-app',
+            'repo': 'acme/widgets',
+        },  # missing most fields
     }
 
     task_id = await issue_review_task.create_fix_followup_task(
@@ -750,9 +985,13 @@ async def test_fix_followup_enforces_max_attempts(monkeypatch, pr_payload):
     async def fake_post(repo, issue_number, token, body):
         comments.append(body)
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
     monkeypatch.setattr(issue_review_task, '_count_fix_attempts', fake_count)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
 
     task_id = await issue_review_task.create_fix_followup_task(
         review_task=_make_review_task('CHANGES_REQUESTED: tests failed'),
@@ -764,7 +1003,9 @@ async def test_fix_followup_enforces_max_attempts(monkeypatch, pr_payload):
 
 
 @pytest.mark.asyncio
-async def test_fix_followup_includes_review_context_in_prompt(monkeypatch, pr_payload):
+async def test_fix_followup_includes_review_context_in_prompt(
+    monkeypatch, pr_payload
+):
     """The fix prompt includes review summary, changed files, blockers, and provenance."""
     dispatched = []
 
@@ -784,10 +1025,19 @@ async def test_fix_followup_includes_review_context_in_prompt(monkeypatch, pr_pa
     async def fake_count(*args, **kwargs):
         return 0
 
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
-    monkeypatch.setattr('a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_dispatch)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
     monkeypatch.setattr(issue_review_task, '_count_fix_attempts', fake_count)
 
     task_id = await issue_review_task.create_fix_followup_task(
@@ -811,7 +1061,9 @@ async def test_fix_followup_includes_review_context_in_prompt(monkeypatch, pr_pa
 
 
 @pytest.mark.asyncio
-async def test_create_merge_task_uses_protocol_native_fix_as_primary(monkeypatch, pr_payload):
+async def test_create_merge_task_uses_protocol_native_fix_as_primary(
+    monkeypatch, pr_payload
+):
     """create_issue_merge_task calls create_fix_followup_task as primary path."""
     fix_created = []
     fallback_called = []
@@ -824,8 +1076,14 @@ async def test_create_merge_task_uses_protocol_native_fix_as_primary(monkeypatch
         fallback_called.append(True)
         return False
 
-    monkeypatch.setattr(issue_review_task, 'create_fix_followup_task', fake_fix_followup)
-    monkeypatch.setattr(issue_review_task, 'post_change_request_followup_if_needed', fake_fallback)
+    monkeypatch.setattr(
+        issue_review_task, 'create_fix_followup_task', fake_fix_followup
+    )
+    monkeypatch.setattr(
+        issue_review_task,
+        'post_change_request_followup_if_needed',
+        fake_fallback,
+    )
 
     task_id = await issue_review_task.create_issue_merge_task(
         review_task=_make_review_task('CHANGES_REQUESTED: tests failed'),
@@ -838,7 +1096,9 @@ async def test_create_merge_task_uses_protocol_native_fix_as_primary(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_create_merge_task_falls_back_to_mention_on_fix_failure(monkeypatch, pr_payload):
+async def test_create_merge_task_falls_back_to_mention_on_fix_failure(
+    monkeypatch, pr_payload
+):
     """create_issue_merge_task falls back to @codetether mention when fix follow-up returns None."""
     fix_created = []
     fallback_called = []
@@ -851,8 +1111,14 @@ async def test_create_merge_task_falls_back_to_mention_on_fix_failure(monkeypatc
         fallback_called.append(True)
         return False
 
-    monkeypatch.setattr(issue_review_task, 'create_fix_followup_task', fake_fix_followup)
-    monkeypatch.setattr(issue_review_task, 'post_change_request_followup_if_needed', fake_fallback)
+    monkeypatch.setattr(
+        issue_review_task, 'create_fix_followup_task', fake_fix_followup
+    )
+    monkeypatch.setattr(
+        issue_review_task,
+        'post_change_request_followup_if_needed',
+        fake_fallback,
+    )
 
     task_id = await issue_review_task.create_issue_merge_task(
         review_task=_make_review_task('CHANGES_REQUESTED: tests failed'),
@@ -865,7 +1131,9 @@ async def test_create_merge_task_falls_back_to_mention_on_fix_failure(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_create_merge_task_does_not_call_fix_on_approval(monkeypatch, pr_payload):
+async def test_create_merge_task_does_not_call_fix_on_approval(
+    monkeypatch, pr_payload
+):
     """create_issue_merge_task does not call fix follow-up for APPROVED reviews."""
     fix_created = []
 
@@ -877,7 +1145,11 @@ async def test_create_merge_task_does_not_call_fix_on_approval(monkeypatch, pr_p
         if path == '/repos/acme/widgets/pulls/77':
             return pr_payload
         if path == '/repos/acme/widgets':
-            return {'allow_squash_merge': True, 'allow_rebase_merge': True, 'allow_merge_commit': True}
+            return {
+                'allow_squash_merge': True,
+                'allow_rebase_merge': True,
+                'allow_merge_commit': True,
+            }
         if method == 'PUT' and 'merge' in path:
             return {'merged': True, 'sha': 'merge123'}
         raise AssertionError(f'unexpected call: {method} {path}')
@@ -885,22 +1157,38 @@ async def test_create_merge_task_does_not_call_fix_on_approval(monkeypatch, pr_p
     async def fake_feedback_status(repo, pr_number, token):
         return {'feedback_addressed': True, 'blockers': []}
 
+    async def fake_status_check_status(repo, sha, token):
+        return {'checks_green': True, 'blockers': []}
+
     async def fake_record(**kwargs):
         pass
 
     async def fake_post(*args, **kwargs):
         pass
 
-    monkeypatch.setattr(issue_review_task, 'create_fix_followup_task', fake_fix_followup)
-    monkeypatch.setattr('a2a_server.github_app.auth.github_json', fake_github_json)
-    monkeypatch.setattr(issue_review_task, 'review_feedback_status', fake_feedback_status)
-    monkeypatch.setattr(issue_review_task, 'record_automation_decision', fake_record)
-    monkeypatch.setattr('a2a_server.github_app.watch.post_issue_comment', fake_post)
+    monkeypatch.setattr(
+        issue_review_task, 'create_fix_followup_task', fake_fix_followup
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'review_feedback_status', fake_feedback_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'status_check_status', fake_status_check_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
 
     # Use AUTO_MERGE_ENABLED path
     monkeypatch.setattr(issue_review_task, 'AUTO_MERGE_ENABLED', True)
 
-    task_id = await issue_review_task.create_issue_merge_task(
+    await issue_review_task.create_issue_merge_task(
         review_task=_make_review_task('APPROVED: looks safe'),
         token='token',
     )


### PR DESCRIPTION
## Summary
- require PR commit statuses and check-runs to be green before CodeTether auto-merge runs
- record and comment structured blockers when checks fail or cannot be verified
- allow protocol-native PR fix follow-up provenance to use github:fix_pr

## Tests
- python3 -m pytest tests/test_github_app_issue_review_flow.py -q
- /tmp/codetether-ruff-venv/bin/ruff check --config .github/linters/.ruff.toml a2a_server/github_app/issue_review_task.py tests/test_github_app_issue_review_flow.py
- /tmp/codetether-ruff-venv/bin/ruff format --config .github/linters/.ruff.toml --check a2a_server/github_app/issue_review_task.py tests/test_github_app_issue_review_flow.py