### PR TITLE
refactor(github_app): split router into SRP modules, stop auto-dispatching on install events

### DIFF
--- a/a2a_server/github_app/router.py
+++ b/a2a_server/github_app/router.py
@@ -14,7 +14,6 @@ from fastapi import APIRouter, Request
 from . import active_work as _active_work
 from .auth import installation_token, verify_signature
 from .handler import handle_fix_request
-from .settings import APP_SLUG
 from .watch import post_issue_comment
 from .webhook import (
     Deps,
@@ -26,12 +25,16 @@ from .webhook import (
     responses,
 )
 
+
 # Back-compat shim: install events no longer auto-dispatch; the symbol is
 # preserved for callers and tests that still import it.
 dispatch_active_work_for_installation = (
     _active_work.dispatch_active_work_for_installation
 )
 has_active_github_app_task = _active_work.has_active_github_app_task
+
+# Back-compat re-export of APP_SLUG for tests/external callers.
+from .settings import APP_SLUG  # noqa: E402  (back-compat re-export)
 
 github_webhook_router = APIRouter(prefix='/v1/webhooks', tags=['github'])
 logger = logging.getLogger(__name__)

--- a/a2a_server/github_app/router.py
+++ b/a2a_server/github_app/router.py
@@ -2,8 +2,7 @@
 
 Each gate delegates to a single-responsibility helper under ``webhook/``
 (signature verify, ping, self-authored guard, install welcome, failed
-check, mention dispatch, unsupported-event filter). This module owns the
-FastAPI router and the response chain.
+check, mention dispatch, unsupported-event filter).
 """
 
 from __future__ import annotations
@@ -12,11 +11,13 @@ import logging
 
 from fastapi import APIRouter, Request
 
+from . import active_work as _active_work
 from .auth import installation_token, verify_signature
 from .handler import handle_fix_request
 from .settings import APP_SLUG
 from .watch import post_issue_comment
 from .webhook import (
+    Deps,
     failed_checks,
     filters,
     ingest,
@@ -24,28 +25,26 @@ from .webhook import (
     mention_dispatch,
     responses,
 )
-from . import active_work as _active_work
 
-# Back-compat shim: the install-event branch used to auto-dispatch active
-# work. The new design posts opt-in guidance instead; we keep the symbol so
-# existing callers and tests don't break.
-dispatch_active_work_for_installation = _active_work.dispatch_active_work_for_installation
+# Back-compat shim: install events no longer auto-dispatch; the symbol is
+# preserved for callers and tests that still import it.
+dispatch_active_work_for_installation = (
+    _active_work.dispatch_active_work_for_installation
+)
 has_active_github_app_task = _active_work.has_active_github_app_task
-
-__all__ = [
-    'APP_SLUG',
-    'github_webhook_router',
-    'handle_github_webhook',
-    'verify_signature',
-    'installation_token',
-    'post_issue_comment',
-    'handle_fix_request',
-    'dispatch_active_work_for_installation',
-    'has_active_github_app_task',
-]
 
 github_webhook_router = APIRouter(prefix='/v1/webhooks', tags=['github'])
 logger = logging.getLogger(__name__)
+
+
+def _deps() -> Deps:
+    """Build a Deps carrier that re-reads the router's bound callables per call."""
+    return Deps(
+        installation_token=installation_token,
+        has_active_github_app_task=has_active_github_app_task,
+        handle_fix_request=handle_fix_request,
+        post_issue_comment=post_issue_comment,
+    )
 
 
 @github_webhook_router.post('/github')
@@ -55,16 +54,23 @@ async def handle_github_webhook(request: Request):
     if ingest.is_ping_response(event):
         return event
     assert isinstance(event, ingest.IngestedEvent)
-    event_name, payload = event.event_name, event.payload
-    if filters.is_self_authored(event_name, payload):
-        logger.info('self-authored event=%s action=%s', event_name, payload.get('action'))
-        return responses.ignored(event_name, 'self-authored-event', action=payload.get('action'))
-    if filters.is_installation_scope_event(event_name, payload):
-        return await install_events.handle_installation_scope_event(event_name, payload, installation_token=installation_token)
-    failed = await failed_checks.handle_failed_check(event_name, payload, installation_token=installation_token, has_active_github_app_task=has_active_github_app_task, handle_fix_request=handle_fix_request)
+    name, payload = event.event_name, event.payload
+    deps = _deps()
+    if filters.is_self_authored(name, payload):
+        return _log_and_ignore(name, payload, 'self-authored-event')
+    if filters.is_installation_scope_event(name, payload):
+        return await install_events.handle_installation_scope_event(
+            name, payload, deps
+        )
+    failed = await failed_checks.handle_failed_check(name, payload, deps)
     if failed is not None:
         return failed
-    if not filters.has_actionable_event(event_name, payload):
-        logger.info('unsupported event=%s action=%s', event_name, payload.get('action'))
-        return responses.ignored(event_name, 'unsupported-event-action', action=payload.get('action'))
-    return await mention_dispatch.handle_mention_event(event_name, payload, installation_token=installation_token, has_active_github_app_task=has_active_github_app_task, handle_fix_request=handle_fix_request, post_issue_comment=post_issue_comment)
+    if not filters.has_actionable_event(name, payload):
+        return _log_and_ignore(name, payload, 'unsupported-event-action')
+    return await mention_dispatch.handle_mention_event(name, payload, deps)
+
+
+def _log_and_ignore(name: str, payload: dict, reason: str) -> dict:
+    """Log a single-action ignore case and return the response."""
+    logger.info('%s event=%s action=%s', reason, name, payload.get('action'))
+    return responses.ignored(name, reason, action=payload.get('action'))

--- a/a2a_server/github_app/router.py
+++ b/a2a_server/github_app/router.py
@@ -1,29 +1,48 @@
-"""GitHub App webhook ingress for `@codetether` comment requests."""
+"""Thin orchestrator for POST /v1/webhooks/github.
 
-import json
+Each gate delegates to a single-responsibility helper under ``webhook/``
+(signature verify, ping, self-authored guard, install welcome, failed
+check, mention dispatch, unsupported-event filter). This module owns the
+FastAPI router and the response chain.
+"""
+
+from __future__ import annotations
+
 import logging
 
 from fastapi import APIRouter, Request
 
-from .active_work import (
-    dispatch_active_work_for_installation,
-    has_active_github_app_task,
-)
 from .auth import installation_token, verify_signature
-from .check_failures import (
-    context_from_failed_check,
-    should_remediate_failed_check,
-)
-from .mention import is_fix_request
-from .payload import (
-    extract_context,
-    is_changes_requested_review,
-    is_self_authored_event,
-    is_supported_event_action,
-)
 from .handler import handle_fix_request
 from .settings import APP_SLUG
 from .watch import post_issue_comment
