### PR TITLE
fix: tag GitHub review follow-ups

### DIFF
--- a/a2a_server/github_app/issue_review_task.py
+++ b/a2a_server/github_app/issue_review_task.py
@@ -196,16 +196,16 @@ def change_request_action_line(
 ) -> str:
     """Render the actionable change-request line.
 
-    Protocol-native fix follow-ups must not tag the GitHub App handle because
-    the fix task is already queued and an extra mention re-enters the webhook
-    path, creating review/fix loops. The mention-based compatibility path still
-    includes the tag because it is only used when no protocol-native task exists.
+    Follow-up requests should explicitly tag the GitHub App handle so reviewer
+    comments are visibly actionable in GitHub. Self-authored App comments are
+    ignored by webhook ingress, so tagging the status comment does not recurse.
     """
     normalized_verdict = (
         str(verdict or 'CHANGES_REQUESTED').strip() or 'CHANGES_REQUESTED'
     )
     if task_id:
         return (
+            f'{CHANGE_REQUEST_MENTION} please address the requested PR changes. '
             f'Protocol-native fix task `{task_id}` is queued for '
             f'`{normalized_verdict}`.'
         )
@@ -649,9 +649,9 @@ async def create_fix_followup_task(
         attempt,
     )
 
-    # Post a comment indicating the protocol-native follow-up without a bot
-    # mention; mentioning the app here would re-enter the webhook path and
-    # enqueue another review cycle even though the fix task already exists.
+    # Post a tagged comment indicating the protocol-native follow-up. Webhook
+    # ingress ignores self-authored App comments, so this is visible in GitHub
+    # without re-entering the fix/review loop.
     comment_body = (
         '## 🛠️ CodeTether Fix Follow-up\n\n'
         f'{change_request_action_line(verdict or "", task_id=task_id)}\n\n'
@@ -979,7 +979,7 @@ End-to-end responsibilities:
 2. Fetch the PR branch and inspect the diff against that Definition of Done, not just generic code quality.
 3. Run the smallest relevant validation for the changed files and every issue checklist item that can be locally checked.
 4. Do not approve your own unsafe or incomplete work. If tests fail, scope drifts, secrets appear, provenance does not match the current head SHA, or any issue DoD item is missing/unproven, request changes with clear remediation.
-5. If anything requires changes, leave a CHANGES_REQUESTED review/comment without mentioning the CodeTether bot; the review completion hook will enqueue the protocol-native fix task.
+5. If anything requires changes, leave a CHANGES_REQUESTED review/comment that starts with `@codetether please address the requested PR changes`; the review completion hook will also enqueue the protocol-native fix task.
 6. If the PR is safe and feature-complete against the issue DoD, leave an approving review or success comment.
 7. Include this exact provenance footer in any GitHub review/comment you create:{footer}
 

--- a/a2a_server/github_app/payload.py
+++ b/a2a_server/github_app/payload.py
@@ -102,7 +102,7 @@ def _changes_requested_review_body(payload: dict[str, Any]) -> str:
     review = payload.get('review') or {}
     reviewer = (review.get('user') or {}).get('login') or 'unknown'
     review_body = str(review.get('body') or '').strip()
-    body = f'Changes requested by reviewer {reviewer}.'
+    body = f'@codetether please address the requested PR changes. Changes requested by reviewer {reviewer}.'
     if review_body:
         body = f'{body}\n\n{review_body}'
     return body

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -1,6 +1,8 @@
 import os
 
-os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault(
+    'DATABASE_URL', 'postgresql://test:test@localhost:5432/test'
+)
 
 import pytest
 
@@ -1246,6 +1248,7 @@ def test_fix_followup_prompt_no_attempt_on_first():
     )
     assert 'Fix attempt' not in prompt
 
+
 @pytest.mark.asyncio
 async def test_branch_verification_uses_git_ref_endpoint(monkeypatch):
     calls = []
