### PR TITLE
fix: require codetether mention in change reviews

### DIFF
--- a/a2a_server/github_app/issue_review_task.py
+++ b/a2a_server/github_app/issue_review_task.py
@@ -979,7 +979,7 @@ End-to-end responsibilities:
 2. Fetch the PR branch and inspect the diff against that Definition of Done, not just generic code quality.
 3. Run the smallest relevant validation for the changed files and every issue checklist item that can be locally checked.
 4. Do not approve your own unsafe or incomplete work. If tests fail, scope drifts, secrets appear, provenance does not match the current head SHA, or any issue DoD item is missing/unproven, request changes with clear remediation.
-5. If anything requires changes, leave a CHANGES_REQUESTED review/comment without mentioning the CodeTether bot; the review completion hook will enqueue the protocol-native fix task.
+5. If anything requires changes, leave a CHANGES_REQUESTED review/comment that includes this exact action line near the top: `@codetether please address the requested PR changes.`
 6. If the PR is safe and feature-complete against the issue DoD, leave an approving review or success comment.
 7. Include this exact provenance footer in any GitHub review/comment you create:{footer}
 

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -182,7 +182,8 @@ async def test_create_review_task_records_allow_decision_without_builder_target(
     assert task_id == 'task-review-1'
     assert created[0]['metadata']['worker_personality'] == 'reviewer'
     assert 'target_worker_id' not in created[0]['metadata']
-    assert 'without mentioning the CodeTether bot' in created[0]['prompt']
+    assert '@codetether please address the requested PR changes.' in created[0]['prompt']
+    assert 'without mentioning the CodeTether bot' not in created[0]['prompt']
     assert 'Source issue / Definition of Done' in created[0]['prompt']
     assert 'Issue DoD' in created[0]['prompt']
     assert (


### PR DESCRIPTION
## Summary\n- Update the GitHub App reviewer prompt so CHANGES_REQUESTED reviews include the exact action line: `@codetether please address the requested PR changes.`\n- Add regression coverage so the prompt no longer allows the previous "without mentioning the CodeTether bot" instruction.\n\n## Validation\n- static/local: `python3 -m pytest tests/test_github_app_issue_review_flow.py::test_create_review_task_records_allow_decision_without_builder_target tests/test_github_app_issue_review_flow.py::test_create_merge_task_requires_explicit_approval -q` → 4 passed\n- static/local: `git diff --check -- a2a_server/github_app/issue_review_task.py tests/test_github_app_issue_review_flow.py` → passed\n\n## Note\nThis fixes the reason reviews were not tagging `@codetether`: the existing reviewer prompt explicitly told the reviewer not to mention the bot.