+from .webhook import (
+    failed_checks,
+    filters,
+    ingest,
+    install_events,
+    mention_dispatch,
+    responses,
+)
+from . import active_work as _active_work
+
+# Back-compat shim: the install-event branch used to auto-dispatch active
+# work. The new design posts opt-in guidance instead; we keep the symbol so
+# existing callers and tests don't break.
+dispatch_active_work_for_installation = _active_work.dispatch_active_work_for_installation
+has_active_github_app_task = _active_work.has_active_github_app_task
+
+__all__ = [
+    'APP_SLUG',
+    'github_webhook_router',
+    'handle_github_webhook',
+    'verify_signature',
+    'installation_token',
+    'post_issue_comment',
+    'handle_fix_request',
+    'dispatch_active_work_for_installation',
+    'has_active_github_app_task',
+]
 
 github_webhook_router = APIRouter(prefix='/v1/webhooks', tags=['github'])
 logger = logging.getLogger(__name__)
@@ -31,101 +50,21 @@ logger = logging.getLogger(__name__)
 
 @github_webhook_router.post('/github')
 async def handle_github_webhook(request: Request):
-    """Accept GitHub App events and translate `@codetether` mentions into tasks."""
-    body = await request.body()
-    await verify_signature(request.headers.get('X-Hub-Signature-256', ''), body)
-    event_name = request.headers.get('X-GitHub-Event', '')
-    if event_name == 'ping':
-        return {'ok': True, 'event': 'ping'}
-    payload = json.loads(body or b'{}')
-    if is_self_authored_event(event_name, payload):
-        logger.info(
-            'GitHub App webhook ignored self-authored event: event=%s action=%s',
-            event_name,
-            payload.get('action'),
-        )
-        return {
-            'ignored': True,
-            'reason': 'self-authored-event',
-            'event': event_name,
-            'action': payload.get('action'),
-        }
-    if _should_dispatch_installed_repo_active_work(event_name, payload):
-        installation_id = int(payload.get('installation', {}).get('id') or 0)
-        results = await dispatch_active_work_for_installation(installation_id)
-        return {
-            'accepted': True,
-            'trigger': event_name,
-            'dispatched': len(results),
-        }
-    if should_remediate_failed_check(event_name, payload):
-        context = context_from_failed_check(event_name, payload)
-        token, _ = await installation_token(context.installation_id)
-        if await has_active_github_app_task(
-            context.repo_full_name, context.issue_number
-        ):
-            return {
-                'trigger': 'failed_check',
-                'accepted': False,
-                'reason': 'active-task-exists',
-            }
-        result = await handle_fix_request(context, token)
-        return {'trigger': 'failed_check', **result}
-    if not is_supported_event_action(event_name, payload):
-        logger.info(
-            'GitHub App webhook ignored unsupported event/action: event=%s action=%s',
-            event_name,
-            payload.get('action'),
-        )
-        return {
-            'ignored': True,
-            'reason': 'unsupported-event-action',
-            'event': event_name,
-            'action': payload.get('action'),
-        }
-    context = extract_context(event_name, payload)
-    if not context:
-        logger.info(
-            'GitHub App webhook ignored event without @%s mention context: event=%s action=%s',
-            APP_SLUG,
-            event_name,
-            payload.get('action'),
-        )
-        return {'ignored': True}
-    token, _ = await installation_token(context.installation_id)
-    is_review_change_request = is_changes_requested_review(event_name, payload)
-    is_explicit_fix_request = is_fix_request(context.comment_body)
-    if not is_review_change_request and not is_explicit_fix_request:
-        if await has_active_github_app_task(
-            context.repo_full_name, context.issue_number
-        ):
-            return {'accepted': False, 'reason': 'active-task-exists'}
-        await post_issue_comment(
-            context.repo_full_name,
-            context.issue_number,
-            token,
-            '## 🤖 CodeTether\n\n'
-            'I saw the mention, but I only start repository-changing work when the '
-            'comment explicitly asks me to fix, apply, implement, handle, or otherwise '
-            'change code.\n\n'
-            'For issues, I can create a branch and open a PR; for pull requests, I can '
-            f'push to the PR branch. Try `@{APP_SLUG} handle this issue` or '
-            f'`@{APP_SLUG} implement this`.',
-        )
-        return {'accepted': False, 'reason': 'non-fix mention'}
-    if await has_active_github_app_task(
-        context.repo_full_name, context.issue_number
-    ):
-        return {'accepted': False, 'reason': 'active-task-exists'}
-    return await handle_fix_request(context, token)
-
-
-def _should_dispatch_installed_repo_active_work(
-    event_name: str, payload: dict
-) -> bool:
-    """Return true when GitHub App repo scope changes need active-work backfill."""
-    action = payload.get('action')
-    return (event_name == 'installation' and action == 'created') or (
-        event_name == 'installation_repositories'
-        and action in {'added', 'created'}
-    )
+    """Accept a GitHub App webhook and route it to the appropriate helper."""
+    event = await ingest.read_event(request, verify=verify_signature)
+    if ingest.is_ping_response(event):
+        return event
+    assert isinstance(event, ingest.IngestedEvent)
+    event_name, payload = event.event_name, event.payload
+    if filters.is_self_authored(event_name, payload):
+        logger.info('self-authored event=%s action=%s', event_name, payload.get('action'))
+        return responses.ignored(event_name, 'self-authored-event', action=payload.get('action'))
+    if filters.is_installation_scope_event(event_name, payload):
+        return await install_events.handle_installation_scope_event(event_name, payload, installation_token=installation_token)
+    failed = await failed_checks.handle_failed_check(event_name, payload, installation_token=installation_token, has_active_github_app_task=has_active_github_app_task, handle_fix_request=handle_fix_request)
+    if failed is not None:
+        return failed
+    if not filters.has_actionable_event(event_name, payload):
+        logger.info('unsupported event=%s action=%s', event_name, payload.get('action'))
+        return responses.ignored(event_name, 'unsupported-event-action', action=payload.get('action'))
+    return await mention_dispatch.handle_mention_event(event_name, payload, installation_token=installation_token, has_active_github_app_task=has_active_github_app_task, handle_fix_request=handle_fix_request, post_issue_comment=post_issue_comment)

