### PR TITLE
fix: use PR number for GitHub App fix follow-ups

### DIFF
--- a/a2a_server/github_app/payload.py
+++ b/a2a_server/github_app/payload.py
@@ -79,6 +79,24 @@ def _body_for_event(event_name: str, payload: dict[str, Any]) -> str:
     return ''
 
 
+def is_changes_requested_review(event_name: str, payload: dict[str, Any]) -> bool:
+    """Return true for PR review submissions that request changes."""
+    if event_name != 'pull_request_review':
+        return False
+    review = payload.get('review') or {}
+    return str(review.get('state') or '').lower() == 'changes_requested'
+
+
+def _changes_requested_review_body(payload: dict[str, Any]) -> str:
+    review = payload.get('review') or {}
+    reviewer = (review.get('user') or {}).get('login') or 'unknown'
+    review_body = str(review.get('body') or '').strip()
+    body = f'Changes requested by reviewer {reviewer}.'
+    if review_body:
+        body = f'{body}\n\n{review_body}'
+    return body
+
+
 def extract_context(event_name: str, payload: dict[str, Any]) -> Optional[MentionContext]:
     """Normalize GitHub webhook payloads that can mention the app."""
     body = _body_for_event(event_name, payload)
@@ -90,7 +108,11 @@ def extract_context(event_name: str, payload: dict[str, Any]) -> Optional[Mentio
     comment_path = ''
     comment_diff_hunk = ''
 
-    if not mentions_bot(body) or not installation_id or not repo_full_name:
+    is_review_change_request = is_changes_requested_review(event_name, payload)
+    if (
+        not is_review_change_request
+        and not mentions_bot(body)
+    ) or not installation_id or not repo_full_name:
         return None
 
     if event_name == 'issue_comment':
@@ -107,6 +129,8 @@ def extract_context(event_name: str, payload: dict[str, Any]) -> Optional[Mentio
         pr_number = issue_number
         review = payload.get('review') or {}
         comment_id = review.get('id') or issue_number
+        if is_review_change_request and not mentions_bot(body):
+            body = _changes_requested_review_body(payload)
     elif event_name == 'issues':
         issue = payload.get('issue', {})
         issue_number = issue.get('number')

--- a/a2a_server/github_app/payload.py
+++ b/a2a_server/github_app/payload.py
@@ -7,7 +7,9 @@ from .mention import mentions_bot
 from .settings import APP_SLUG
 
 
-def _actor_for_event(event_name: str, payload: dict[str, Any]) -> dict[str, Any]:
+def _actor_for_event(
+    event_name: str, payload: dict[str, Any]
+) -> dict[str, Any]:
     """Return the GitHub actor that authored the user-visible webhook text."""
     if event_name in {'issue_comment', 'pull_request_review_comment'}:
         return payload.get('comment', {}).get('user', {}) or {}
@@ -31,7 +33,10 @@ def is_self_authored_event(event_name: str, payload: dict[str, Any]) -> bool:
     """
     app_slug = APP_SLUG.lower()
     expected_bot_login = f'{app_slug}[bot]'
-    actors = [_actor_for_event(event_name, payload), payload.get('sender', {}) or {}]
+    actors = [
+        _actor_for_event(event_name, payload),
+        payload.get('sender', {}) or {},
+    ]
     for actor in actors:
         login = str(actor.get('login', '') or '').lower()
         actor_type = str(actor.get('type', '') or '').lower()
@@ -51,7 +56,9 @@ def is_supported_event_action(event_name: str, payload: dict[str, Any]) -> bool:
         if action == 'created':
             return True
         if action == 'edited':
-            old_body = (payload.get('changes', {}).get('body', {}) or {}).get('from', '')
+            old_body = (payload.get('changes', {}).get('body', {}) or {}).get(
+                'from', ''
+            )
             new_body = _body_for_event(event_name, payload)
             return mentions_bot(new_body) and not mentions_bot(old_body)
         return False
@@ -61,7 +68,9 @@ def is_supported_event_action(event_name: str, payload: dict[str, Any]) -> bool:
         if action == 'opened':
             return True
         if action == 'edited':
-            old_body = (payload.get('changes', {}).get('body', {}) or {}).get('from', '')
+            old_body = (payload.get('changes', {}).get('body', {}) or {}).get(
+                'from', ''
+            )
             new_body = _body_for_event(event_name, payload)
             return mentions_bot(new_body) and not mentions_bot(old_body)
     return False
@@ -79,7 +88,9 @@ def _body_for_event(event_name: str, payload: dict[str, Any]) -> str:
     return ''
 
 
-def is_changes_requested_review(event_name: str, payload: dict[str, Any]) -> bool:
+def is_changes_requested_review(
+    event_name: str, payload: dict[str, Any]
+) -> bool:
     """Return true for PR review submissions that request changes."""
     if event_name != 'pull_request_review':
         return False
@@ -97,7 +108,9 @@ def _changes_requested_review_body(payload: dict[str, Any]) -> str:
     return body
 
 
-def extract_context(event_name: str, payload: dict[str, Any]) -> Optional[MentionContext]:
+def extract_context(
+    event_name: str, payload: dict[str, Any]
+) -> Optional[MentionContext]:
     """Normalize GitHub webhook payloads that can mention the app."""
     body = _body_for_event(event_name, payload)
     installation_id = payload.get('installation', {}).get('id')
@@ -110,9 +123,10 @@ def extract_context(event_name: str, payload: dict[str, Any]) -> Optional[Mentio
 
     is_review_change_request = is_changes_requested_review(event_name, payload)
     if (
-        not is_review_change_request
-        and not mentions_bot(body)
-    ) or not installation_id or not repo_full_name:
+        (not is_review_change_request and not mentions_bot(body))
+        or not installation_id
+        or not repo_full_name
+    ):
         return None
 
     if event_name == 'issue_comment':
@@ -123,7 +137,9 @@ def extract_context(event_name: str, payload: dict[str, Any]) -> Optional[Mentio
         issue_number = payload.get('pull_request', {}).get('number')
         pr_number = issue_number
         comment_path = payload.get('comment', {}).get('path', '') or ''
-        comment_diff_hunk = payload.get('comment', {}).get('diff_hunk', '') or ''
+        comment_diff_hunk = (
+            payload.get('comment', {}).get('diff_hunk', '') or ''
+        )
     elif event_name == 'pull_request_review':
         issue_number = payload.get('pull_request', {}).get('number')
         pr_number = issue_number

--- a/a2a_server/github_app/router.py
+++ b/a2a_server/github_app/router.py
@@ -11,6 +11,7 @@ from .check_failures import context_from_failed_check, should_remediate_failed_c
 from .mention import is_fix_request
 from .payload import (
     extract_context,
+    is_changes_requested_review,
     is_self_authored_event,
     is_supported_event_action,
 )
@@ -80,7 +81,9 @@ async def handle_github_webhook(request: Request):
         )
         return {'ignored': True}
     token, _ = await installation_token(context.installation_id)
-    if not is_fix_request(context.comment_body):
+    is_review_change_request = is_changes_requested_review(event_name, payload)
+    is_explicit_fix_request = is_fix_request(context.comment_body)
+    if not is_review_change_request and not is_explicit_fix_request:
         if await has_active_github_app_task(context.repo_full_name, context.issue_number):
             return {'accepted': False, 'reason': 'active-task-exists'}
         await post_issue_comment(

--- a/a2a_server/github_app/router.py
+++ b/a2a_server/github_app/router.py
@@ -5,9 +5,15 @@ import logging
 
 from fastapi import APIRouter, Request
 
-from .active_work import dispatch_active_work_for_installation, has_active_github_app_task
+from .active_work import (
+    dispatch_active_work_for_installation,
+    has_active_github_app_task,
+)
 from .auth import installation_token, verify_signature
-from .check_failures import context_from_failed_check, should_remediate_failed_check
+from .check_failures import (
+    context_from_failed_check,
+    should_remediate_failed_check,
+)
 from .mention import is_fix_request
 from .payload import (
     extract_context,
@@ -55,8 +61,14 @@ async def handle_github_webhook(request: Request):
     if should_remediate_failed_check(event_name, payload):
         context = context_from_failed_check(event_name, payload)
         token, _ = await installation_token(context.installation_id)
-        if await has_active_github_app_task(context.repo_full_name, context.issue_number):
-            return {'trigger': 'failed_check', 'accepted': False, 'reason': 'active-task-exists'}
+        if await has_active_github_app_task(
+            context.repo_full_name, context.issue_number
+        ):
+            return {
+                'trigger': 'failed_check',
+                'accepted': False,
+                'reason': 'active-task-exists',
+            }
         result = await handle_fix_request(context, token)
         return {'trigger': 'failed_check', **result}
     if not is_supported_event_action(event_name, payload):
@@ -84,32 +96,36 @@ async def handle_github_webhook(request: Request):
     is_review_change_request = is_changes_requested_review(event_name, payload)
     is_explicit_fix_request = is_fix_request(context.comment_body)
     if not is_review_change_request and not is_explicit_fix_request:
-        if await has_active_github_app_task(context.repo_full_name, context.issue_number):
+        if await has_active_github_app_task(
+            context.repo_full_name, context.issue_number
+        ):
             return {'accepted': False, 'reason': 'active-task-exists'}
         await post_issue_comment(
             context.repo_full_name,
             context.issue_number,
             token,
-            "## 🤖 CodeTether\n\n"
-            "I saw the mention, but I only start repository-changing work when the "
-            "comment explicitly asks me to fix, apply, implement, handle, or otherwise "
-            "change code.\n\n"
-            "For issues, I can create a branch and open a PR; for pull requests, I can "
-            f"push to the PR branch. Try `@{APP_SLUG} handle this issue` or "
-            f"`@{APP_SLUG} implement this`.",
+            '## 🤖 CodeTether\n\n'
+            'I saw the mention, but I only start repository-changing work when the '
+            'comment explicitly asks me to fix, apply, implement, handle, or otherwise '
+            'change code.\n\n'
+            'For issues, I can create a branch and open a PR; for pull requests, I can '
+            f'push to the PR branch. Try `@{APP_SLUG} handle this issue` or '
+            f'`@{APP_SLUG} implement this`.',
         )
         return {'accepted': False, 'reason': 'non-fix mention'}
-    if await has_active_github_app_task(context.repo_full_name, context.issue_number):
+    if await has_active_github_app_task(
+        context.repo_full_name, context.issue_number
+    ):
         return {'accepted': False, 'reason': 'active-task-exists'}
     return await handle_fix_request(context, token)
 
 
-def _should_dispatch_installed_repo_active_work(event_name: str, payload: dict) -> bool:
+def _should_dispatch_installed_repo_active_work(
+    event_name: str, payload: dict
+) -> bool:
     """Return true when GitHub App repo scope changes need active-work backfill."""
     action = payload.get('action')
-    return (
-        event_name == 'installation' and action == 'created'
-    ) or (
+    return (event_name == 'installation' and action == 'created') or (
         event_name == 'installation_repositories'
         and action in {'added', 'created'}
     )

--- a/a2a_server/github_app/task_context.py
+++ b/a2a_server/github_app/task_context.py
@@ -3,7 +3,9 @@
 from .auth import installation_token
 
 
-async def github_app_task_context(task: dict) -> tuple[str, int, str, str] | None:
+async def github_app_task_context(
+    task: dict,
+) -> tuple[str, int, str, str] | None:
     """Resolve repo, issue/PR number, branch, and installation token."""
     from .. import database as db
 
@@ -28,7 +30,11 @@ async def github_app_task_context(task: dict) -> tuple[str, int, str, str] | Non
     # comment/review code must fetch `/pulls/{pr_number}` rather than the
     # source issue number.
     number = metadata.get('pr_number') or metadata.get('issue_number')
-    branch = metadata.get('branch_name') or metadata.get('pr_head') or metadata.get('git_branch')
+    branch = (
+        metadata.get('branch_name')
+        or metadata.get('pr_head')
+        or metadata.get('git_branch')
+    )
     if not number or not branch:
         return None
     return (

--- a/a2a_server/github_app/task_context.py
+++ b/a2a_server/github_app/task_context.py
@@ -22,13 +22,18 @@ async def github_app_task_context(task: dict) -> tuple[str, int, str, str] | Non
     if not installation_id:
         return None
     token, _ = await installation_token(int(str(installation_id)))
-    issue_number = metadata.get('issue_number') or metadata.get('pr_number')
+    # Generic GitHub App task context is used by both issue tasks and PR tasks.
+    # Prefer the PR number when present: review-fix tasks carry both
+    # `issue_number` (source issue) and `pr_number` (target PR), and PR final
+    # comment/review code must fetch `/pulls/{pr_number}` rather than the
+    # source issue number.
+    number = metadata.get('pr_number') or metadata.get('issue_number')
     branch = metadata.get('branch_name') or metadata.get('pr_head') or metadata.get('git_branch')
-    if not issue_number or not branch:
+    if not number or not branch:
         return None
     return (
         str(metadata.get('repo') or '').strip(),
-        int(issue_number),
+        int(number),
         str(branch).strip(),
         token,
     )

--- a/tests/test_github_app_router.py
+++ b/tests/test_github_app_router.py
@@ -461,6 +461,7 @@ async def test_installation_created_event_dispatches_active_work(monkeypatch):
         'dispatched': 1,
     }
 
+
 @pytest.mark.asyncio
 async def test_checks_failed_mention_routes_to_fix_handler(monkeypatch):
     calls = []
@@ -521,6 +522,71 @@ async def test_checks_failed_mention_routes_to_fix_handler(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_changes_requested_review_without_mention_creates_fix_task(monkeypatch):
+    calls = []
+
+    class FakeRequest:
+        headers = {
+            'X-Hub-Signature-256': 'sha256=test',
+            'X-GitHub-Event': 'pull_request_review',
+        }
+
+        async def body(self):
+            return json.dumps({
+                'action': 'submitted',
+                'installation': {'id': 123},
+                'repository': {'full_name': 'owner/repo'},
+                'pull_request': {'number': 7},
+                'review': {
+                    'id': 456,
+                    'state': 'changes_requested',
+                    'body': 'Please add coverage for the new edge case.',
+                    'user': {'login': 'reviewer', 'type': 'User'},
+                },
+                'sender': {'login': 'reviewer', 'type': 'User'},
+            }).encode()
+
+    async def fake_verify(signature, body):
+        assert signature == 'sha256=test'
+
+    async def fake_installation_token(installation_id):
+        assert installation_id == 123
+        return 'ghs_test', '2026-04-24T22:00:00Z'
+
+    async def fake_has_active_github_app_task(repo, number):
+        assert repo == 'owner/repo'
+        assert number == 7
+        return False
+
+    async def fake_handle_fix_request(context, token):
+        calls.append((context, token))
+        return {'accepted': True, 'clone_task_id': 'task-review'}
+
+    async def fail_post_issue_comment(repo, issue_number, token, body):
+        raise AssertionError('changes-requested reviews should not be treated as non-fix mentions')
+
+    monkeypatch.setattr(router, 'verify_signature', fake_verify)
+    monkeypatch.setattr(router, 'installation_token', fake_installation_token)
+    monkeypatch.setattr(router, 'has_active_github_app_task', fake_has_active_github_app_task)
+    monkeypatch.setattr(router, 'handle_fix_request', fake_handle_fix_request)
+    monkeypatch.setattr(router, 'post_issue_comment', fail_post_issue_comment)
+
+    result = await router.handle_github_webhook(FakeRequest())
+
+    assert result == {'accepted': True, 'clone_task_id': 'task-review'}
+    assert len(calls) == 1
+    context, token = calls[0]
+    assert token == 'ghs_test'
+    assert context.repo_full_name == 'owner/repo'
+    assert context.issue_number == 7
+    assert context.pr_number == 7
+    assert context.comment_id == 456
+    assert '@codetether' not in context.comment_body
+    assert 'Changes requested by reviewer reviewer' in context.comment_body
+    assert 'Please add coverage for the new edge case.' in context.comment_body
+
+
+@pytest.mark.asyncio
 async def test_failed_check_event_dedupes_when_active_task_exists(monkeypatch):
     class FakeRequest:
         headers = {
@@ -569,6 +635,47 @@ async def test_failed_check_event_dedupes_when_active_task_exists(monkeypatch):
         'accepted': False,
         'reason': 'active-task-exists',
     }
+
+
+@pytest.mark.asyncio
+async def test_non_changes_requested_review_without_mention_is_ignored(monkeypatch):
+    class FakeRequest:
+        headers = {
+            'X-Hub-Signature-256': 'sha256=test',
+            'X-GitHub-Event': 'pull_request_review',
+        }
+
+        async def body(self):
+            return json.dumps({
+                'action': 'submitted',
+                'installation': {'id': 123},
+                'repository': {'full_name': 'owner/repo'},
+                'pull_request': {'number': 7},
+                'review': {
+                    'id': 456,
+                    'state': 'commented',
+                    'body': 'Looks okay overall.',
+                    'user': {'login': 'reviewer', 'type': 'User'},
+                },
+                'sender': {'login': 'reviewer', 'type': 'User'},
+            }).encode()
+
+    async def fake_verify(signature, body):
+        assert signature == 'sha256=test'
+
+    async def fail_installation_token(installation_id):
+        raise AssertionError('installation token should not be minted for unmentioned review comments')
+
+    async def fail_handle_fix_request(context, token):
+        raise AssertionError('unmentioned non-changes-requested reviews should not create tasks')
+
+    monkeypatch.setattr(router, 'verify_signature', fake_verify)
+    monkeypatch.setattr(router, 'installation_token', fail_installation_token)
+    monkeypatch.setattr(router, 'handle_fix_request', fail_handle_fix_request)
+
+    result = await router.handle_github_webhook(FakeRequest())
+
+    assert result == {'ignored': True}
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_app_router.py
+++ b/tests/test_github_app_router.py
@@ -6,7 +6,9 @@ from a2a_server.github_app import router
 
 
 @pytest.mark.asyncio
-async def test_non_fix_mention_posts_actionable_issue_and_pr_guidance(monkeypatch):
+async def test_non_fix_mention_posts_actionable_issue_and_pr_guidance(
+    monkeypatch,
+):
     calls = []
     app_slug = router.APP_SLUG
 
@@ -17,13 +19,18 @@ async def test_non_fix_mention_posts_actionable_issue_and_pr_guidance(monkeypatc
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'created',
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'issue': {'number': 7},
-                'comment': {'id': 99, 'body': f'@{app_slug} thanks for looking'},
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'created',
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'issue': {'number': 7},
+                    'comment': {
+                        'id': 99,
+                        'body': f'@{app_slug} thanks for looking',
+                    },
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -67,13 +74,23 @@ async def test_build_failed_mention_routes_to_fix_handler(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'created',
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'issue': {'number': 87, 'pull_request': {'url': 'https://api.github.com/repos/owner/repo/pulls/87'}},
-                'comment': {'id': 99, 'body': f'@{app_slug} the build failed'},
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'created',
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'issue': {
+                        'number': 87,
+                        'pull_request': {
+                            'url': 'https://api.github.com/repos/owner/repo/pulls/87'
+                        },
+                    },
+                    'comment': {
+                        'id': 99,
+                        'body': f'@{app_slug} the build failed',
+                    },
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -87,7 +104,9 @@ async def test_build_failed_mention_routes_to_fix_handler(monkeypatch):
         return {'accepted': True, 'clone_task_id': 'task-build-failed'}
 
     async def fail_post_issue_comment(*args, **kwargs):
-        raise AssertionError('build failed mention should not get non-fix guidance')
+        raise AssertionError(
+            'build failed mention should not get non-fix guidance'
+        )
 
     monkeypatch.setattr(router, 'verify_signature', fake_verify)
     monkeypatch.setattr(router, 'installation_token', fake_installation_token)
@@ -116,24 +135,28 @@ async def test_bot_authored_issue_comment_is_ignored(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'created',
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'sender': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
-                'issue': {'number': 7},
-                'comment': {
-                    'id': 99,
-                    'user': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
-                    'body': f'@{app_slug} follow-up required: please address tests',
-                },
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'created',
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'sender': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
+                    'issue': {'number': 7},
+                    'comment': {
+                        'id': 99,
+                        'user': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
+                        'body': f'@{app_slug} follow-up required: please address tests',
+                    },
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
 
     async def fail_installation_token(installation_id):
-        raise AssertionError('installation token should not be minted for bot-authored comments')
+        raise AssertionError(
+            'installation token should not be minted for bot-authored comments'
+        )
 
     async def fail_handle_fix_request(context, token):
         raise AssertionError('bot-authored comments must not create fix tasks')
@@ -164,17 +187,19 @@ async def test_issue_opened_mention_routes_to_fix_handler(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'opened',
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'issue': {
-                    'id': 456,
-                    'number': 7,
-                    'title': 'Broken flow',
-                    'body': f'@{app_slug} handle this issue',
-                },
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'opened',
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'issue': {
+                        'id': 456,
+                        'number': 7,
+                        'title': 'Broken flow',
+                        'body': f'@{app_slug} handle this issue',
+                    },
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -215,17 +240,19 @@ async def test_issue_edited_ignores_existing_mentions(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'edited',
-                'changes': {'body': {'from': f'@{app_slug} old request'}},
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'issue': {
-                    'id': 456,
-                    'number': 7,
-                    'body': f'@{app_slug} handle this issue',
-                },
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'edited',
+                    'changes': {'body': {'from': f'@{app_slug} old request'}},
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'issue': {
+                        'id': 456,
+                        'number': 7,
+                        'body': f'@{app_slug} handle this issue',
+                    },
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -257,18 +284,20 @@ async def test_self_authored_issue_comment_is_ignored(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'created',
-                'sender': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'issue': {'number': 7},
-                'comment': {
-                    'id': 99,
-                    'body': f'Try `@{app_slug} handle this issue`.',
-                    'user': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
-                },
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'created',
+                    'sender': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'issue': {'number': 7},
+                    'comment': {
+                        'id': 99,
+                        'body': f'Try `@{app_slug} handle this issue`.',
+                        'user': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
+                    },
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -304,20 +333,22 @@ async def test_self_authored_review_comment_is_ignored(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'created',
-                'sender': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'pull_request': {'number': 7},
-                'comment': {
-                    'id': 99,
-                    'body': f'@{app_slug} finish this',
-                    'path': 'app.py',
-                    'diff_hunk': '@@',
-                    'user': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
-                },
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'created',
+                    'sender': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'pull_request': {'number': 7},
+                    'comment': {
+                        'id': 99,
+                        'body': f'@{app_slug} finish this',
+                        'path': 'app.py',
+                        'diff_hunk': '@@',
+                        'user': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
+                    },
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -335,7 +366,9 @@ async def test_self_authored_review_comment_is_ignored(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_installation_repositories_event_dispatches_active_work(monkeypatch):
+async def test_installation_repositories_event_dispatches_active_work(
+    monkeypatch,
+):
     calls = []
 
     class FakeRequest:
@@ -345,10 +378,12 @@ async def test_installation_repositories_event_dispatches_active_work(monkeypatc
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'added',
-                'installation': {'id': 123},
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'added',
+                    'installation': {'id': 123},
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -379,7 +414,9 @@ async def test_installation_repositories_event_dispatches_active_work(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_self_authored_installation_repositories_event_is_not_backfilled(monkeypatch):
+async def test_self_authored_installation_repositories_event_is_not_backfilled(
+    monkeypatch,
+):
     app_slug = router.APP_SLUG
 
     class FakeRequest:
@@ -389,20 +426,26 @@ async def test_self_authored_installation_repositories_event_is_not_backfilled(m
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'added',
-                'installation': {'id': 123},
-                'sender': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'added',
+                    'installation': {'id': 123},
+                    'sender': {'login': f'{app_slug}[bot]', 'type': 'Bot'},
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
 
     async def fail_dispatch_active_work_for_installation(installation_id):
-        raise AssertionError('self-authored events must not trigger active-work backfill')
+        raise AssertionError(
+            'self-authored events must not trigger active-work backfill'
+        )
 
     async def fail_installation_token(installation_id):
-        raise AssertionError('self-authored events should not mint installation tokens')
+        raise AssertionError(
+            'self-authored events should not mint installation tokens'
+        )
 
     monkeypatch.setattr(router, 'verify_signature', fake_verify)
     monkeypatch.setattr(
@@ -433,10 +476,12 @@ async def test_installation_created_event_dispatches_active_work(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'created',
-                'installation': {'id': 123},
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'created',
+                    'installation': {'id': 123},
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -474,16 +519,23 @@ async def test_checks_failed_mention_routes_to_fix_handler(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'created',
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'issue': {
-                    'number': 573,
-                    'pull_request': {'url': 'https://api.github.com/repos/owner/repo/pulls/573'},
-                },
-                'comment': {'id': 99, 'body': f'@{app_slug}, the checks failed'},
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'created',
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'issue': {
+                        'number': 573,
+                        'pull_request': {
+                            'url': 'https://api.github.com/repos/owner/repo/pulls/573'
+                        },
+                    },
+                    'comment': {
+                        'id': 99,
+                        'body': f'@{app_slug}, the checks failed',
+                    },
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -501,11 +553,15 @@ async def test_checks_failed_mention_routes_to_fix_handler(monkeypatch):
         return {'accepted': True, 'clone_task_id': 'task-1'}
 
     async def fail_post_issue_comment(repo, issue_number, token, body):
-        raise AssertionError('checks failed mention must not post non-fix guidance')
+        raise AssertionError(
+            'checks failed mention must not post non-fix guidance'
+        )
 
     monkeypatch.setattr(router, 'verify_signature', fake_verify)
     monkeypatch.setattr(router, 'installation_token', fake_installation_token)
-    monkeypatch.setattr(router, 'has_active_github_app_task', fake_has_active_github_app_task)
+    monkeypatch.setattr(
+        router, 'has_active_github_app_task', fake_has_active_github_app_task
+    )
     monkeypatch.setattr(router, 'handle_fix_request', fake_handle_fix_request)
     monkeypatch.setattr(router, 'post_issue_comment', fail_post_issue_comment)
 
@@ -522,7 +578,9 @@ async def test_checks_failed_mention_routes_to_fix_handler(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_changes_requested_review_without_mention_creates_fix_task(monkeypatch):
+async def test_changes_requested_review_without_mention_creates_fix_task(
+    monkeypatch,
+):
     calls = []
 
     class FakeRequest:
@@ -532,19 +590,21 @@ async def test_changes_requested_review_without_mention_creates_fix_task(monkeyp
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'submitted',
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'pull_request': {'number': 7},
-                'review': {
-                    'id': 456,
-                    'state': 'changes_requested',
-                    'body': 'Please add coverage for the new edge case.',
-                    'user': {'login': 'reviewer', 'type': 'User'},
-                },
-                'sender': {'login': 'reviewer', 'type': 'User'},
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'submitted',
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'pull_request': {'number': 7},
+                    'review': {
+                        'id': 456,
+                        'state': 'changes_requested',
+                        'body': 'Please add coverage for the new edge case.',
+                        'user': {'login': 'reviewer', 'type': 'User'},
+                    },
+                    'sender': {'login': 'reviewer', 'type': 'User'},
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -563,11 +623,15 @@ async def test_changes_requested_review_without_mention_creates_fix_task(monkeyp
         return {'accepted': True, 'clone_task_id': 'task-review'}
 
     async def fail_post_issue_comment(repo, issue_number, token, body):
-        raise AssertionError('changes-requested reviews should not be treated as non-fix mentions')
+        raise AssertionError(
+            'changes-requested reviews should not be treated as non-fix mentions'
+        )
 
     monkeypatch.setattr(router, 'verify_signature', fake_verify)
     monkeypatch.setattr(router, 'installation_token', fake_installation_token)
-    monkeypatch.setattr(router, 'has_active_github_app_task', fake_has_active_github_app_task)
+    monkeypatch.setattr(
+        router, 'has_active_github_app_task', fake_has_active_github_app_task
+    )
     monkeypatch.setattr(router, 'handle_fix_request', fake_handle_fix_request)
     monkeypatch.setattr(router, 'post_issue_comment', fail_post_issue_comment)
 
@@ -595,18 +659,23 @@ async def test_failed_check_event_dedupes_when_active_task_exists(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'completed',
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'check_run': {
-                    'id': 777,
-                    'name': 'CI',
-                    'conclusion': 'failure',
-                    'app': {'slug': 'github-actions', 'name': 'GitHub Actions'},
-                    'pull_requests': [{'number': 573}],
-                },
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'completed',
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'check_run': {
+                        'id': 777,
+                        'name': 'CI',
+                        'conclusion': 'failure',
+                        'app': {
+                            'slug': 'github-actions',
+                            'name': 'GitHub Actions',
+                        },
+                        'pull_requests': [{'number': 573}],
+                    },
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -621,11 +690,15 @@ async def test_failed_check_event_dedupes_when_active_task_exists(monkeypatch):
         return True
 
     async def fail_handle_fix_request(context, token):
-        raise AssertionError('failed check remediation must dedupe active PR task')
+        raise AssertionError(
+            'failed check remediation must dedupe active PR task'
+        )
 
     monkeypatch.setattr(router, 'verify_signature', fake_verify)
     monkeypatch.setattr(router, 'installation_token', fake_installation_token)
-    monkeypatch.setattr(router, 'has_active_github_app_task', fake_has_active_github_app_task)
+    monkeypatch.setattr(
+        router, 'has_active_github_app_task', fake_has_active_github_app_task
+    )
     monkeypatch.setattr(router, 'handle_fix_request', fail_handle_fix_request)
 
     result = await router.handle_github_webhook(FakeRequest())
@@ -638,7 +711,9 @@ async def test_failed_check_event_dedupes_when_active_task_exists(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_non_changes_requested_review_without_mention_is_ignored(monkeypatch):
+async def test_non_changes_requested_review_without_mention_is_ignored(
+    monkeypatch,
+):
     class FakeRequest:
         headers = {
             'X-Hub-Signature-256': 'sha256=test',
@@ -646,28 +721,34 @@ async def test_non_changes_requested_review_without_mention_is_ignored(monkeypat
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'submitted',
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'pull_request': {'number': 7},
-                'review': {
-                    'id': 456,
-                    'state': 'commented',
-                    'body': 'Looks okay overall.',
-                    'user': {'login': 'reviewer', 'type': 'User'},
-                },
-                'sender': {'login': 'reviewer', 'type': 'User'},
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'submitted',
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'pull_request': {'number': 7},
+                    'review': {
+                        'id': 456,
+                        'state': 'commented',
+                        'body': 'Looks okay overall.',
+                        'user': {'login': 'reviewer', 'type': 'User'},
+                    },
+                    'sender': {'login': 'reviewer', 'type': 'User'},
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
 
     async def fail_installation_token(installation_id):
-        raise AssertionError('installation token should not be minted for unmentioned review comments')
+        raise AssertionError(
+            'installation token should not be minted for unmentioned review comments'
+        )
 
     async def fail_handle_fix_request(context, token):
-        raise AssertionError('unmentioned non-changes-requested reviews should not create tasks')
+        raise AssertionError(
+            'unmentioned non-changes-requested reviews should not create tasks'
+        )
 
     monkeypatch.setattr(router, 'verify_signature', fake_verify)
     monkeypatch.setattr(router, 'installation_token', fail_installation_token)
@@ -689,16 +770,20 @@ async def test_non_fix_guidance_suppressed_when_active_task_exists(monkeypatch):
         }
 
         async def body(self):
-            return json.dumps({
-                'action': 'created',
-                'installation': {'id': 123},
-                'repository': {'full_name': 'owner/repo'},
-                'issue': {
-                    'number': 573,
-                    'pull_request': {'url': 'https://api.github.com/repos/owner/repo/pulls/573'},
-                },
-                'comment': {'id': 99, 'body': f'@{app_slug} hello?'},
-            }).encode()
+            return json.dumps(
+                {
+                    'action': 'created',
+                    'installation': {'id': 123},
+                    'repository': {'full_name': 'owner/repo'},
+                    'issue': {
+                        'number': 573,
+                        'pull_request': {
+                            'url': 'https://api.github.com/repos/owner/repo/pulls/573'
+                        },
+                    },
+                    'comment': {'id': 99, 'body': f'@{app_slug} hello?'},
+                }
+            ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
@@ -717,7 +802,9 @@ async def test_non_fix_guidance_suppressed_when_active_task_exists(monkeypatch):
 
     monkeypatch.setattr(router, 'verify_signature', fake_verify)
     monkeypatch.setattr(router, 'installation_token', fake_installation_token)
-    monkeypatch.setattr(router, 'has_active_github_app_task', fake_has_active_github_app_task)
+    monkeypatch.setattr(
+        router, 'has_active_github_app_task', fake_has_active_github_app_task
+    )
     monkeypatch.setattr(router, 'post_issue_comment', fail_post_issue_comment)
 
     result = await router.handle_github_webhook(FakeRequest())

--- a/tests/test_github_app_task_completion.py
+++ b/tests/test_github_app_task_completion.py
@@ -2,7 +2,9 @@ import os
 
 import pytest
 
-os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault(
+    'DATABASE_URL', 'postgresql://test:test@localhost:5432/test'
+)
 
 from a2a_server import git_service
 from a2a_server.github_app import issue_prepare_completion
@@ -17,7 +19,9 @@ async def test_pr_prepare_task_creates_pr_followup(monkeypatch):
     async def fake_handle(task, worker_id=None):
         calls.append((task, worker_id))
 
-    monkeypatch.setattr(task_completion, 'handle_pr_prepare_completion', fake_handle)
+    monkeypatch.setattr(
+        task_completion, 'handle_pr_prepare_completion', fake_handle
+    )
 
     task = {
         'title': 'Prepare PR workspace #40',
@@ -68,7 +72,8 @@ async def test_pr_prepare_completion_skips_duplicate_followup(monkeypatch):
         pr_prepare_completion, '_claim_pr_followup_creation', fake_claim
     )
     monkeypatch.setattr(
-        'a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_create
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_create,
     )
 
     task = {
@@ -81,7 +86,10 @@ async def test_pr_prepare_completion_skips_duplicate_followup(monkeypatch):
             'post_clone_task': {
                 'title': 'Apply PR fix #40',
                 'prompt': 'fix it',
-                'metadata': {'repo': 'rileyseaburg/codetether', 'pr_number': 40},
+                'metadata': {
+                    'repo': 'rileyseaburg/codetether',
+                    'pr_number': 40,
+                },
             },
         },
     }
@@ -127,11 +135,18 @@ async def test_pr_prepare_completion_records_followup_task(monkeypatch):
     monkeypatch.setattr(
         pr_prepare_completion, '_record_pr_followup_task', fake_record
     )
-    monkeypatch.setattr(pr_prepare_completion, '_acquire_followup_lock', fake_lock)
-    monkeypatch.setattr(pr_prepare_completion, '_release_followup_lock', fake_unlock)
-    monkeypatch.setattr(pr_prepare_completion, '_active_followup_task_id', fake_active)
     monkeypatch.setattr(
-        'a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_create
+        pr_prepare_completion, '_acquire_followup_lock', fake_lock
+    )
+    monkeypatch.setattr(
+        pr_prepare_completion, '_release_followup_lock', fake_unlock
+    )
+    monkeypatch.setattr(
+        pr_prepare_completion, '_active_followup_task_id', fake_active
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_create,
     )
 
     task = {
@@ -147,7 +162,10 @@ async def test_pr_prepare_completion_records_followup_task(monkeypatch):
             'post_clone_task': {
                 'title': 'Apply PR fix #40',
                 'prompt': 'fix it',
-                'metadata': {'repo': 'rileyseaburg/codetether', 'pr_number': 40},
+                'metadata': {
+                    'repo': 'rileyseaburg/codetether',
+                    'pr_number': 40,
+                },
             },
         },
     }
@@ -159,7 +177,9 @@ async def test_pr_prepare_completion_records_followup_task(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pr_prepare_completion_skips_when_active_followup_exists(monkeypatch):
+async def test_pr_prepare_completion_skips_when_active_followup_exists(
+    monkeypatch,
+):
     created = []
     recorded = []
 
@@ -193,14 +213,21 @@ async def test_pr_prepare_completion_skips_when_active_followup_exists(monkeypat
     monkeypatch.setattr(
         pr_prepare_completion, '_claim_pr_followup_creation', fake_claim
     )
-    monkeypatch.setattr(pr_prepare_completion, '_acquire_followup_lock', fake_lock)
-    monkeypatch.setattr(pr_prepare_completion, '_release_followup_lock', fake_unlock)
-    monkeypatch.setattr(pr_prepare_completion, '_active_followup_task_id', fake_active)
+    monkeypatch.setattr(
+        pr_prepare_completion, '_acquire_followup_lock', fake_lock
+    )
+    monkeypatch.setattr(
+        pr_prepare_completion, '_release_followup_lock', fake_unlock
+    )
+    monkeypatch.setattr(
+        pr_prepare_completion, '_active_followup_task_id', fake_active
+    )
     monkeypatch.setattr(
         pr_prepare_completion, '_record_pr_followup_task', fake_record
     )
     monkeypatch.setattr(
-        'a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_create
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_create,
     )
 
     task = {
@@ -213,7 +240,10 @@ async def test_pr_prepare_completion_skips_when_active_followup_exists(monkeypat
             'post_clone_task': {
                 'title': 'Apply PR fix #40',
                 'prompt': 'fix it',
-                'metadata': {'repo': 'rileyseaburg/codetether', 'pr_number': 40},
+                'metadata': {
+                    'repo': 'rileyseaburg/codetether',
+                    'pr_number': 40,
+                },
             },
         },
     }
@@ -251,14 +281,27 @@ async def test_issue_prepare_completion_records_followup_task(monkeypatch):
         created.append(kwargs)
         return 'work-issue-1'
 
-    monkeypatch.setattr(issue_prepare_completion, 'issue_task_context', fake_context)
-    monkeypatch.setattr(issue_prepare_completion, '_claim_pr_followup_creation', fake_claim)
-    monkeypatch.setattr(issue_prepare_completion, '_record_pr_followup_task', fake_record)
-    monkeypatch.setattr(issue_prepare_completion, '_acquire_followup_lock', fake_lock)
-    monkeypatch.setattr(issue_prepare_completion, '_release_followup_lock', fake_unlock)
-    monkeypatch.setattr(issue_prepare_completion, '_active_followup_task_id', fake_active)
     monkeypatch.setattr(
-        'a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_create
+        issue_prepare_completion, 'issue_task_context', fake_context
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_claim_pr_followup_creation', fake_claim
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_record_pr_followup_task', fake_record
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_acquire_followup_lock', fake_lock
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_release_followup_lock', fake_unlock
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_active_followup_task_id', fake_active
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_create,
     )
 
     task = {
@@ -272,11 +315,16 @@ async def test_issue_prepare_completion_records_followup_task(monkeypatch):
             'post_clone_task': {
                 'title': 'Work issue #39',
                 'prompt': 'fix it',
-                'metadata': {'repo': 'rileyseaburg/codetether', 'issue_number': 39},
+                'metadata': {
+                    'repo': 'rileyseaburg/codetether',
+                    'issue_number': 39,
+                },
             },
         },
     }
-    await issue_prepare_completion.handle_issue_prepare_completion(task, 'wrk_456')
+    await issue_prepare_completion.handle_issue_prepare_completion(
+        task, 'wrk_456'
+    )
 
     assert created[0]['title'] == 'Work issue #39'
     assert 'target_worker_id' not in created[0]['metadata']
@@ -284,7 +332,9 @@ async def test_issue_prepare_completion_records_followup_task(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_issue_prepare_completion_skips_when_active_followup_exists(monkeypatch):
+async def test_issue_prepare_completion_skips_when_active_followup_exists(
+    monkeypatch,
+):
     created = []
     recorded = []
 
@@ -320,14 +370,27 @@ async def test_issue_prepare_completion_skips_when_active_followup_exists(monkey
         created.append(kwargs)
         return 'work-new'
 
-    monkeypatch.setattr(issue_prepare_completion, 'issue_task_context', fake_context)
-    monkeypatch.setattr(issue_prepare_completion, '_claim_pr_followup_creation', fake_claim)
-    monkeypatch.setattr(issue_prepare_completion, '_acquire_followup_lock', fake_lock)
-    monkeypatch.setattr(issue_prepare_completion, '_release_followup_lock', fake_unlock)
-    monkeypatch.setattr(issue_prepare_completion, '_active_followup_task_id', fake_active)
-    monkeypatch.setattr(issue_prepare_completion, '_record_pr_followup_task', fake_record)
     monkeypatch.setattr(
-        'a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_create
+        issue_prepare_completion, 'issue_task_context', fake_context
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_claim_pr_followup_creation', fake_claim
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_acquire_followup_lock', fake_lock
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_release_followup_lock', fake_unlock
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_active_followup_task_id', fake_active
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_record_pr_followup_task', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_create,
     )
 
     task = {
@@ -340,11 +403,16 @@ async def test_issue_prepare_completion_skips_when_active_followup_exists(monkey
             'post_clone_task': {
                 'title': 'Work issue #39',
                 'prompt': 'fix it',
-                'metadata': {'repo': 'rileyseaburg/codetether', 'issue_number': 39},
+                'metadata': {
+                    'repo': 'rileyseaburg/codetether',
+                    'issue_number': 39,
+                },
             },
         },
     }
-    await issue_prepare_completion.handle_issue_prepare_completion(task, 'wrk_456')
+    await issue_prepare_completion.handle_issue_prepare_completion(
+        task, 'wrk_456'
+    )
 
     assert created == []
     assert recorded == [('prepare-issue-duplicate', 'work-existing')]
@@ -365,10 +433,15 @@ async def test_issue_prepare_completion_skips_duplicate_followup(monkeypatch):
         created.append(kwargs)
         return 'work-issue-1'
 
-    monkeypatch.setattr(issue_prepare_completion, 'issue_task_context', fake_context)
-    monkeypatch.setattr(issue_prepare_completion, '_claim_pr_followup_creation', fake_claim)
     monkeypatch.setattr(
-        'a2a_server.persistent_worker_pool.create_and_dispatch_task', fake_create
+        issue_prepare_completion, 'issue_task_context', fake_context
+    )
+    monkeypatch.setattr(
+        issue_prepare_completion, '_claim_pr_followup_creation', fake_claim
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_create,
     )
 
     task = {
@@ -381,11 +454,16 @@ async def test_issue_prepare_completion_skips_duplicate_followup(monkeypatch):
             'post_clone_task': {
                 'title': 'Work issue #39',
                 'prompt': 'fix it',
-                'metadata': {'repo': 'rileyseaburg/codetether', 'issue_number': 39},
+                'metadata': {
+                    'repo': 'rileyseaburg/codetether',
+                    'issue_number': 39,
+                },
             },
         },
     }
-    await issue_prepare_completion.handle_issue_prepare_completion(task, 'wrk_456')
+    await issue_prepare_completion.handle_issue_prepare_completion(
+        task, 'wrk_456'
+    )
 
     assert created == []
 
@@ -397,7 +475,9 @@ async def test_issue_prepare_task_still_uses_issue_followup(monkeypatch):
     async def fake_handle(task, worker_id=None):
         calls.append((task, worker_id))
 
-    monkeypatch.setattr(task_completion, 'handle_issue_prepare_completion', fake_handle)
+    monkeypatch.setattr(
+        task_completion, 'handle_issue_prepare_completion', fake_handle
+    )
 
     task = {
         'title': 'Prepare issue workspace #39',
@@ -433,7 +513,9 @@ async def test_git_credentials_fall_back_to_workspace_github_app(monkeypatch):
     from a2a_server import database as db
     from a2a_server.github_app import auth
 
-    monkeypatch.setattr(git_service, 'get_git_credentials', fake_get_git_credentials)
+    monkeypatch.setattr(
+        git_service, 'get_git_credentials', fake_get_git_credentials
+    )
     monkeypatch.setattr(db, 'db_get_workspace', fake_db_get_workspace)
     monkeypatch.setattr(auth, 'installation_token', fake_installation_token)
 
@@ -454,7 +536,9 @@ async def test_git_credentials_fall_back_to_workspace_github_app(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_github_app_task_context_prefers_pr_number_for_pr_tasks(monkeypatch):
+async def test_github_app_task_context_prefers_pr_number_for_pr_tasks(
+    monkeypatch,
+):
     from a2a_server import database as db
     from a2a_server.github_app import task_context
     from a2a_server.github_app.task_context import github_app_task_context
@@ -474,7 +558,9 @@ async def test_github_app_task_context_prefers_pr_number_for_pr_tasks(monkeypatc
         return 'ghs_test_token', '2026-04-24T22:00:00Z'
 
     monkeypatch.setattr(db, 'db_get_workspace', fake_db_get_workspace)
-    monkeypatch.setattr(task_context, 'installation_token', fake_installation_token)
+    monkeypatch.setattr(
+        task_context, 'installation_token', fake_installation_token
+    )
 
     context = await github_app_task_context(
         {

--- a/tests/test_github_app_task_completion.py
+++ b/tests/test_github_app_task_completion.py
@@ -451,3 +451,47 @@ async def test_git_credentials_fall_back_to_workspace_github_app(monkeypatch):
         'host': 'github.com',
         'path': 'rileyseaburg/spotlessbinco.git',
     }
+
+
+@pytest.mark.asyncio
+async def test_github_app_task_context_prefers_pr_number_for_pr_tasks(monkeypatch):
+    from a2a_server import database as db
+    from a2a_server.github_app import task_context
+    from a2a_server.github_app.task_context import github_app_task_context
+
+    async def fake_db_get_workspace(workspace_id):
+        assert workspace_id == 'ws-pr-fix'
+        return {
+            'agent_config': {
+                'git_auth': {
+                    'github_app': {'installation_id': '12345'},
+                }
+            }
+        }
+
+    async def fake_installation_token(installation_id):
+        assert installation_id == 12345
+        return 'ghs_test_token', '2026-04-24T22:00:00Z'
+
+    monkeypatch.setattr(db, 'db_get_workspace', fake_db_get_workspace)
+    monkeypatch.setattr(task_context, 'installation_token', fake_installation_token)
+
+    context = await github_app_task_context(
+        {
+            'metadata': {
+                'source': 'github-app',
+                'workspace_id': 'ws-pr-fix',
+                'repo': 'rileyseaburg/spotlessbinco',
+                'issue_number': 578,
+                'pr_number': 579,
+                'branch_name': 'codetether/issue-578',
+            }
+        }
+    )
+
+    assert context == (
+        'rileyseaburg/spotlessbinco',
+        579,
+        'codetether/issue-578',
+        'ghs_test_token',
+    )


### PR DESCRIPTION
## Summary\n- Prefer metadata.pr_number over issue_number in generic GitHub App task context so PR-fix completion fetches /pulls/{pr_number}.\n- Allow CHANGES_REQUESTED review webhooks to route into fix handling without requiring an @codetether mention.\n- Add regressions for issue #578 / PR #579 style workflows where issue and PR numbers differ.\n\n## Validation\n- static/local: python3 -m pytest tests/test_github_app_task_completion.py tests/test_github_app_router.py -q (26 passed)\n- static/local: git diff --check for touched files