### PR TITLE
feat: add Rudder GitHub App incident broker

### DIFF
--- a/a2a_server/github_app/__init__.py
+++ b/a2a_server/github_app/__init__.py
@@ -2,5 +2,10 @@
 
 from .credentials import github_git_credentials_router
 from .router import github_webhook_router
+from .rudder_incidents import rudder_incident_router
 
-__all__ = ['github_git_credentials_router', 'github_webhook_router']
+__all__ = [
+    "github_git_credentials_router",
+    "github_webhook_router",
+    "rudder_incident_router",
+]

--- a/a2a_server/github_app/rudder_incidents.py
+++ b/a2a_server/github_app/rudder_incidents.py
@@ -1,0 +1,148 @@
+"""Rudder runtime incident -> GitHub issue broker.
+
+This endpoint lets an in-cluster Rudder controller send sanitized Kubernetes
+runtime incidents to CodeTether. CodeTether owns the GitHub App private key,
+mints a short-lived installation token, and creates or updates GitHub issues.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+from urllib.parse import quote
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from ..worker_auth import verify_auth
+from .auth import github_json, installation_token
+
+rudder_incident_router = APIRouter(
+    prefix="/v1/integrations/rudder",
+    tags=["rudder-incidents"],
+)
+
+
+class RudderIncidentPolicy(BaseModel):
+    auto_create: bool = Field(default=False)
+    update_existing: bool = Field(default=True)
+
+
+class RudderIncidentRequest(BaseModel):
+    repo: str = Field(..., description="GitHub repository in owner/name form")
+    installation_id: int = Field(..., description="GitHub App installation id")
+    fingerprint: str
+    severity: str = Field(default="error")
+    namespace: str
+    release: Optional[str] = None
+    workload: Optional[str] = None
+    pod: Optional[str] = None
+    container: Optional[str] = None
+    reason: Optional[str] = None
+    message: str
+    log_excerpt: Optional[str] = None
+    labels: list[str] = Field(default_factory=list)
+    policy: RudderIncidentPolicy = Field(default_factory=RudderIncidentPolicy)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _issue_title(incident: RudderIncidentRequest) -> str:
+    scope = incident.release or incident.workload or incident.namespace
+    reason = incident.reason or incident.severity
+    return f"[{incident.severity.upper()}] {scope}: {reason}"[:240]
+
+
+def _issue_body(incident: RudderIncidentRequest) -> str:
+    labels = ", ".join(incident.labels) if incident.labels else "none"
+    excerpt = (incident.log_excerpt or incident.message).strip()[:12000]
+    return f"""## Rudder Kubernetes runtime incident
+
+{incident.message}
+
+## Scope
+
+- Namespace: `{incident.namespace}`
+- Release: `{incident.release or 'unknown'}`
+- Workload: `{incident.workload or 'unknown'}`
+- Pod: `{incident.pod or 'unknown'}`
+- Container: `{incident.container or 'unknown'}`
+- Severity: `{incident.severity}`
+- Reason: `{incident.reason or 'unknown'}`
+- Labels: `{labels}`
+- Reported at: `{_now_iso()}`
+
+## Evidence
+
+```text
+{excerpt}
+```
+
+## Dedupe fingerprint
+
+`rudder-log-fingerprint: {incident.fingerprint}`
+
+<!-- rudder-log-fingerprint: {incident.fingerprint} -->
+"""
+
+
+async def _find_existing_issue(repo: str, fingerprint: str, token: str) -> Optional[dict[str, Any]]:
+    query = quote(f'repo:{repo} is:issue is:open "rudder-log-fingerprint: {fingerprint}"')
+    result = await github_json("GET", f"/search/issues?q={query}", token)
+    items = result.get("items") or []
+    return items[0] if items else None
+
+
+@rudder_incident_router.post("/log-incidents")
+async def reconcile_log_incident(request: Request, incident: RudderIncidentRequest) -> dict[str, Any]:
+    """Create or update a GitHub issue for a sanitized Rudder LogIncident.
+
+    Authentication uses the existing worker auth helper. If A2A_AUTH_TOKENS is
+    configured, callers must send Authorization: Bearer <token>. The GitHub
+    write itself uses a short-lived GitHub App installation token.
+    """
+    verify_auth(request)
+
+    token, expires_at = await installation_token(incident.installation_id)
+    existing = await _find_existing_issue(incident.repo, incident.fingerprint, token)
+    body = _issue_body(incident)
+
+    if existing and incident.policy.update_existing:
+        issue_number = int(existing["number"])
+        await github_json(
+            "POST",
+            f"/repos/{incident.repo}/issues/{issue_number}/comments",
+            token,
+            {"body": body[:65000]},
+        )
+        return {
+            "action": "updated_existing_issue",
+            "issue_number": issue_number,
+            "issue_url": existing.get("html_url"),
+            "token_expires_at": expires_at,
+        }
+
+    if not incident.policy.auto_create:
+        return {
+            "action": "drafted",
+            "title": _issue_title(incident),
+            "body": body,
+            "existing_issue_url": existing.get("html_url") if existing else None,
+            "token_expires_at": expires_at,
+        }
+
+    labels = sorted(set(["rudder", "k8s-log-error", *incident.labels]))
+    created = await github_json(
+        "POST",
+        f"/repos/{incident.repo}/issues",
+        token,
+        {"title": _issue_title(incident), "body": body[:65000], "labels": labels},
+    )
+    return {
+        "action": "created_issue",
+        "issue_number": created.get("number"),
+        "issue_url": created.get("html_url"),
+        "token_expires_at": expires_at,
+    }

--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -77,12 +77,14 @@ try:
     from .github_app import (
         github_git_credentials_router,
         github_webhook_router,
+        rudder_incident_router,
     )
 
     GITHUB_APP_ROUTES_AVAILABLE = True
 except ImportError:
     github_git_credentials_router = None
     github_webhook_router = None
+    rudder_incident_router = None
     GITHUB_APP_ROUTES_AVAILABLE = False
 
 # Import OAuth 2.1 provider for MCP protocol compliance
@@ -674,11 +676,13 @@ class A2AServer:
             GITHUB_APP_ROUTES_AVAILABLE
             and github_webhook_router
             and github_git_credentials_router
+            and rudder_incident_router
         ):
             self.app.include_router(github_webhook_router)
             self.app.include_router(github_git_credentials_router)
+            self.app.include_router(rudder_incident_router)
             logger.info(
-                'GitHub App routes mounted at /v1/webhooks/github and /v1/agent/workspaces/*/git/credentials'
+                'GitHub App routes mounted at /v1/webhooks/github, /v1/agent/workspaces/*/git/credentials, and /v1/integrations/rudder/log-incidents'
             )
 
         # Include token billing API routes for per-token usage tracking


### PR DESCRIPTION
## Summary

Adds a CodeTether-side Rudder incident broker endpoint:

```text
POST /v1/integrations/rudder/log-incidents
```

This lets an in-cluster Rudder controller send sanitized Kubernetes runtime incidents to CodeTether. CodeTether keeps ownership of GitHub App private keys, mints short-lived installation tokens, and creates or updates GitHub issues via the existing GitHub App helpers.

## What changed

- Added `a2a_server/github_app/rudder_incidents.py`
  - accepts sanitized incident payloads
  - authenticates with existing worker auth helper
  - mints GitHub App installation tokens
  - searches for existing open issues by Rudder fingerprint
  - comments on existing issues or creates new issues when policy allows
- Exports `rudder_incident_router` from `a2a_server/github_app/__init__.py`
- Mounts the new route in `a2a_server/server.py`

## Validation evidence

- static/local: `python3 -m py_compile a2a_server/github_app/rudder_incidents.py a2a_server/github_app/__init__.py a2a_server/server.py` succeeded on the development host.

## Not yet proven

- not-run: live Argo sync after merge.
- not-run: live endpoint request against `api.codetether.run`.
- not-run: real GitHub App issue/comment creation.

After merge, Argo should pick up `main`; live proof should include the Argo Application revision/sync/health and a real endpoint/GitHub issue result.