@@ -1271,14 +1274,17 @@ async def test_branch_verification_uses_git_ref_endpoint(monkeypatch):
     assert calls == [
         (
             'GET',
-            '/repos/CodeTether/TetherScript/git/ref/heads/codetether%2Fissue-12',
+            '/repos/CodeTether/TetherScript/git/ref/heads/codetether%2F'
+            'issue-12',
             'token',
         )
     ]
 
 
 @pytest.mark.asyncio
-async def test_issue_final_comment_reports_missing_branch_as_infra_failure(monkeypatch):
+async def test_issue_final_comment_reports_missing_branch_as_infra_failure(
+    monkeypatch,
+):
     comments = []
 
     async def fake_context(task):
@@ -1312,13 +1318,20 @@ async def test_issue_final_comment_reports_missing_branch_as_infra_failure(monke
 
     assert len(comments) == 1
     assert 'Branch verification failed after worker completion' in comments[0]
-    assert 'GET /repos/CodeTether/TetherScript/git/ref/heads/codetether%2Fissue-12' in comments[0]
-    assert 'Recovery: retry or investigate worker commit/push/auth' in comments[0]
+    assert (
+        'GET /repos/CodeTether/TetherScript/git/ref/heads/codetether%2F'
+        'issue-12' in comments[0]
+    )
+    assert (
+        'Recovery: retry or investigate worker commit/push/auth' in comments[0]
+    )
     assert 'did not push commits' not in comments[0]
 
 
 @pytest.mark.asyncio
-async def test_issue_terminal_normalization_fails_missing_branch_before_check(monkeypatch):
+async def test_issue_terminal_normalization_fails_missing_branch_before_check(
+    monkeypatch,
+):
     calls = []
 
     async def fake_db_get_task(task_id):
@@ -1335,7 +1348,9 @@ async def test_issue_terminal_normalization_fails_missing_branch_before_check(mo
             'metadata': {'source': 'github-app', 'workflow_stage': 'code'},
         }
 
-    async def fake_update(task_id, status, worker_id=None, result=None, error=None):
+    async def fake_update(
+        task_id, status, worker_id=None, result=None, error=None
+    ):
         calls.append(('update', status, error))
         return True
 
@@ -1343,7 +1358,12 @@ async def test_issue_terminal_normalization_fails_missing_branch_before_check(mo
         return 'CodeTether/TetherScript', 12, 'codetether/issue-12', 'token'
 
     async def fake_verify(repo, branch, token):
-        return {'branch_exists': False, 'has_commits': False, 'head_sha': '', 'error': '404 ref not found'}
+        return {
+            'branch_exists': False,
+            'has_commits': False,
+            'head_sha': '',
+            'error': '404 ref not found',
+        }
 
     checks = []
 
@@ -1355,13 +1375,24 @@ async def test_issue_terminal_normalization_fails_missing_branch_before_check(mo
         calls.append(('notify', task['status'], task.get('error')))
 
     monkeypatch.setattr('a2a_server.database.db_get_task', fake_db_get_task)
-    monkeypatch.setattr('a2a_server.database.db_update_task_status', fake_update)
+    monkeypatch.setattr(
+        'a2a_server.database.db_update_task_status', fake_update
+    )
     monkeypatch.setattr(issue_final_comment, 'issue_task_context', fake_context)
-    monkeypatch.setattr(issue_final_comment, '_verify_branch_and_commits', fake_verify)
-    monkeypatch.setattr('a2a_server.github_app.checks.ensure_task_check_run', fake_check)
-    monkeypatch.setattr('a2a_server.github_app.task_completion.notify_issue_task_completion', fake_notify)
+    monkeypatch.setattr(
+        issue_final_comment, '_verify_branch_and_commits', fake_verify
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.checks.ensure_task_check_run', fake_check
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.task_completion.notify_issue_task_completion',
+        fake_notify,
+    )
 
-    from a2a_server.github_app.task_status_hook import handle_github_app_terminal_task
+    from a2a_server.github_app.task_status_hook import (
+        handle_github_app_terminal_task,
+    )
 
     await handle_github_app_terminal_task('task-code')
 

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -182,7 +182,10 @@ async def test_create_review_task_records_allow_decision_without_builder_target(
     assert task_id == 'task-review-1'
     assert created[0]['metadata']['worker_personality'] == 'reviewer'
     assert 'target_worker_id' not in created[0]['metadata']
-    assert '@codetether please address the requested PR changes' in created[0]['prompt']
+    assert (
+        '@codetether please address the requested PR changes'
+        in created[0]['prompt']
+    )
     assert 'Source issue / Definition of Done' in created[0]['prompt']
     assert 'Issue DoD' in created[0]['prompt']
     assert (

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -182,7 +182,7 @@ async def test_create_review_task_records_allow_decision_without_builder_target(
     assert task_id == 'task-review-1'
     assert created[0]['metadata']['worker_personality'] == 'reviewer'
     assert 'target_worker_id' not in created[0]['metadata']
-    assert 'without mentioning the CodeTether bot' in created[0]['prompt']
+    assert '@codetether please address the requested PR changes' in created[0]['prompt']
     assert 'Source issue / Definition of Done' in created[0]['prompt']
     assert 'Issue DoD' in created[0]['prompt']
     assert (
@@ -328,8 +328,8 @@ async def test_change_request_followup_skips_duplicate_tag(monkeypatch):
     )
 
     assert task_id is None
-    # No @codetether fallback comment was posted (fix follow-up handled it)
-    assert all('@codetether please address' not in c for c in comments)
+    # No fallback comment was posted (fix follow-up handled it)
+    assert comments == []
 
 
 def test_reviewer_approval_ignores_blocked_prose():
@@ -807,10 +807,10 @@ async def test_fix_followup_creates_task_on_changes_requested(
     assert meta['pr_head_sha'] == 'abc123'
     assert 'Reviewer verdict: `CHANGES_REQUESTED`' in comments[0]
     assert 'Protocol-native fix task `task-fix-1`' in comments[0]
-    assert '@codetether' not in comments[0]
+    assert '@codetether please address the requested PR changes' in comments[0]
 
 
-def test_change_request_action_line_tags_only_mention_path():
+def test_change_request_action_line_tags_protocol_and_mention_paths():
     protocol_line = issue_review_task.change_request_action_line(
         'CHANGES_REQUESTED', task_id='task-fix-1'
     )
@@ -818,8 +818,8 @@ def test_change_request_action_line_tags_only_mention_path():
         'CHANGES_REQUESTED'
     )
 
-    assert protocol_line.startswith('Protocol-native fix task')
-    assert '@codetether' not in protocol_line
+    assert protocol_line.startswith('@codetether please address')
+    assert 'Protocol-native fix task `task-fix-1`' in protocol_line
     assert mention_line.startswith('@codetether please address')
     assert '`CHANGES_REQUESTED`' in protocol_line
 

--- a/tests/test_github_app_router.py
+++ b/tests/test_github_app_router.py
@@ -645,7 +645,9 @@ async def test_changes_requested_review_without_mention_creates_fix_task(
     assert context.issue_number == 7
     assert context.pr_number == 7
     assert context.comment_id == 456
-    assert '@codetether' not in context.comment_body
+    assert context.comment_body.startswith(
+        '@codetether please address the requested PR changes.'
+    )
     assert 'Changes requested by reviewer reviewer' in context.comment_body
     assert 'Please add coverage for the new edge case.' in context.comment_body
 


### PR DESCRIPTION
## Summary
- Update GitHub App reviewer instructions so change requests start with @codetether
- Include @codetether in protocol-native fix follow-up comments while relying on self-authored webhook filtering to prevent loops
- Normalize changes-requested review webhook context to include the @codetether action phrase

## Validation
- focused CI-like: python3 -m pytest tests/test_github_app_issue_review_flow.py tests/test_github_app_router.py -q (51 passed)
- static/local: git diff --check