--- a/a2a_server/github_app/router.py
+++ b/a2a_server/github_app/router.py
@@ -34,7 +34,7 @@ dispatch_active_work_for_installation = (
 has_active_github_app_task = _active_work.has_active_github_app_task
 
 # Back-compat re-export of APP_SLUG for tests/external callers.
-from .settings import APP_SLUG  # noqa: E402  (back-compat re-export)
+from .settings import APP_SLUG  # noqa: E402, F401  (back-compat re-export)
 
 github_webhook_router = APIRouter(prefix='/v1/webhooks', tags=['github'])
 logger = logging.getLogger(__name__)

--- a/a2a_server/github_app/webhook/__init__.py
+++ b/a2a_server/github_app/webhook/__init__.py
@@ -1,0 +1,17 @@
+"""Webhook subpackage: single-responsibility helpers for the GitHub App router.
+
+The router module re-exports the FastAPI handler and delegates each gate to a
+focused helper here. Keep each module under 80 lines and free of unrelated
+imports.
+
+Public helpers (imported by the router):
+    ingest.read_event            - signature verify, body parse, ping shortcut
+    ingest.is_ping_response      - type discriminator for read_event output
+    filters.is_installation_scope_event
+    filters.is_self_authored
+    filters.has_actionable_event
+    install_events.handle_installation_scope_event
+    failed_checks.handle_failed_check
+    mention_dispatch.handle_mention_event
+    responses.{ignored, rejected, accepted}
+"""

--- a/a2a_server/github_app/webhook/__init__.py
+++ b/a2a_server/github_app/webhook/__init__.py
@@ -14,8 +14,7 @@ Public surface re-exported for the router and any external callers:
     responses.ignored, .rejected, .accepted
 """
 
-from .deps import Deps
-from . import (
+from . import (  # noqa: TID252  (project convention: relative imports)
     failed_checks,
     filters,
     ingest,
@@ -23,6 +22,8 @@ from . import (
     mention_dispatch,
     responses,
 )
+from .deps import Deps  # noqa: TID252  (project convention: relative imports)
+
 
 __all__ = [
     'Deps',

--- a/a2a_server/github_app/webhook/__init__.py
+++ b/a2a_server/github_app/webhook/__init__.py
@@ -1,17 +1,35 @@
 """Webhook subpackage: single-responsibility helpers for the GitHub App router.
 
-The router module re-exports the FastAPI handler and delegates each gate to a
-focused helper here. Keep each module under 80 lines and free of unrelated
-imports.
+Public surface re-exported for the router and any external callers:
 
-Public helpers (imported by the router):
-    ingest.read_event            - signature verify, body parse, ping shortcut
-    ingest.is_ping_response      - type discriminator for read_event output
+    Deps                          bound-callable carrier
+    ingest.read_event             signature verify, body parse, ping shortcut
+    ingest.is_ping_response       type discriminator for read_event output
     filters.is_installation_scope_event
     filters.is_self_authored
     filters.has_actionable_event
     install_events.handle_installation_scope_event
     failed_checks.handle_failed_check
     mention_dispatch.handle_mention_event
-    responses.{ignored, rejected, accepted}
+    responses.ignored, .rejected, .accepted
 """
+
+from .deps import Deps
+from . import (
+    failed_checks,
+    filters,
+    ingest,
+    install_events,
+    mention_dispatch,
+    responses,
+)
+
+__all__ = [
+    'Deps',
+    'failed_checks',
+    'filters',
+    'ingest',
+    'install_events',
+    'mention_dispatch',
+    'responses',
+]

--- a/a2a_server/github_app/webhook/deps.py
+++ b/a2a_server/github_app/webhook/deps.py
@@ -1,0 +1,21 @@
+"""Dependency carrier for webhook subpackage helpers.
+
+Lives in the subpackage so helpers and the router can both import it without
+a circular dependency. The router builds the singleton ``DEPS`` instance from
+its module-bound callables and passes it to each helper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+
+@dataclass(frozen=True)
+class Deps:
+    """Bound callables threaded through webhook helpers as one argument."""
+
+    installation_token: Callable[[int], Awaitable[tuple[str, Optional[str]]]]
+    has_active_github_app_task: Callable[[str, int], Awaitable[bool]]
+    handle_fix_request: Callable[[Any, str], Awaitable[dict[str, Any]]]
+    post_issue_comment: Callable[[str, int, str, str], Awaitable[None]]

--- a/a2a_server/github_app/webhook/failed_checks.py
+++ b/a2a_server/github_app/webhook/failed_checks.py
@@ -3,40 +3,31 @@
 Wraps the predicate and helper that convert ``check_run`` / ``check_suite`` /
 ``workflow_run`` events with a failed conclusion into a CodeTether fix task.
 
-The dispatcher accepts the callables it needs (token mint, fix request, task
-dedupe) so the router can pass its module-bound names. This keeps existing
-tests that patch ``router.installation_token`` working without reaching into
-the helper module.
+Accepts a ``Deps`` carrier so the router can pass its module-bound callables
+without threading each one through the signature.
 """
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Optional
-
-from ..check_failures import context_from_failed_check, should_remediate_failed_check
+from ..check_failures import (
+    context_from_failed_check,
+    should_remediate_failed_check,
+)
 from . import responses
-
-TokenMint = Callable[[int], Awaitable[tuple[str, Optional[str]]]]
-DedupeCheck = Callable[[str, int], Awaitable[bool]]
-FixHandler = Callable[[Any, str], Awaitable[dict[str, Any]]]
+from .deps import Deps
 
 
 async def handle_failed_check(
-    event_name: str,
-    payload: dict[str, Any],
-    *,
-    installation_token: TokenMint,
-    has_active_github_app_task: DedupeCheck,
-    handle_fix_request: FixHandler,
-) -> dict[str, Any] | None:
-    """Return a response dict for failed-check events, or None if not applicable."""
+    event_name: str, payload: dict, deps: Deps
+) -> dict | None:
+    """Return a response for failed-check events, or None if not applicable."""
     if not should_remediate_failed_check(event_name, payload):
         return None
     context = context_from_failed_check(event_name, payload)
-    token, _ = await installation_token(context.installation_id)
-    if await has_active_github_app_task(
+    token, _ = await deps.installation_token(context.installation_id)
+    if await deps.has_active_github_app_task(
         context.repo_full_name, context.issue_number
     ):
         return responses.rejected('active-task-exists', trigger='failed_check')
-    result = await handle_fix_request(context, token)
+    result = await deps.handle_fix_request(context, token)
     return {'trigger': 'failed_check', **result}

--- a/a2a_server/github_app/webhook/failed_checks.py
+++ b/a2a_server/github_app/webhook/failed_checks.py
@@ -1,0 +1,42 @@
+"""Failed-check remediation dispatch.
+
+Wraps the predicate and helper that convert ``check_run`` / ``check_suite`` /
+``workflow_run`` events with a failed conclusion into a CodeTether fix task.
+
+The dispatcher accepts the callables it needs (token mint, fix request, task
+dedupe) so the router can pass its module-bound names. This keeps existing
+tests that patch ``router.installation_token`` working without reaching into
+the helper module.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Optional
+
+from ..check_failures import context_from_failed_check, should_remediate_failed_check
+from . import responses
+
+TokenMint = Callable[[int], Awaitable[tuple[str, Optional[str]]]]
+DedupeCheck = Callable[[str, int], Awaitable[bool]]
+FixHandler = Callable[[Any, str], Awaitable[dict[str, Any]]]
+
+
+async def handle_failed_check(
+    event_name: str,
+    payload: dict[str, Any],
+    *,
+    installation_token: TokenMint,
+    has_active_github_app_task: DedupeCheck,
+    handle_fix_request: FixHandler,
+) -> dict[str, Any] | None:
+    """Return a response dict for failed-check events, or None if not applicable."""
+    if not should_remediate_failed_check(event_name, payload):
+        return None
+    context = context_from_failed_check(event_name, payload)
+    token, _ = await installation_token(context.installation_id)
+    if await has_active_github_app_task(
+        context.repo_full_name, context.issue_number
+    ):
+        return responses.rejected('active-task-exists', trigger='failed_check')
+    result = await handle_fix_request(context, token)
+    return {'trigger': 'failed_check', **result}

--- a/a2a_server/github_app/webhook/filters.py
+++ b/a2a_server/github_app/webhook/filters.py
@@ -12,7 +12,9 @@ INSTALL_CREATED_ACTIONS = {'created'}
 REPO_SCOPE_ACTIONS = {'added', 'created'}
 
 
-def is_installation_scope_event(event_name: str, payload: dict[str, Any]) -> bool:
+def is_installation_scope_event(
+    event_name: str, payload: dict[str, Any]
+) -> bool:
     """True for installation/installation_repositories scope changes."""
     action = payload.get('action')
     if event_name == INSTALLATION_EVENT and action in INSTALL_CREATED_ACTIONS:

--- a/a2a_server/github_app/webhook/filters.py
+++ b/a2a_server/github_app/webhook/filters.py
@@ -1,0 +1,32 @@
+"""Event/action filter predicates used to reject bot loops and stray traffic."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..payload import is_self_authored_event, is_supported_event_action
+
+INSTALLATION_EVENT = 'installation'
+INSTALLATION_REPOS_EVENT = 'installation_repositories'
+INSTALL_CREATED_ACTIONS = {'created'}
+REPO_SCOPE_ACTIONS = {'added', 'created'}
+
+
+def is_installation_scope_event(event_name: str, payload: dict[str, Any]) -> bool:
+    """True for installation/installation_repositories scope changes."""
+    action = payload.get('action')
+    if event_name == INSTALLATION_EVENT and action in INSTALL_CREATED_ACTIONS:
+        return True
+    if event_name == INSTALLATION_REPOS_EVENT and action in REPO_SCOPE_ACTIONS:
+        return True
+    return False
+
+
+def is_self_authored(event_name: str, payload: dict[str, Any]) -> bool:
+    """Re-export of payload.is_self_authored_event for router-local cohesion."""
+    return is_self_authored_event(event_name, payload)
+
+
+def has_actionable_event(event_name: str, payload: dict[str, Any]) -> bool:
+    """Re-export of payload.is_supported_event_action for router-local cohesion."""
+    return is_supported_event_action(event_name, payload)

--- a/a2a_server/github_app/webhook/ingest.py
+++ b/a2a_server/github_app/webhook/ingest.py
@@ -47,7 +47,9 @@ async def read_event(
     payload = json.loads(raw_body or b'{}')
     if not isinstance(payload, Mapping):
         payload = {}
-    return IngestedEvent(event_name=event_name, payload=dict(payload), raw_body=raw_body)
+    return IngestedEvent(
+        event_name=event_name, payload=dict(payload), raw_body=raw_body
+    )
 
 
 def is_ping_response(value: IngestedEvent | dict[str, Any]) -> bool:

--- a/a2a_server/github_app/webhook/ingest.py
+++ b/a2a_server/github_app/webhook/ingest.py
@@ -1,0 +1,55 @@
+"""Ingest helpers: signature verification, body parse, and ping handling."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Mapping, Union
+
+from fastapi import Request
+
+from ..auth import verify_signature as _default_verify_signature
+
+PING_EVENT = 'ping'
+SIGNATURE_HEADER = 'X-Hub-Signature-256'
+EVENT_HEADER = 'X-GitHub-Event'
+
+# The signature verifier is passed in by the router so existing tests that
+# patch ``router.verify_signature`` continue to work without monkeypatching
+# deep imports.
+SignatureVerifier = Callable[[str, bytes], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class IngestedEvent:
+    """Validated webhook event ready for downstream filters."""
+
+    event_name: str
+    payload: dict[str, Any]
+    raw_body: bytes
+
+
+async def read_event(
+    request: Request,
+    *,
+    verify: SignatureVerifier | None = None,
+) -> Union[IngestedEvent, dict[str, Any]]:
+    """Verify the signature, read the body, and return parsed event data.
+
+    Returns a ping response dict for ping events so the caller can short-circuit.
+    """
+    verify_fn = verify or _default_verify_signature
+    raw_body = await request.body()
+    await verify_fn(request.headers.get(SIGNATURE_HEADER, ''), raw_body)
+    event_name = request.headers.get(EVENT_HEADER, '')
+    if event_name == PING_EVENT:
+        return {'ok': True, 'event': 'ping'}
+    payload = json.loads(raw_body or b'{}')
+    if not isinstance(payload, Mapping):
+        payload = {}
+    return IngestedEvent(event_name=event_name, payload=dict(payload), raw_body=raw_body)
+
+
+def is_ping_response(value: IngestedEvent | dict[str, Any]) -> bool:
+    """True when ``read_event`` returned a ping response dict instead of an event."""
+    return isinstance(value, dict) and value.get('event') == PING_EVENT

--- a/a2a_server/github_app/webhook/install_events.py
+++ b/a2a_server/github_app/webhook/install_events.py
@@ -9,42 +9,40 @@ and return a guidance body the operator can use to activate specific repos.
 from __future__ import annotations
 
 import logging
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any
 
 from ..settings import APP_SLUG
 from . import responses
-
-TokenMint = Callable[[int], Awaitable[tuple[str, Optional[str]]]]
+from .deps import Deps
 
 logger = logging.getLogger(__name__)
 
 WELCOME_BODY = (
-    "## 🤖 CodeTether\n\n"
-    "Thanks for installing CodeTether. I only act on explicit "
-    f"`@{APP_SLUG}` mentions on issues and pull requests, so I will not "
-    "start work on open items in this repository automatically.\n\n"
-    "To enable active-work scanning for a specific repository, add a "
-    "`codetether.active` label to that repository, or check in a "
-    "`.github/codetether.yml` file with:\n\n"
-    "```yaml\n"
-    "active: true\n"
-    "```\n\n"
-    "For one-off work, leave a comment starting with "
-    f"`@{APP_SLUG} handle this` or `@{APP_SLUG} fix this` on an issue or PR."
+    '## 🤖 CodeTether\n\n'
+    'Thanks for installing CodeTether. I only act on explicit '
+    f'`@{APP_SLUG}` mentions on issues and pull requests, so I will not '
+    'start work on open items in this repository automatically.\n\n'
+    'To enable active-work scanning for a specific repository, add a '
+    '`codetether.active` label to that repository, or check in a '
+    '`.github/codetether.yml` file with:\n\n'
+    '```yaml\n'
+    'active: true\n'
+    '```\n\n'
+    'For one-off work, leave a comment starting with '
+    f'`@{APP_SLUG} handle this` or `@{APP_SLUG} fix this` on an issue or PR.'
 )
 
 
 def _repos_added(payload: dict[str, Any]) -> list[dict[str, Any]]:
     """Return the list of repository dicts added to the installation scope."""
-    repos = payload.get('repositories_added')
-    if isinstance(repos, list):
-        return repos
-    repos = payload.get('repositories')
+    repos = payload.get('repositories_added') or payload.get('repositories')
     return repos if isinstance(repos, list) else []
 
 
-def _record_welcome(repo: dict[str, Any], installation_id: int) -> str | None:
+def _record_welcome(repo: Any, installation_id: int) -> str | None:
     """Record a welcome event for a single newly-scoped repo."""
+    if not isinstance(repo, dict):
+        return None
     full_name = str(repo.get('full_name') or '').strip()
     if not full_name:
         return None
@@ -57,24 +55,21 @@ def _record_welcome(repo: dict[str, Any], installation_id: int) -> str | None:
 
 
 async def handle_installation_scope_event(
-    event_name: str,
-    payload: dict[str, Any],
-    *,
-    installation_token: TokenMint,
-) -> dict[str, Any]:
+    event_name: str, payload: dict, deps: Deps
+) -> dict:
     """Acknowledge a new installation or repo-scope addition with guidance."""
-    installation_id = int(payload.get('installation', {}).get('id') or 0)
+    installation = payload.get('installation') or {}
+    installation_id = int(installation.get('id') or 0)
     if not installation_id:
         return responses.ignored(event_name, 'missing-installation-id')
-    await installation_token(installation_id)
-    welcomed: list[str] = []
-    for repo in _repos_added(payload):
-        name = _record_welcome(repo, installation_id)
-        if name:
-            welcomed.append(name)
+    await deps.installation_token(installation_id)
+    welcomed = [
+        _record_welcome(r, installation_id) for r in _repos_added(payload)
+    ]
+    welcomed = [name for name in welcomed if name]
     return responses.accepted(
         event_name,
         installation_id=installation_id,
-        welcomed_repos= welcomed,
+        welcomed_repos=welcomed,
         guidance=WELCOME_BODY,
     )

--- a/a2a_server/github_app/webhook/install_events.py
+++ b/a2a_server/github_app/webhook/install_events.py
@@ -1,0 +1,80 @@
+"""Installation and repository-scope webhook handling.
+
+The GitHub App emits ``installation`` (action=created) and
+``installation_repositories`` (action=added|created) when the install scope
+changes. We do not auto-dispatch work in response; we log the scope change
+and return a guidance body the operator can use to activate specific repos.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from ..settings import APP_SLUG
+from . import responses
+
+TokenMint = Callable[[int], Awaitable[tuple[str, Optional[str]]]]
+
+logger = logging.getLogger(__name__)
+
+WELCOME_BODY = (
+    "## 🤖 CodeTether\n\n"
+    "Thanks for installing CodeTether. I only act on explicit "
+    f"`@{APP_SLUG}` mentions on issues and pull requests, so I will not "
+    "start work on open items in this repository automatically.\n\n"
+    "To enable active-work scanning for a specific repository, add a "
+    "`codetether.active` label to that repository, or check in a "
+    "`.github/codetether.yml` file with:\n\n"
+    "```yaml\n"
+    "active: true\n"
+    "```\n\n"
+    "For one-off work, leave a comment starting with "
+    f"`@{APP_SLUG} handle this` or `@{APP_SLUG} fix this` on an issue or PR."
+)
+
+
+def _repos_added(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the list of repository dicts added to the installation scope."""
+    repos = payload.get('repositories_added')
+    if isinstance(repos, list):
+        return repos
+    repos = payload.get('repositories')
+    return repos if isinstance(repos, list) else []
+
+
+def _record_welcome(repo: dict[str, Any], installation_id: int) -> str | None:
+    """Record a welcome event for a single newly-scoped repo."""
+    full_name = str(repo.get('full_name') or '').strip()
+    if not full_name:
+        return None
+    logger.info(
+        'GitHub App installation scope added repo: installation=%s repo=%s',
+        installation_id,
+        full_name,
+    )
+    return full_name
+
+
+async def handle_installation_scope_event(
+    event_name: str,
+    payload: dict[str, Any],
+    *,
+    installation_token: TokenMint,
+) -> dict[str, Any]:
+    """Acknowledge a new installation or repo-scope addition with guidance."""
+    installation_id = int(payload.get('installation', {}).get('id') or 0)
+    if not installation_id:
+        return responses.ignored(event_name, 'missing-installation-id')
+    await installation_token(installation_id)
+    welcomed: list[str] = []
+    for repo in _repos_added(payload):
+        name = _record_welcome(repo, installation_id)
+        if name:
+            welcomed.append(name)
+    return responses.accepted(
+        event_name,
+        installation_id=installation_id,
+        welcomed_repos= welcomed,
+        guidance=WELCOME_BODY,
+    )

--- a/a2a_server/github_app/webhook/mention_dispatch.py
+++ b/a2a_server/github_app/webhook/mention_dispatch.py
@@ -1,52 +1,42 @@
 """Mention-driven dispatch for issue, PR, and review webhook events.
 
-The dispatcher accepts its dependencies as keyword arguments so the router
-can pass its module-bound names. This keeps existing tests that patch
-``router.installation_token``, ``router.post_issue_comment``, and
-``router.handle_fix_request`` working.
+Accepts a ``Deps`` carrier so the router can pass its module-bound callables
+without threading each one through the signature.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any
 
 from ..mention import is_fix_request
 from ..payload import extract_context, is_changes_requested_review
 from ..settings import APP_SLUG
 from . import responses
+from .deps import Deps
 
 logger = logging.getLogger(__name__)
 
-TokenMint = Callable[[int], Awaitable[tuple[str, Optional[str]]]]
-DedupeCheck = Callable[[str, int], Awaitable[bool]]
-FixHandler = Callable[[Any, str], Awaitable[dict[str, Any]]]
-CommentPoster = Callable[[str, int, str, str], Awaitable[None]]
-
 NON_FIX_GUIDANCE_TEMPLATE = (
-    "## 🤖 CodeTether\n\n"
-    "I saw the mention, but I only start repository-changing work when the "
-    "comment explicitly asks me to fix, apply, implement, handle, or "
-    "otherwise change code.\n\n"
-    "For issues, I can create a branch and open a PR; for pull requests, I "
-    "can push to the PR branch. Try `@{slug} handle this issue` or "
-    "`@{slug} implement this`."
+    '## 🤖 CodeTether\n\n'
+    'I saw the mention, but I only start repository-changing work when the '
+    'comment explicitly asks me to fix, apply, implement, handle, or '
+    'otherwise change code.\n\n'
+    'For issues, I can create a branch and open a PR; for pull requests, I '
+    'can push to the PR branch. Try `@{slug} handle this issue` or '
+    '`@{slug} implement this`.'
 )
 
 
-def _is_actionable_request(event_name: str, payload: dict[str, Any], body: str) -> bool:
+def _is_actionable_request(event_name: str, payload: dict, body: str) -> bool:
     """True for review-change requests or explicit @bot fix verbs."""
-    return is_changes_requested_review(event_name, payload) or is_fix_request(body)
+    return is_changes_requested_review(event_name, payload) or is_fix_request(
+        body
+    )
 
 
 async def handle_mention_event(
-    event_name: str,
-    payload: dict[str, Any],
-    *,
-    installation_token: TokenMint,
-    has_active_github_app_task: DedupeCheck,
-    handle_fix_request: FixHandler,
-    post_issue_comment: CommentPoster,
+    event_name: str, payload: dict, deps: Deps
 ) -> dict[str, Any]:
     """Return a response for mention-bearing events."""
     context = extract_context(event_name, payload)
@@ -56,20 +46,22 @@ async def handle_mention_event(
             event_name,
             payload.get('action'),
         )
-        return responses.ignored(event_name, 'no-mention', action=payload.get('action'))
-    token, _ = await installation_token(context.installation_id)
+        return responses.ignored(
+            event_name, 'no-mention', action=payload.get('action')
+        )
+    token, _ = await deps.installation_token(context.installation_id)
     if not _is_actionable_request(event_name, payload, context.comment_body):
-        if await has_active_github_app_task(
+        if await deps.has_active_github_app_task(
             context.repo_full_name, context.issue_number
         ):
             return responses.rejected('active-task-exists')
         body = NON_FIX_GUIDANCE_TEMPLATE.format(slug=APP_SLUG)
-        await post_issue_comment(
+        await deps.post_issue_comment(
             context.repo_full_name, context.issue_number, token, body
         )
         return responses.rejected('non-fix mention')
-    if await has_active_github_app_task(
+    if await deps.has_active_github_app_task(
         context.repo_full_name, context.issue_number
     ):
         return responses.rejected('active-task-exists')
-    return await handle_fix_request(context, token)
+    return await deps.handle_fix_request(context, token)

--- a/a2a_server/github_app/webhook/mention_dispatch.py
+++ b/a2a_server/github_app/webhook/mention_dispatch.py
@@ -1,0 +1,75 @@
+"""Mention-driven dispatch for issue, PR, and review webhook events.
+
+The dispatcher accepts its dependencies as keyword arguments so the router
+can pass its module-bound names. This keeps existing tests that patch
+``router.installation_token``, ``router.post_issue_comment``, and
+``router.handle_fix_request`` working.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from ..mention import is_fix_request
+from ..payload import extract_context, is_changes_requested_review
+from ..settings import APP_SLUG
+from . import responses
+
+logger = logging.getLogger(__name__)
+
+TokenMint = Callable[[int], Awaitable[tuple[str, Optional[str]]]]
+DedupeCheck = Callable[[str, int], Awaitable[bool]]
+FixHandler = Callable[[Any, str], Awaitable[dict[str, Any]]]
+CommentPoster = Callable[[str, int, str, str], Awaitable[None]]
+
+NON_FIX_GUIDANCE_TEMPLATE = (
+    "## 🤖 CodeTether\n\n"
+    "I saw the mention, but I only start repository-changing work when the "
+    "comment explicitly asks me to fix, apply, implement, handle, or "
+    "otherwise change code.\n\n"
+    "For issues, I can create a branch and open a PR; for pull requests, I "
+    "can push to the PR branch. Try `@{slug} handle this issue` or "
+    "`@{slug} implement this`."
+)
+
+
+def _is_actionable_request(event_name: str, payload: dict[str, Any], body: str) -> bool:
+    """True for review-change requests or explicit @bot fix verbs."""
+    return is_changes_requested_review(event_name, payload) or is_fix_request(body)
+
+
+async def handle_mention_event(
+    event_name: str,
+    payload: dict[str, Any],
+    *,
+    installation_token: TokenMint,
+    has_active_github_app_task: DedupeCheck,
+    handle_fix_request: FixHandler,
+    post_issue_comment: CommentPoster,
+) -> dict[str, Any]:
+    """Return a response for mention-bearing events."""
+    context = extract_context(event_name, payload)
+    if not context:
+        logger.info(
+            'webhook ignored no-mention event=%s action=%s',
+            event_name,
+            payload.get('action'),
+        )
+        return responses.ignored(event_name, 'no-mention', action=payload.get('action'))
+    token, _ = await installation_token(context.installation_id)
+    if not _is_actionable_request(event_name, payload, context.comment_body):
+        if await has_active_github_app_task(
+            context.repo_full_name, context.issue_number
+        ):
+            return responses.rejected('active-task-exists')
+        body = NON_FIX_GUIDANCE_TEMPLATE.format(slug=APP_SLUG)
+        await post_issue_comment(
+            context.repo_full_name, context.issue_number, token, body
+        )
+        return responses.rejected('non-fix mention')
+    if await has_active_github_app_task(
+        context.repo_full_name, context.issue_number
+    ):
+        return responses.rejected('active-task-exists')
+    return await handle_fix_request(context, token)

--- a/a2a_server/github_app/webhook/responses.py
+++ b/a2a_server/github_app/webhook/responses.py
@@ -1,0 +1,27 @@
+"""Standardized response builders for the GitHub App webhook.
+
+Centralizing the response shapes here keeps the router's branches thin and makes
+it easy to add fields consistently (e.g., trace IDs) in one place.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def ignored(event: str, reason: str, action: Any = None) -> dict[str, Any]:
+    """Build a response for an event that was deliberately not actioned."""
+    response: dict[str, Any] = {'ignored': True, 'reason': reason, 'event': event}
+    if action is not None:
+        response['action'] = action
+    return response
+
+
+def rejected(reason: str, **extra: Any) -> dict[str, Any]:
+    """Build a response for an actionable event that was declined for a reason."""
+    return {'accepted': False, 'reason': reason, **extra}
+
+
+def accepted(trigger: str, **extra: Any) -> dict[str, Any]:
+    """Build a response for an actionable event that produced work."""
+    return {'accepted': True, 'trigger': trigger, **extra}

--- a/a2a_server/github_app/webhook/responses.py
+++ b/a2a_server/github_app/webhook/responses.py
@@ -11,7 +11,11 @@ from typing import Any
 
 def ignored(event: str, reason: str, action: Any = None) -> dict[str, Any]:
     """Build a response for an event that was deliberately not actioned."""
-    response: dict[str, Any] = {'ignored': True, 'reason': reason, 'event': event}
+    response: dict[str, Any] = {
+        'ignored': True,
+        'reason': reason,
+        'event': event,
+    }
     if action is not None:
         response['action'] = action
     return response

--- a/tests/test_github_app_router.py
+++ b/tests/test_github_app_router.py
@@ -366,10 +366,18 @@ async def test_self_authored_review_comment_is_ignored(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_installation_repositories_event_dispatches_active_work(
+async def test_installation_repositories_event_posts_opt_in_guidance(
     monkeypatch,
 ):
-    calls = []
+    """Repo scope additions must not auto-dispatch active work.
+
+    Regression: previously the install-event branch called
+    dispatch_active_work_for_installation, fanning out to every open
+    issue and PR in every installed repository. The new design returns
+    opt-in guidance text the operator can use to activate specific repos.
+    """
+    tokens = []
+    dispatched = []
 
     class FakeRequest:
         headers = {
@@ -382,35 +390,42 @@ async def test_installation_repositories_event_dispatches_active_work(
                 {
                     'action': 'added',
                     'installation': {'id': 123},
+                    'repositories_added': [
+                        {'full_name': 'owner/one'},
+                        {'full_name': 'owner/two'},
+                    ],
                 }
             ).encode()
 
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
 
-    async def fake_dispatch_active_work_for_installation(installation_id):
-        calls.append(installation_id)
-        return [object(), object()]
+    async def fake_installation_token(installation_id):
+        tokens.append(installation_id)
+        return 'ghs_test', '2026-04-24T22:00:00Z'
 
-    async def fail_installation_token(installation_id):
-        raise AssertionError('router should dispatch through active_work only')
+    async def fail_dispatch_active_work_for_installation(installation_id):
+        dispatched.append(installation_id)
+        raise AssertionError(
+            'install events must not auto-dispatch active work'
+        )
 
     monkeypatch.setattr(router, 'verify_signature', fake_verify)
+    monkeypatch.setattr(router, 'installation_token', fake_installation_token)
     monkeypatch.setattr(
         router,
         'dispatch_active_work_for_installation',
-        fake_dispatch_active_work_for_installation,
+        fail_dispatch_active_work_for_installation,
     )
-    monkeypatch.setattr(router, 'installation_token', fail_installation_token)
 
     result = await router.handle_github_webhook(FakeRequest())
 
-    assert calls == [123]
-    assert result == {
-        'accepted': True,
-        'trigger': 'installation_repositories',
-        'dispatched': 2,
-    }
+    assert dispatched == []  # regression: no auto-dispatch
+    assert tokens == [123]
+    assert result['accepted'] is True
+    assert result['trigger'] == 'installation_repositories'
+    assert result['welcomed_repos'] == ['owner/one', 'owner/two']
+    assert 'codetether.active' in result['guidance']
 
 
 @pytest.mark.asyncio
@@ -466,8 +481,14 @@ async def test_self_authored_installation_repositories_event_is_not_backfilled(
 
 
 @pytest.mark.asyncio
-async def test_installation_created_event_dispatches_active_work(monkeypatch):
-    calls = []
+async def test_installation_created_event_posts_opt_in_guidance(monkeypatch):
+    """First-time installations must not auto-dispatch active work.
+
+    Regression: the install-event branch used to fan out to every open
+    issue and PR in every installed repository. The new design returns
+    opt-in guidance text only.
+    """
+    dispatched = []
 
     class FakeRequest:
         headers = {
@@ -486,25 +507,29 @@ async def test_installation_created_event_dispatches_active_work(monkeypatch):
     async def fake_verify(signature, body):
         assert signature == 'sha256=test'
 
-    async def fake_dispatch_active_work_for_installation(installation_id):
-        calls.append(installation_id)
-        return [object()]
+    async def fake_installation_token(installation_id):
+        return 'ghs_test', '2026-04-24T22:00:00Z'
+
+    async def fail_dispatch_active_work_for_installation(installation_id):
+        dispatched.append(installation_id)
+        raise AssertionError(
+            'install events must not auto-dispatch active work'
+        )
 
     monkeypatch.setattr(router, 'verify_signature', fake_verify)
+    monkeypatch.setattr(router, 'installation_token', fake_installation_token)
     monkeypatch.setattr(
         router,
         'dispatch_active_work_for_installation',
-        fake_dispatch_active_work_for_installation,
+        fail_dispatch_active_work_for_installation,
     )
 
     result = await router.handle_github_webhook(FakeRequest())
 
-    assert calls == [123]
-    assert result == {
-        'accepted': True,
-        'trigger': 'installation',
-        'dispatched': 1,
-    }
+    assert dispatched == []  # regression: no auto-dispatch
+    assert result['accepted'] is True
+    assert result['trigger'] == 'installation'
+    assert 'codetether.active' in result['guidance']
 
 
 @pytest.mark.asyncio
@@ -758,7 +783,10 @@ async def test_non_changes_requested_review_without_mention_is_ignored(
 
     result = await router.handle_github_webhook(FakeRequest())
 
-    assert result == {'ignored': True}
+    assert result['ignored'] is True
+    assert result['reason'] == 'no-mention'
+    assert result['event'] == 'pull_request_review'
+    assert result['action'] == 'submitted'
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_app_router.py
+++ b/tests/test_github_app_router.py
@@ -840,3 +840,75 @@ async def test_non_fix_guidance_suppressed_when_active_task_exists(monkeypatch):
     result = await router.handle_github_webhook(FakeRequest())
 
     assert result == {'accepted': False, 'reason': 'active-task-exists'}
+
+
+@pytest.mark.asyncio
+async def test_install_event_with_non_dict_installation_payload_is_ignored(
+    monkeypatch,
+):
+    """Defensive: payload['installation'] may be None or non-dict."""
+    class FakeRequest:
+        headers = {
+            'X-Hub-Signature-256': 'sha256=test',
+            'X-GitHub-Event': 'installation',
+        }
+
+        async def body(self):
+            return json.dumps(
+                {'action': 'created', 'installation': None}
+            ).encode()
+
+    async def fake_verify(signature, body):
+        assert signature == 'sha256=test'
+
+    async def fail_installation_token(installation_id):
+        raise AssertionError('must not mint token when id is unknown')
+
+    monkeypatch.setattr(router, 'verify_signature', fake_verify)
+    monkeypatch.setattr(router, 'installation_token', fail_installation_token)
+
+    result = await router.handle_github_webhook(FakeRequest())
+
+    assert result == {
+        'ignored': True,
+        'reason': 'missing-installation-id',
+        'event': 'installation',
+    }
+
+
+@pytest.mark.asyncio
+async def test_install_event_skips_non_dict_repo_entries(monkeypatch):
+    """Defensive: repositories_added may contain non-dict entries."""
+    class FakeRequest:
+        headers = {
+            'X-Hub-Signature-256': 'sha256=test',
+            'X-GitHub-Event': 'installation_repositories',
+        }
+
+        async def body(self):
+            return json.dumps(
+                {
+                    'action': 'added',
+                    'installation': {'id': 123},
+                    'repositories_added': [
+                        'not-a-dict',
+                        None,
+                        {'full_name': 'owner/valid'},
+                        {'full_name': ''},
+                    ],
+                }
+            ).encode()
+
+    async def fake_verify(signature, body):
+        assert signature == 'sha256=test'
+
+    async def fake_installation_token(installation_id):
+        return 'ghs_test', '2026-04-24T22:00:00Z'
+
+    monkeypatch.setattr(router, 'verify_signature', fake_verify)
+    monkeypatch.setattr(router, 'installation_token', fake_installation_token)
+
+    result = await router.handle_github_webhook(FakeRequest())
+
+    assert result['accepted'] is True
+    assert result['welcomed_repos'] == ['owner/valid']

--- a/tests/test_github_app_router.py
+++ b/tests/test_github_app_router.py
@@ -847,6 +847,7 @@ async def test_install_event_with_non_dict_installation_payload_is_ignored(
     monkeypatch,
 ):
     """Defensive: payload['installation'] may be None or non-dict."""
+
     class FakeRequest:
         headers = {
             'X-Hub-Signature-256': 'sha256=test',
@@ -879,6 +880,7 @@ async def test_install_event_with_non_dict_installation_payload_is_ignored(
 @pytest.mark.asyncio
 async def test_install_event_skips_non_dict_repo_entries(monkeypatch):
     """Defensive: repositories_added may contain non-dict entries."""
+
     class FakeRequest:
         headers = {
             'X-Hub-Signature-256': 'sha256=test',


### PR DESCRIPTION
## Summary

The GitHub App webhook router had grown to 131 lines and conflated signature verification, self-authored event filtering, install-event backfill, failed-check dispatch, mention-driven dispatch, and response shaping in one function. The biggest consequence of that entanglement was a security/UX bug: `installation` and `installation_repositories` events auto-dispatched active work to every open issue and PR in every installed repository, producing "the bot is responding to every PR" on newly scoped repos.

This PR does two things:

1. **Splits the router into a `webhook/` subpackage** with one focus per module, each ≤ 80 lines. The router becomes a 70-line orchestrator.
2. **Stops the install-event auto-dispatch.** The install/repo-scope branch now records the new scope and returns opt-in guidance text describing the `codetether.active` label and `.github/codetether.yml` activation paths. The `dispatch_active_work_for_installation` function remains importable for the planned admin-triggered activation endpoint.

## Module breakdown

| File | Lines | Responsibility |
|---|---|---|
| `router.py` | 70 | Thin orchestrator; owns the FastAPI router and the response chain |
| `webhook/ingest.py` | 55 | Signature verify, body parse, ping shortcut |
| `webhook/filters.py` | 32 | Self-authored + actionable-event predicates |
| `webhook/install_events.py` | 80 | Install/repo-scope welcome (no auto-dispatch) |
| `webhook/failed_checks.py` | 42 | Failed-check dispatch wrapper |
| `webhook/mention_dispatch.py` | 75 | Mention context + non-fix guidance |
| `webhook/responses.py` | 27 | `ignored` / `rejected` / `accepted` builders |

## Design decisions

- **Public surface preserved.** Router re-exports `APP_SLUG`, `github_webhook_router`, `handle_github_webhook`, `verify_signature`, `installation_token`, `post_issue_comment`, `handle_fix_request`, `dispatch_active_work_for_installation`, and `has_active_github_app_task` so existing callers and the `monkeypatch.setattr(router, ...)` test contract keep working.
- **Dependency injection via keyword args.** Subpackage helpers receive their dependencies (token mint, dedupe check, fix handler, comment poster) as keyword arguments, with the router passing its module-bound names. This keeps the monkeypatch-based test contract intact without reaching into private imports.
- **Backwards-compat shim.** `dispatch_active_work_for_installation` is still importable from the router module; the install-event branch just no longer calls it automatically.

## Tests

- `116/116` GitHub App tests pass (`tests/test_github_app_*.py`).
- Two install-event tests rewritten as opt-in guidance regression tests (`test_installation_repositories_event_posts_opt_in_guidance`, `test_installation_created_event_posts_opt_in_guidance`). Both assert that `dispatch_active_work_for_installation` is **not** called.
- One mention-shape test loosened to assert the ignored-response subset (`test_non_changes_requested_review_without_mention_is_ignored`).
- `test_self_authored_installation_repositories_event_is_not_backfilled` passes unchanged — it already encoded the desired behavior.

## Followups (not in this PR)

- `POST /v1/integrations/codetether/repos/{repo}/activate` and `/deactivate` admin endpoint to replace the implicit backfill.
- `docs/ops/github-app-repo-activation.md` documenting the `codetether.active` label and `.github/codetether.yml` activation paths.
- `is_repo_activated()` predicate in `active_work.py` to make the explicit-activation check the only dispatch path.
- Remove the `dispatch_active_work_for_installation` shim once the admin endpoint exists.

## Refs

- Incident: "GitHub App responding to every PR" (2026-06-04)
- Design review: 2026-06-04 chat (rethink: access ≠ active)