### PR TITLE
fix(github-app): harden worker routing and review idempotency

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -8,6 +8,7 @@ ACo
 ADK
 AError
 AExecutor
+AGG
 AIP
 APF
 ARequest
@@ -109,6 +110,7 @@ Solax
 TJS
 TMDB
 Tful
+Tik
 Trello
 UIs
 URLTo
@@ -142,6 +144,7 @@ aacacac
 aboutasha
 achat
 aconnect
+adgroup
 adk
 admins
 afet
@@ -149,6 +152,7 @@ affef
 agentcard
 agentic
 agentskill
+agg
 agntcy
 ainvoke
 airbnb
@@ -379,6 +383,7 @@ tbl
 testserver
 textpart
 threadsafe
+tiktok
 toctree
 tok
 toolkits

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@main
+        uses: check-spelling/check-spelling@v0.0.25
         with:
           suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
           checkout: true

--- a/a2a_server/agent_bridge.py
+++ b/a2a_server/agent_bridge.py
@@ -407,6 +407,7 @@ class AgentBridge:
             if task.model_used and 'model_used' not in metadata:
                 metadata['model_used'] = task.model_used
 
+            tenant_id = str(metadata.get('tenant_id') or '').strip() or None
             await db.db_upsert_task(
                 {
                     'id': task.id,
@@ -430,7 +431,9 @@ class AgentBridge:
                     'completed_at': task.completed_at.isoformat()
                     if task.completed_at
                     else None,
-                }
+                    'tenant_id': tenant_id,
+                },
+                tenant_id=tenant_id,
             )
         except Exception as e:
             logger.error(f'Failed to save task to PostgreSQL: {e}')

--- a/a2a_server/agent_bridge.py
+++ b/a2a_server/agent_bridge.py
@@ -1,5 +1,4 @@
-"""
-Agent Bridge - Integrates CodeTether agent with A2A Server
+"""Agent Bridge - Integrates CodeTether agent with A2A Server
 
 This module provides a bridge between the A2A protocol server and the
 CodeTether agent, allowing web UI triggers to start AI agents working
@@ -24,36 +23,47 @@ import logging
 import os
 import subprocess
 import uuid
+
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Callable
+from typing import Any
 
 import aiohttp
 
 # Import PostgreSQL database module
 from . import database as db
+from .knative_events import (
+    KnativeEventError,
+    publish_task_event,
+)
+from .knative_events import (
+    is_enabled as is_knative_events_enabled,
+)
+from .knative_spawner import (
+    KNATIVE_ENABLED as KNATIVE_SPAWNER_ENABLED,
+)
 
 # Import Knative modules for event-driven worker spawning
 from .knative_spawner import (
-    knative_spawner,
     KnativeSpawnerError,
     WorkerStatus,
-    KNATIVE_ENABLED as KNATIVE_SPAWNER_ENABLED,
+    knative_spawner,
 )
-from .knative_events import (
-    publish_task_event,
-    is_enabled as is_knative_events_enabled,
-    KnativeEventError,
-)
+
 
 logger = logging.getLogger(__name__)
 
 # Agent host configuration - allows container to connect to host VM's agent
 # Accepts AGENT_HOST/AGENT_PORT (preferred) or legacy OPENCODE_HOST/OPENCODE_PORT
-AGENT_HOST = os.environ.get('AGENT_HOST', os.environ.get('OPENCODE_HOST', 'localhost'))
-AGENT_DEFAULT_PORT = int(os.environ.get('AGENT_PORT', os.environ.get('OPENCODE_PORT', '9777')))
+AGENT_HOST = os.environ.get(
+    'AGENT_HOST', os.environ.get('OPENCODE_HOST', 'localhost')
+)
+AGENT_DEFAULT_PORT = int(
+    os.environ.get('AGENT_PORT', os.environ.get('OPENCODE_PORT', '9777'))
+)
 
 # Backward-compatible aliases
 # Legacy OPENCODE_HOST removed
@@ -127,17 +137,15 @@ MODEL_SELECTOR_KEYS = list(MODEL_SELECTOR.keys())
 
 
 def is_knative_enabled() -> bool:
-    """
-    Check if Knative worker spawning is enabled.
+    """Check if Knative worker spawning is enabled.
 
     Returns True if both Knative spawning and Knative events are enabled.
     """
     return KNATIVE_SPAWNER_ENABLED and is_knative_events_enabled()
 
 
-def resolve_model(model_input: Optional[str]) -> Optional[str]:
-    """
-    Resolve a user-friendly model name to the full provider/model-id format.
+def resolve_model(model_input: str | None) -> str | None:
+    """Resolve a user-friendly model name to the full provider/model-id format.
 
     Args:
         model_input: User input like 'minimax', 'claude-sonnet', or full 'provider/model-id'
@@ -175,26 +183,24 @@ class AgentTask:
     title: str
     prompt: str
     agent_type: str = 'build'  # build, plan, general, explore
-    model: Optional[str] = (
+    model: str | None = (
         None  # Full provider/model-id (e.g., 'minimax/minimax-m2.1')
     )
     status: AgentTaskStatus = AgentTaskStatus.PENDING
     priority: int = 0  # Higher = more urgent
     created_at: datetime = field(default_factory=datetime.utcnow)
-    started_at: Optional[datetime] = None
-    completed_at: Optional[datetime] = None
-    result: Optional[str] = None
-    error: Optional[str] = None
-    session_id: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    target_agent_name: Optional[str] = None  # If set, only this agent can claim
-    worker_id: Optional[str] = None  # ID of the worker that executed this task
-    model_ref: Optional[str] = None  # Requested model (provider:model format)
-    model_used: Optional[str] = (
-        None  # Actual model used (may differ if fallback)
-    )
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    result: str | None = None
+    error: str | None = None
+    session_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    target_agent_name: str | None = None  # If set, only this agent can claim
+    worker_id: str | None = None  # ID of the worker that executed this task
+    model_ref: str | None = None  # Requested model (provider:model format)
+    model_used: str | None = None  # Actual model used (may differ if fallback)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             'id': self.id,
             'codebase_id': self.codebase_id,
@@ -231,16 +237,16 @@ class RegisteredCodebase:
     path: str
     description: str = ''
     registered_at: datetime = field(default_factory=datetime.utcnow)
-    agent_config: Dict[str, Any] = field(default_factory=dict)
-    last_triggered: Optional[datetime] = None
+    agent_config: dict[str, Any] = field(default_factory=dict)
+    last_triggered: datetime | None = None
     status: AgentStatus = AgentStatus.IDLE
-    agent_port: Optional[int] = None
-    session_id: Optional[str] = None
+    agent_port: int | None = None
+    session_id: str | None = None
     watch_mode: bool = False  # Whether agent is in watch mode
     watch_interval: int = 5  # Seconds between task checks
-    worker_id: Optional[str] = None  # ID of the worker that owns this codebase
+    worker_id: str | None = None  # ID of the worker that owns this codebase
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             'id': self.id,
             'name': self.name,
@@ -267,9 +273,9 @@ class AgentTriggerRequest:
     codebase_id: str
     prompt: str
     agent: str = 'build'  # build, plan, general, explore
-    model: Optional[str] = None
-    files: List[str] = field(default_factory=list)
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    model: str | None = None
+    files: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -277,13 +283,13 @@ class AgentTriggerResponse:
     """Response from triggering an agent."""
 
     success: bool
-    session_id: Optional[str] = None
+    session_id: str | None = None
     message: str = ''
-    codebase_id: Optional[str] = None
-    agent: Optional[str] = None
-    error: Optional[str] = None
+    codebase_id: str | None = None
+    agent: str | None = None
+    error: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             'success': self.success,
             'session_id': self.session_id,
@@ -295,8 +301,7 @@ class AgentTriggerResponse:
 
 
 class AgentBridge:
-    """
-    Bridge between A2A Server and CodeTether agent.
+    """Bridge between A2A Server and CodeTether agent.
 
     Manages workspace registrations, task queues, and triggers agents
     through the CodeTether HTTP API. Supports watch mode where agents
@@ -305,13 +310,12 @@ class AgentBridge:
 
     def __init__(
         self,
-        agent_bin: Optional[str] = None,
+        agent_bin: str | None = None,
         default_port: int = None,
         auto_start: bool = True,
-        agent_host: Optional[str] = None,
+        agent_host: str | None = None,
     ):
-        """
-        Initialize the Agent bridge.
+        """Initialize the Agent bridge.
 
         Args:
             agent_bin: Path to codetether agent binary (auto-detected if None)
@@ -325,41 +329,38 @@ class AgentBridge:
         self.agent_host = agent_host or AGENT_HOST
 
         # In-memory caches (populated from PostgreSQL on demand)
-        self._codebases: Dict[str, RegisteredCodebase] = {}
-        self._tasks: Dict[str, AgentTask] = {}  # task_id -> task
-        self._codebase_tasks: Dict[
-            str, List[str]
+        self._codebases: dict[str, RegisteredCodebase] = {}
+        self._tasks: dict[str, AgentTask] = {}  # task_id -> task
+        self._codebase_tasks: dict[
+            str, list[str]
         ] = {}  # codebase_id -> [task_ids]
 
         # Watch mode background tasks
-        self._watch_tasks: Dict[
+        self._watch_tasks: dict[
             str, asyncio.Task
         ] = {}  # codebase_id -> asyncio task
 
         # Active agent processes
-        self._processes: Dict[str, subprocess.Popen] = {}
+        self._processes: dict[str, subprocess.Popen] = {}
 
         # Port allocations
-        self._port_allocations: Dict[str, int] = {}
+        self._port_allocations: dict[str, int] = {}
         self._next_port = self.default_port
 
         # Event callbacks
-        self._on_status_change: List[Callable] = []
-        self._on_message: List[Callable] = []
-        self._on_task_update: List[Callable] = []
+        self._on_status_change: list[Callable] = []
+        self._on_message: list[Callable] = []
+        self._on_task_update: list[Callable] = []
 
         # HTTP session for API calls
-        self._session: Optional[aiohttp.ClientSession] = None
+        self._session: aiohttp.ClientSession | None = None
 
-        logger.info(
-            f'Agent bridge initialized with binary: {self.agent_bin}'
-        )
+        logger.info(f'Agent bridge initialized with binary: {self.agent_bin}')
         logger.info(f'Agent host: {self.agent_host}:{self.default_port}')
-        logger.info(f'Using PostgreSQL database for persistence')
+        logger.info('Using PostgreSQL database for persistence')
 
-    def _get_agent_base_url(self, port: Optional[int] = None) -> str:
-        """
-        Get the base URL for agent API.
+    def _get_agent_base_url(self, port: int | None = None) -> str:
+        """Get the base URL for agent API.
 
         Uses configured agent_host to allow container->host communication.
         """
@@ -438,7 +439,7 @@ class AgentBridge:
         except Exception as e:
             logger.error(f'Failed to save task to PostgreSQL: {e}')
 
-    def _task_from_db_row(self, row: Dict[str, Any]) -> AgentTask:
+    def _task_from_db_row(self, row: dict[str, Any]) -> AgentTask:
         """Convert a database row to an AgentTask object."""
 
         def parse_dt(val):
@@ -481,7 +482,7 @@ class AgentBridge:
             model_used=metadata.get('model_used'),
         )
 
-    async def _load_task_from_db(self, task_id: str) -> Optional[AgentTask]:
+    async def _load_task_from_db(self, task_id: str) -> AgentTask | None:
         """Load a task from PostgreSQL and cache it in memory.
 
         IMPORTANT: Does NOT overwrite an existing in-memory task, because the
@@ -532,10 +533,12 @@ class AgentBridge:
             # 1. Discover all tenant IDs using admin_scope (bypasses RLS).
             pool = await db.get_pool()
             if not pool:
-                logger.warning('Database pool unavailable, skipping workspace load')
+                logger.warning(
+                    'Database pool unavailable, skipping workspace load'
+                )
                 return
 
-            tenant_ids: List[str] = []
+            tenant_ids: list[str] = []
             async with db.admin_scope() as conn:
                 rows = await conn.fetch(
                     'SELECT id FROM tenants ORDER BY created_at'
@@ -554,9 +557,9 @@ class AgentBridge:
                         ws_rows = await conn.fetch(
                             'SELECT * FROM workspaces ORDER BY updated_at DESC'
                         )
-                except Exception as te:
+                except Exception as exc:
                     logger.warning(
-                        f'Failed to load workspaces for tenant {tid}: {te}'
+                        f'Failed to load workspaces for tenant {tid}: {exc}'
                     )
                     continue
 
@@ -606,10 +609,10 @@ class AgentBridge:
 
     async def _load_tasks_from_db(
         self,
-        codebase_id: Optional[str] = None,
-        status: Optional[str] = None,
+        codebase_id: str | None = None,
+        status: str | None = None,
         limit: int = 100,
-    ) -> List[AgentTask]:
+    ) -> list[AgentTask]:
         """Load tasks from PostgreSQL and cache them in memory."""
         try:
             rows = await db.db_list_tasks(
@@ -714,12 +717,11 @@ class AgentBridge:
         name: str,
         path: str,
         description: str = '',
-        agent_config: Optional[Dict[str, Any]] = None,
-        worker_id: Optional[str] = None,
-        codebase_id: Optional[str] = None,
+        agent_config: dict[str, Any] | None = None,
+        worker_id: str | None = None,
+        codebase_id: str | None = None,
     ) -> RegisteredCodebase:
-        """
-        Register a codebase for agent work.
+        """Register a codebase for agent work.
 
         Args:
             name: Display name for the codebase
@@ -839,11 +841,11 @@ class AgentBridge:
             return True
         return False
 
-    def get_codebase(self, codebase_id: str) -> Optional[RegisteredCodebase]:
+    def get_codebase(self, codebase_id: str) -> RegisteredCodebase | None:
         """Get a registered codebase by ID."""
         return self._codebases.get(codebase_id)
 
-    def list_codebases(self) -> List[RegisteredCodebase]:
+    def list_codebases(self) -> list[RegisteredCodebase]:
         """List all registered codebases."""
         return list(self._codebases.values())
 
@@ -857,9 +859,9 @@ class AgentBridge:
         name: str,
         path: str,
         description: str = '',
-        agent_config: Optional[Dict[str, Any]] = None,
-        worker_id: Optional[str] = None,
-        workspace_id: Optional[str] = None,
+        agent_config: dict[str, Any] | None = None,
+        worker_id: str | None = None,
+        workspace_id: str | None = None,
     ) -> RegisteredCodebase:
         return await self.register_codebase(
             name=name,
@@ -873,10 +875,10 @@ class AgentBridge:
     async def unregister_workspace(self, workspace_id: str) -> bool:
         return await self.unregister_codebase(workspace_id)
 
-    def get_workspace(self, workspace_id: str) -> Optional[RegisteredCodebase]:
+    def get_workspace(self, workspace_id: str) -> RegisteredCodebase | None:
         return self.get_codebase(workspace_id)
 
-    def list_workspaces(self) -> List[RegisteredCodebase]:
+    def list_workspaces(self) -> list[RegisteredCodebase]:
         return self.list_codebases()
 
     def _allocate_port(self, codebase_id: str) -> int:
@@ -890,8 +892,7 @@ class AgentBridge:
         return port
 
     async def _start_agent_server(self, codebase: RegisteredCodebase) -> int:
-        """
-        Start an agent server for a codebase.
+        """Start an agent server for a codebase.
 
         Returns the port number.
         """
@@ -905,9 +906,7 @@ class AgentBridge:
             str(port),
         ]
 
-        logger.info(
-            f'Starting agent server for {codebase.name} on port {port}'
-        )
+        logger.info(f'Starting agent server for {codebase.name} on port {port}')
         logger.debug(f'Command: {" ".join(cmd)}')
 
         try:
@@ -973,8 +972,7 @@ class AgentBridge:
         self,
         request: AgentTriggerRequest,
     ) -> AgentTriggerResponse:
-        """
-        Trigger an agent to work on a codebase.
+        """Trigger an agent to work on a codebase.
 
         Args:
             request: The trigger request with prompt and configuration
@@ -1018,11 +1016,10 @@ class AgentBridge:
                     codebase_id=request.codebase_id,
                     agent=request.agent,
                 )
-            else:
-                return AgentTriggerResponse(
-                    success=False,
-                    error='Failed to create task for remote worker',
-                )
+            return AgentTriggerResponse(
+                success=False,
+                error='Failed to create task for remote worker',
+            )
 
         try:
             # Local execution: Ensure agent server is running
@@ -1125,8 +1122,7 @@ class AgentBridge:
         request: AgentTriggerRequest,
         codebase: RegisteredCodebase,
     ) -> AgentTriggerResponse:
-        """
-        Trigger an agent using Knative worker infrastructure.
+        """Trigger an agent using Knative worker infrastructure.
 
         This method:
         1. Creates a task in PostgreSQL
@@ -1143,7 +1139,6 @@ class AgentBridge:
         """
         # Generate session ID (or use existing)
         session_id = request.metadata.get('session_id') or str(uuid.uuid4())[:8]
-        task_id = str(uuid.uuid4())
 
         # Prepare model specification for CloudEvent
         model_spec = None
@@ -1334,8 +1329,7 @@ class AgentBridge:
             )
 
     async def end_session(self, session_id: str) -> bool:
-        """
-        End a session and optionally clean up its Knative worker.
+        """End a session and optionally clean up its Knative worker.
 
         This method:
         1. Marks the session as ended in PostgreSQL
@@ -1400,9 +1394,8 @@ class AgentBridge:
 
         return True
 
-    async def get_available_models(self) -> List[Dict[str, Any]]:
-        """
-        Fetch available models from agent.
+    async def get_available_models(self) -> list[dict[str, Any]]:
+        """Fetch available models from agent.
 
         Tries to query an active agent instance. If none are running,
         it may start a temporary one or fall back to reading config.
@@ -1410,10 +1403,7 @@ class AgentBridge:
         # 1. Try to find an active agent instance
         active_port = None
         for codebase in self._codebases.values():
-            if (
-                codebase.agent_port
-                and codebase.status == AgentStatus.RUNNING
-            ):
+            if codebase.agent_port and codebase.status == AgentStatus.RUNNING:
                 active_port = codebase.agent_port
                 break
 
@@ -1471,9 +1461,7 @@ class AgentBridge:
 
         return []
 
-    async def get_agent_status(
-        self, codebase_id: str
-    ) -> Optional[Dict[str, Any]]:
+    async def get_agent_status(self, codebase_id: str) -> dict[str, Any] | None:
         """Get the current status of an agent."""
         codebase = self._codebases.get(codebase_id)
         if not codebase:
@@ -1504,7 +1492,7 @@ class AgentBridge:
         self,
         codebase_id: str,
         message: str,
-        agent: Optional[str] = None,
+        agent: str | None = None,
     ) -> AgentTriggerResponse:
         """Send an additional message to an active agent session."""
         codebase = self._codebases.get(codebase_id)
@@ -1562,11 +1550,7 @@ class AgentBridge:
     async def interrupt_agent(self, codebase_id: str) -> bool:
         """Interrupt the current agent task."""
         codebase = self._codebases.get(codebase_id)
-        if (
-            not codebase
-            or not codebase.session_id
-            or not codebase.agent_port
-        ):
+        if not codebase or not codebase.session_id or not codebase.agent_port:
             return False
 
         try:
@@ -1613,17 +1597,16 @@ class AgentBridge:
 
     async def create_task(
         self,
-        codebase_id: Optional[str],
+        codebase_id: str | None,
         title: str,
         prompt: str,
         agent_type: str = 'build',
         priority: int = 0,
-        model: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        model_ref: Optional[str] = None,
-    ) -> Optional[AgentTask]:
-        """
-        Create a new task for an agent.
+        model: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        model_ref: str | None = None,
+    ) -> AgentTask | None:
+        """Create a new task for an agent.
 
         Special codebase_id values:
         - None: Global tasks that any worker can claim
@@ -1694,7 +1677,7 @@ class AgentBridge:
 
         return task
 
-    async def get_task(self, task_id: str) -> Optional[AgentTask]:
+    async def get_task(self, task_id: str) -> AgentTask | None:
         """Get a task by ID. Checks in-memory cache first, then database."""
         # Check in-memory cache first
         task = self._tasks.get(task_id)
@@ -1705,9 +1688,9 @@ class AgentBridge:
 
     async def list_tasks(
         self,
-        codebase_id: Optional[str] = None,
-        status: Optional[AgentTaskStatus] = None,
-    ) -> List[AgentTask]:
+        codebase_id: str | None = None,
+        status: AgentTaskStatus | None = None,
+    ) -> list[AgentTask]:
         """List tasks, optionally filtered by codebase or status. Loads from database."""
         # Load tasks from database (this also caches them in memory)
         status_str = status.value if status else None
@@ -1722,9 +1705,7 @@ class AgentBridge:
 
         return tasks
 
-    async def get_next_pending_task(
-        self, codebase_id: str
-    ) -> Optional[AgentTask]:
+    async def get_next_pending_task(self, codebase_id: str) -> AgentTask | None:
         """Get the next pending task for a codebase."""
         pending = await self.list_tasks(
             codebase_id=codebase_id, status=AgentTaskStatus.PENDING
@@ -1735,12 +1716,12 @@ class AgentBridge:
         self,
         task_id: str,
         status: AgentTaskStatus,
-        result: Optional[str] = None,
-        error: Optional[str] = None,
-        session_id: Optional[str] = None,
-        worker_id: Optional[str] = None,
-        model_used: Optional[str] = None,
-    ) -> Optional[AgentTask]:
+        result: str | None = None,
+        error: str | None = None,
+        session_id: str | None = None,
+        worker_id: str | None = None,
+        model_used: str | None = None,
+    ) -> AgentTask | None:
         """Update task status.
 
         Args:
@@ -1870,8 +1851,7 @@ class AgentBridge:
     async def start_watch_mode(
         self, codebase_id: str, interval: int = 5
     ) -> bool:
-        """
-        Start watch mode for a codebase - agent will poll for and execute tasks.
+        """Start watch mode for a codebase - agent will poll for and execute tasks.
 
         Args:
             codebase_id: ID of the codebase
@@ -2122,7 +2102,7 @@ class AgentBridge:
 
 
 # Global bridge instance
-_bridge: Optional[AgentBridge] = None
+_bridge: AgentBridge | None = None
 
 
 def get_bridge() -> AgentBridge:
@@ -2134,10 +2114,10 @@ def get_bridge() -> AgentBridge:
 
 
 def init_bridge(
-    agent_bin: Optional[str] = None,
+    agent_bin: str | None = None,
     default_port: int = None,
     auto_start: bool = True,
-    agent_host: Optional[str] = None,
+    agent_host: str | None = None,
 ) -> AgentBridge:
     """Initialize the global Agent bridge instance."""
     global _bridge
@@ -2156,10 +2136,10 @@ def get_agent_bridge() -> AgentBridge:
 
 
 def init_agent_bridge(
-    agent_bin: Optional[str] = None,
+    agent_bin: str | None = None,
     default_port: int = None,
     auto_start: bool = True,
-    agent_host: Optional[str] = None,
+    agent_host: str | None = None,
 ) -> AgentBridge:
     """Initialize the global AgentBridge instance."""
     return init_bridge(

--- a/a2a_server/database.py
+++ b/a2a_server/database.py
@@ -1,5 +1,4 @@
-"""
-PostgreSQL database persistence layer for A2A Server.
+"""PostgreSQL database persistence layer for A2A Server.
 
 Provides durable storage for workers, workspaces, tasks, and sessions
 that survives server restarts and works across multiple replicas.
@@ -25,15 +24,19 @@ import json
 import logging
 import os
 import uuid
+
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
+
 
 logger = logging.getLogger(__name__)
 
 # Database URL from environment — no hardcoded fallback.
 # One of DATABASE_URL or A2A_DATABASE_URL MUST be set.
-DATABASE_URL = os.environ.get('DATABASE_URL') or os.environ.get('A2A_DATABASE_URL')
+DATABASE_URL = os.environ.get('DATABASE_URL') or os.environ.get(
+    'A2A_DATABASE_URL'
+)
 if not DATABASE_URL:
     raise RuntimeError(
         'DATABASE_URL (or A2A_DATABASE_URL) environment variable is required. '
@@ -49,13 +52,12 @@ _initialized = False
 # RLS is enabled by default for multi-tenant isolation.
 RLS_ENABLED = os.environ.get('RLS_ENABLED', 'true').lower() == 'true'
 RLS_STRICT_MODE = os.environ.get('RLS_STRICT_MODE', 'false').lower() == 'true'
-SCHEMA_INIT_ON_STARTUP = (
-    os.environ.get('A2A_SCHEMA_INIT_ON_STARTUP', 'true').lower()
-    not in {'0', 'false', 'no'}
-)
+SCHEMA_INIT_ON_STARTUP = os.environ.get(
+    'A2A_SCHEMA_INIT_ON_STARTUP', 'true'
+).lower() not in {'0', 'false', 'no'}
 
 
-def _parse_timestamp(value: Union[str, datetime, None]) -> Optional[datetime]:
+def _parse_timestamp(value: str | datetime | None) -> datetime | None:
     """Parse a timestamp from string or datetime to datetime object."""
     if value is None:
         return None
@@ -100,7 +102,7 @@ async def get_pool():
                 max_size=10,
                 command_timeout=30,
             )
-            logger.info(f'✓ PostgreSQL connection pool created')
+            logger.info('✓ PostgreSQL connection pool created')
 
             # Initialize schema if needed
             if not _initialized:
@@ -241,7 +243,7 @@ async def _init_schema():
         # Migration: Add Git repo columns to workspaces
         for col_def in [
             'git_url TEXT',
-            'git_branch TEXT DEFAULT \'main\'',
+            "git_branch TEXT DEFAULT 'main'",
         ]:
             try:
                 await conn.execute(
@@ -289,8 +291,15 @@ async def _init_schema():
             pass
 
         # Migration: Rename codebase_id -> workspace_id across all tables
-        for _tbl in ['tasks', 'sessions', 'inbound_emails', 'outbound_emails',
-                      'ralph_runs', 'prd_chat_sessions', 'perpetual_loops']:
+        for _tbl in [
+            'tasks',
+            'sessions',
+            'inbound_emails',
+            'outbound_emails',
+            'ralph_runs',
+            'prd_chat_sessions',
+            'perpetual_loops',
+        ]:
             try:
                 await conn.execute(
                     f'ALTER TABLE {_tbl} RENAME COLUMN codebase_id TO workspace_id'
@@ -643,7 +652,7 @@ async def close_pool():
 
 
 async def db_upsert_worker(
-    worker_info: Dict[str, Any], tenant_id: Optional[str] = None
+    worker_info: dict[str, Any], tenant_id: str | None = None
 ) -> bool:
     """Insert or update a worker in the database.
 
@@ -711,7 +720,7 @@ async def db_delete_worker(worker_id: str) -> bool:
         return False
 
 
-async def db_get_worker(worker_id: str) -> Optional[Dict[str, Any]]:
+async def db_get_worker(worker_id: str) -> dict[str, Any] | None:
     """Get a worker by ID."""
     pool = await get_pool()
     if not pool:
@@ -732,8 +741,8 @@ async def db_get_worker(worker_id: str) -> Optional[Dict[str, Any]]:
 
 async def db_get_active_worker_by_name(
     name: str,
-    tenant_id: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
+    tenant_id: str | None = None,
+) -> dict[str, Any] | None:
     """Get the most recently seen active worker for an agent name."""
     pool = await get_pool()
     if not pool:
@@ -744,7 +753,7 @@ async def db_get_active_worker_by_name(
             query = (
                 "SELECT * FROM workers WHERE name = $1 AND status = 'active'"
             )
-            params: List[Any] = [name]
+            params: list[Any] = [name]
             if tenant_id:
                 query += ' AND tenant_id = $2'
                 params.append(tenant_id)
@@ -760,9 +769,9 @@ async def db_get_active_worker_by_name(
 
 
 async def db_list_workers(
-    status: Optional[str] = None,
-    tenant_id: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+    status: str | None = None,
+    tenant_id: str | None = None,
+) -> list[dict[str, Any]]:
     """List all workers, optionally filtered by status or tenant."""
     pool = await get_pool()
     if not pool:
@@ -817,7 +826,7 @@ async def db_update_worker_heartbeat(worker_id: str) -> bool:
 
 
 async def db_upsert_agent_definition(
-    agent: Dict[str, Any], tenant_id: Optional[str] = None
+    agent: dict[str, Any], tenant_id: str | None = None
 ) -> bool:
     """Insert or update an agent definition.
 
@@ -911,7 +920,7 @@ async def db_delete_agent_definitions_by_worker(worker_id: str) -> bool:
         return False
 
 
-async def db_get_agent_definition(agent_id: str) -> Optional[Dict[str, Any]]:
+async def db_get_agent_definition(agent_id: str) -> dict[str, Any] | None:
     """Get an agent definition by ID."""
     pool = await get_pool()
     if not pool:
@@ -932,7 +941,7 @@ async def db_get_agent_definition(agent_id: str) -> Optional[Dict[str, Any]]:
 
 async def db_get_agent_definition_by_name(
     worker_id: str, name: str
-) -> Optional[Dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Get an agent definition by worker ID and name."""
     pool = await get_pool()
     if not pool:
@@ -954,11 +963,11 @@ async def db_get_agent_definition_by_name(
 
 
 async def db_list_agent_definitions(
-    worker_id: Optional[str] = None,
-    tenant_id: Optional[str] = None,
+    worker_id: str | None = None,
+    tenant_id: str | None = None,
     include_hidden: bool = False,
     include_native: bool = True,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """List agent definitions, optionally filtered by worker or tenant."""
     pool = await get_pool()
     if not pool:
@@ -1000,7 +1009,7 @@ async def db_list_agent_definitions(
         return []
 
 
-async def db_list_all_agent_definitions() -> List[Dict[str, Any]]:
+async def db_list_all_agent_definitions() -> list[dict[str, Any]]:
     """List all agent definitions across all workers (admin endpoint)."""
     pool = await get_pool()
     if not pool:
@@ -1009,7 +1018,7 @@ async def db_list_all_agent_definitions() -> List[Dict[str, Any]]:
     try:
         async with pool.acquire() as conn:
             rows = await conn.fetch(
-                "SELECT * FROM agent_definitions WHERE hidden = FALSE ORDER BY worker_id, name"
+                'SELECT * FROM agent_definitions WHERE hidden = FALSE ORDER BY worker_id, name'
             )
             return [_row_to_agent_definition(row) for row in rows]
     except Exception as e:
@@ -1017,7 +1026,7 @@ async def db_list_all_agent_definitions() -> List[Dict[str, Any]]:
         return []
 
 
-def _row_to_agent_definition(row) -> Dict[str, Any]:
+def _row_to_agent_definition(row) -> dict[str, Any]:
     """Convert a database row to an agent definition dict."""
     return {
         'id': row['id'],
@@ -1027,18 +1036,24 @@ def _row_to_agent_definition(row) -> Dict[str, Any]:
         'native': row['native'],
         'hidden': row['hidden'],
         'model': row['model'],
-        'temperature': float(row['temperature']) if row['temperature'] else None,
+        'temperature': float(row['temperature'])
+        if row['temperature']
+        else None,
         'top_p': float(row['top_p']) if row['top_p'] else None,
         'max_steps': row['max_steps'],
         'system_prompt': row['system_prompt'],
         'worker_id': row['worker_id'],
         'tenant_id': row['tenant_id'],
-        'created_at': row['created_at'].isoformat() if row['created_at'] else None,
-        'updated_at': row['updated_at'].isoformat() if row['updated_at'] else None,
+        'created_at': row['created_at'].isoformat()
+        if row['created_at']
+        else None,
+        'updated_at': row['updated_at'].isoformat()
+        if row['updated_at']
+        else None,
     }
 
 
-def _row_to_worker(row) -> Dict[str, Any]:
+def _row_to_worker(row) -> dict[str, Any]:
     """Convert a database row to a worker dict."""
     return {
         'worker_id': row['worker_id'],
@@ -1065,7 +1080,7 @@ def _row_to_worker(row) -> Dict[str, Any]:
 
 
 async def db_upsert_workspace(
-    workspace: Dict[str, Any], tenant_id: Optional[str] = None
+    workspace: dict[str, Any], tenant_id: str | None = None
 ) -> bool:
     """Insert or update a workspace in the database.
 
@@ -1079,7 +1094,9 @@ async def db_upsert_workspace(
 
     try:
         # Handle both 'created_at' and 'registered_at' field names
-        created_at = workspace.get('created_at') or workspace.get('registered_at')
+        created_at = workspace.get('created_at') or workspace.get(
+            'registered_at'
+        )
         # Use provided tenant_id or fall back to workspace dict
         effective_tenant_id = tenant_id or workspace.get('tenant_id')
 
@@ -1142,7 +1159,7 @@ async def db_delete_workspace(workspace_id: str) -> bool:
         return False
 
 
-async def db_get_workspace(workspace_id: str) -> Optional[Dict[str, Any]]:
+async def db_get_workspace(workspace_id: str) -> dict[str, Any] | None:
     """Get a workspace by ID."""
     pool = await get_pool()
     if not pool:
@@ -1162,10 +1179,10 @@ async def db_get_workspace(workspace_id: str) -> Optional[Dict[str, Any]]:
 
 
 async def db_list_workspaces(
-    worker_id: Optional[str] = None,
-    status: Optional[str] = None,
-    tenant_id: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+    worker_id: str | None = None,
+    status: str | None = None,
+    tenant_id: str | None = None,
+) -> list[dict[str, Any]]:
     """List all workspaces, optionally filtered by worker, status, or tenant."""
     pool = await get_pool()
     if not pool:
@@ -1201,7 +1218,7 @@ async def db_list_workspaces(
         return []
 
 
-async def db_list_workspaces_by_path(path: str) -> List[Dict[str, Any]]:
+async def db_list_workspaces_by_path(path: str) -> list[dict[str, Any]]:
     """List all workspaces matching a specific normalized path.
 
     Returns workspaces ordered by created_at ASC so the oldest (canonical) ID is first.
@@ -1223,7 +1240,7 @@ async def db_list_workspaces_by_path(path: str) -> List[Dict[str, Any]]:
         return []
 
 
-async def db_get_canonical_workspace_id(path: str) -> Optional[str]:
+async def db_get_canonical_workspace_id(path: str) -> str | None:
     """Get the canonical (oldest) workspace ID for a given path.
 
     This is the authoritative ID that should be used for task routing.
@@ -1236,7 +1253,7 @@ async def db_get_canonical_workspace_id(path: str) -> Optional[str]:
 
 
 async def db_deduplicate_workspaces(
-    path: str, keep_id: Optional[str] = None
+    path: str, keep_id: str | None = None
 ) -> int:
     """Remove duplicate workspace entries for a path, keeping only the canonical one.
 
@@ -1292,7 +1309,7 @@ async def db_deduplicate_workspaces(
         return 0
 
 
-async def db_deduplicate_all_workspaces() -> Dict[str, int]:
+async def db_deduplicate_all_workspaces() -> dict[str, int]:
     """Deduplicate all workspace entries, keeping the oldest for each path.
 
     Returns:
@@ -1327,7 +1344,7 @@ async def db_deduplicate_all_workspaces() -> Dict[str, int]:
         return results
 
 
-def _row_to_workspace(row) -> Dict[str, Any]:
+def _row_to_workspace(row) -> dict[str, Any]:
     """Convert a database row to a workspace dict."""
     agent_config = row['agent_config']
     if isinstance(agent_config, str):
@@ -1383,7 +1400,7 @@ db_list_codebases = db_list_workspaces
 
 
 async def db_upsert_task(
-    task: Dict[str, Any], tenant_id: Optional[str] = None
+    task: dict[str, Any], tenant_id: str | None = None
 ) -> bool:
     """Insert or update a task in the database.
 
@@ -1468,7 +1485,7 @@ async def db_upsert_task(
         return False
 
 
-async def db_get_task(task_id: str) -> Optional[Dict[str, Any]]:
+async def db_get_task(task_id: str) -> dict[str, Any] | None:
     """Get a task by ID."""
     pool = await get_pool()
     if not pool:
@@ -1488,14 +1505,14 @@ async def db_get_task(task_id: str) -> Optional[Dict[str, Any]]:
 
 
 async def db_list_tasks(
-    workspace_id: Optional[str] = None,
-    codebase_id: Optional[str] = None,
-    status: Optional[str] = None,
-    worker_id: Optional[str] = None,
+    workspace_id: str | None = None,
+    codebase_id: str | None = None,
+    status: str | None = None,
+    worker_id: str | None = None,
     limit: int = 100,
-    tenant_id: Optional[str] = None,
-    agent_name: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+    tenant_id: str | None = None,
+    agent_name: str | None = None,
+) -> list[dict[str, Any]]:
     """List tasks with optional filters including tenant isolation."""
     pool = await get_pool()
     if not pool:
@@ -1507,6 +1524,7 @@ async def db_list_tasks(
             workspace_id = codebase_id
 
         async with pool.acquire() as conn:
+
             def _build_query(workspace_column: str):
                 query = 'SELECT * FROM tasks WHERE 1=1'
                 params = []
@@ -1564,11 +1582,7 @@ async def db_list_tasks(
                             params.append(agent_name)
                             param_idx += 1
 
-                        query += (
-                            ' AND ('
-                            + ' OR '.join(ff_visibility)
-                            + ')'
-                        )
+                        query += ' AND (' + ' OR '.join(ff_visibility) + ')'
 
                         # Exclude tasks targeted at a different agent.
                         # Workers should only see tasks they are eligible to
@@ -1630,9 +1644,7 @@ async def db_list_tasks(
                     params.append(tenant_id)
                     param_idx += 1
 
-                query += (
-                    f' ORDER BY priority DESC, created_at ASC LIMIT ${param_idx}'
-                )
+                query += f' ORDER BY priority DESC, created_at ASC LIMIT ${param_idx}'
                 params.append(limit)
                 return query, params
 
@@ -1658,8 +1670,8 @@ async def db_list_tasks(
 
 
 async def db_get_next_pending_task(
-    workspace_id: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
+    workspace_id: str | None = None,
+) -> dict[str, Any] | None:
     """Get the next pending task (highest priority, oldest first)."""
     pool = await get_pool()
     if not pool:
@@ -1695,9 +1707,9 @@ async def db_get_next_pending_task(
 async def db_update_task_status(
     task_id: str,
     status: str,
-    worker_id: Optional[str] = None,
-    result: Optional[str] = None,
-    error: Optional[str] = None,
+    worker_id: str | None = None,
+    result: str | None = None,
+    error: str | None = None,
 ) -> bool:
     """Update task status and optionally result/error."""
     pool = await get_pool()
@@ -1713,7 +1725,7 @@ async def db_update_task_status(
         task = await db_get_task(task_id)
         if task:
             metadata = task.get('metadata', {}) or {}
-            is_prd_chat = metadata.get('prd_chat') == True
+            is_prd_chat = bool(metadata.get('prd_chat'))
             session_id = metadata.get('session_id')
     except Exception:
         pass
@@ -1766,7 +1778,7 @@ async def db_update_task_status(
         return False
 
 
-def _row_to_task(row) -> Dict[str, Any]:
+def _row_to_task(row) -> dict[str, Any]:
     """Convert a database row to a task dict."""
     metadata = row['metadata']
     if isinstance(metadata, str):
@@ -1811,7 +1823,7 @@ def _row_to_task(row) -> Dict[str, Any]:
 
 
 async def db_upsert_session(
-    session: Dict[str, Any], tenant_id: Optional[str] = None
+    session: dict[str, Any], tenant_id: str | None = None
 ) -> bool:
     """Insert or update a session in the database.
 
@@ -1862,8 +1874,8 @@ async def db_upsert_session(
 async def db_list_sessions(
     workspace_id: str,
     limit: int = 50,
-    tenant_id: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+    tenant_id: str | None = None,
+) -> list[dict[str, Any]]:
     """List sessions for a workspace, optionally filtered by tenant."""
     pool = await get_pool()
     if not pool:
@@ -1903,8 +1915,8 @@ async def db_list_sessions(
 async def db_list_all_sessions(
     limit: int = 100,
     offset: int = 0,
-    tenant_id: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+    tenant_id: str | None = None,
+) -> list[dict[str, Any]]:
     """List all sessions across all workspaces, optionally filtered by tenant."""
     pool = await get_pool()
     if not pool:
@@ -1950,7 +1962,7 @@ async def db_list_all_sessions(
         return []
 
 
-async def db_get_session(session_id: str) -> Optional[Dict[str, Any]]:
+async def db_get_session(session_id: str) -> dict[str, Any] | None:
     """Get a session by ID."""
     pool = await get_pool()
     if not pool:
@@ -1969,7 +1981,7 @@ async def db_get_session(session_id: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-def _row_to_session(row) -> Dict[str, Any]:
+def _row_to_session(row) -> dict[str, Any]:
     """Convert a database row to a session dict."""
     summary = row['summary']
     if isinstance(summary, str):
@@ -2002,7 +2014,7 @@ def _row_to_session(row) -> Dict[str, Any]:
 async def db_update_session_worker_status(
     session_id: str,
     worker_status: str,
-    knative_service_name: Optional[str] = None,
+    knative_service_name: str | None = None,
 ) -> bool:
     """Update session worker status and optionally the Knative service name.
 
@@ -2151,7 +2163,7 @@ async def db_update_workspace_sync_time(workspace_id: str) -> bool:
 # ========================================
 
 
-async def db_upsert_message(message: Dict[str, Any]) -> bool:
+async def db_upsert_message(message: dict[str, Any]) -> bool:
     """Insert or update a session message."""
     pool = await get_pool()
     if not pool:
@@ -2188,7 +2200,7 @@ async def db_upsert_message(message: Dict[str, Any]) -> bool:
 
 async def db_list_messages(
     session_id: str, limit: int = 50
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """List messages for a session."""
     pool = await get_pool()
     if not pool:
@@ -2212,7 +2224,7 @@ async def db_list_messages(
         return []
 
 
-def _row_to_message(row) -> Dict[str, Any]:
+def _row_to_message(row) -> dict[str, Any]:
     """Convert a database row to a message dict."""
     tokens = row['tokens']
     if isinstance(tokens, str):
@@ -2246,7 +2258,7 @@ def _row_to_message(row) -> Dict[str, Any]:
 # ========================================
 
 
-async def db_health_check() -> Dict[str, Any]:
+async def db_health_check() -> dict[str, Any]:
     """Check database health and return stats."""
     pool = await get_pool()
 
@@ -2293,7 +2305,7 @@ async def db_health_check() -> Dict[str, Any]:
 # ========================================
 
 
-async def db_save_monitor_message(message: Dict[str, Any]) -> bool:
+async def db_save_monitor_message(message: dict[str, Any]) -> bool:
     """Save a monitor message to the database."""
     pool = await get_pool()
     if not pool:
@@ -2326,9 +2338,9 @@ async def db_save_monitor_message(message: Dict[str, Any]) -> bool:
 
 async def db_list_monitor_messages(
     limit: int = 100,
-    agent_name: Optional[str] = None,
-    msg_type: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+    agent_name: str | None = None,
+    msg_type: str | None = None,
+) -> list[dict[str, Any]]:
     """List monitor messages from the database."""
     pool = await get_pool()
     if not pool:
@@ -2360,7 +2372,7 @@ async def db_list_monitor_messages(
         return []
 
 
-async def db_get_monitor_stats() -> Dict[str, Any]:
+async def db_get_monitor_stats() -> dict[str, Any]:
     """Get monitor statistics from the database."""
     pool = await get_pool()
     if not pool:
@@ -2396,7 +2408,7 @@ async def db_count_monitor_messages() -> int:
         return 0
 
 
-def _row_to_monitor_message(row) -> Dict[str, Any]:
+def _row_to_monitor_message(row) -> dict[str, Any]:
     """Convert a database row to a monitor message dict."""
     metadata = row['metadata']
     if isinstance(metadata, str):
@@ -2472,7 +2484,7 @@ async def create_tenant(
         raise
 
 
-async def get_tenant_by_realm(realm_name: str) -> Optional[dict]:
+async def get_tenant_by_realm(realm_name: str) -> dict | None:
     """Get a tenant by realm name.
 
     Args:
@@ -2498,7 +2510,7 @@ async def get_tenant_by_realm(realm_name: str) -> Optional[dict]:
         return None
 
 
-async def get_tenant_by_id(tenant_id: str) -> Optional[dict]:
+async def get_tenant_by_id(tenant_id: str) -> dict | None:
     """Get a tenant by ID.
 
     Args:
@@ -2524,7 +2536,7 @@ async def get_tenant_by_id(tenant_id: str) -> Optional[dict]:
         return None
 
 
-async def list_tenants(limit: int = 100, offset: int = 0) -> List[dict]:
+async def list_tenants(limit: int = 100, offset: int = 0) -> list[dict]:
     """List all tenants with pagination.
 
     Args:
@@ -2736,7 +2748,7 @@ async def clear_tenant_context(conn) -> None:
         logger.warning(f'Failed to clear tenant context: {e}')
 
 
-async def get_tenant_context(conn) -> Optional[str]:
+async def get_tenant_context(conn) -> str | None:
     """Get the current tenant context from the database connection.
 
     Args:
@@ -2845,7 +2857,7 @@ async def db_execute_as_tenant(tenant_id: str, query: str, *args) -> Any:
         return await conn.execute(query, *args)
 
 
-async def db_fetch_as_tenant(tenant_id: str, query: str, *args) -> List[Any]:
+async def db_fetch_as_tenant(tenant_id: str, query: str, *args) -> list[Any]:
     """Fetch rows with tenant context.
 
     Convenience function for fetching rows within tenant scope.
@@ -2864,7 +2876,7 @@ async def db_fetch_as_tenant(tenant_id: str, query: str, *args) -> List[Any]:
 
 async def db_fetchrow_as_tenant(
     tenant_id: str, query: str, *args
-) -> Optional[Any]:
+) -> Any | None:
     """Fetch a single row with tenant context.
 
     Args:
@@ -2881,7 +2893,7 @@ async def db_fetchrow_as_tenant(
 
 async def db_fetchval_as_tenant(
     tenant_id: str, query: str, *args
-) -> Optional[Any]:
+) -> Any | None:
     """Fetch a single value with tenant context.
 
     Args:
@@ -2902,8 +2914,8 @@ async def db_fetchval_as_tenant(
 
 
 async def db_run_migrations(
-    migrations_dir: Optional[str] = None,
-) -> Dict[str, Any]:
+    migrations_dir: str | None = None,
+) -> dict[str, Any]:
     """Run SQL migration files from the migrations directory.
 
     Executes all .sql files in the migrations directory that haven't been
@@ -2933,7 +2945,7 @@ async def db_run_migrations(
     if not pool:
         raise RuntimeError('Database pool not available')
 
-    results: Dict[str, List[Any]] = {'applied': [], 'skipped': [], 'failed': []}
+    results: dict[str, list[Any]] = {'applied': [], 'skipped': [], 'failed': []}
 
     async with pool.acquire() as conn:
         # Ensure schema_migrations table exists
@@ -2998,7 +3010,7 @@ async def db_run_migrations(
     return results
 
 
-async def db_enable_rls() -> Dict[str, Any]:
+async def db_enable_rls() -> dict[str, Any]:
     """Enable RLS by running the enable_rls.sql migration.
 
     This enables Row-Level Security on all tenant-scoped tables:
@@ -3041,7 +3053,7 @@ async def db_enable_rls() -> Dict[str, Any]:
         return {'status': 'error', 'message': str(e)}
 
 
-async def db_disable_rls() -> Dict[str, Any]:
+async def db_disable_rls() -> dict[str, Any]:
     """Disable RLS by running the disable_rls.sql migration.
 
     This disables Row-Level Security and removes all policies.
@@ -3079,7 +3091,7 @@ async def db_disable_rls() -> Dict[str, Any]:
         return {'status': 'error', 'message': str(e)}
 
 
-async def get_rls_status() -> Dict[str, Any]:
+async def get_rls_status() -> dict[str, Any]:
     """Get the current RLS status for all tenant-scoped tables.
 
     Returns:
@@ -3122,7 +3134,7 @@ async def get_rls_status() -> Dict[str, Any]:
                 AND tablename IN ('workers', 'workspaces', 'tasks', 'sessions', 'rbac_user_roles')
             """)
 
-            policy_count: Dict[str, int] = {}
+            policy_count: dict[str, int] = {}
             for policy in policies:
                 table = policy['tablename']
                 if table not in policy_count:
@@ -3178,19 +3190,18 @@ async def db_log_inbound_email(
     to_email: str,
     subject: str,
     body_text: str,
-    body_html: Optional[str] = None,
-    session_id: Optional[str] = None,
-    workspace_id: Optional[str] = None,
-    task_id: Optional[str] = None,
-    sender_ip: Optional[str] = None,
-    spf_result: Optional[str] = None,
+    body_html: str | None = None,
+    session_id: str | None = None,
+    workspace_id: str | None = None,
+    task_id: str | None = None,
+    sender_ip: str | None = None,
+    spf_result: str | None = None,
     status: str = 'received',
-    error: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
-    tenant_id: Optional[str] = None,
-) -> Optional[str]:
-    """
-    Log an inbound email to the database.
+    error: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    tenant_id: str | None = None,
+) -> str | None:
+    """Log an inbound email to the database.
 
     Args:
         from_email: Sender email address
@@ -3255,12 +3266,11 @@ async def db_log_inbound_email(
 
 async def db_update_inbound_email(
     email_id: str,
-    task_id: Optional[str] = None,
-    status: Optional[str] = None,
-    error: Optional[str] = None,
+    task_id: str | None = None,
+    status: str | None = None,
+    error: str | None = None,
 ) -> bool:
-    """
-    Update an inbound email record after processing.
+    """Update an inbound email record after processing.
 
     Args:
         email_id: The email record ID
@@ -3314,21 +3324,20 @@ async def db_log_outbound_email(
     to_email: str,
     from_email: str,
     subject: str,
-    body_html: Optional[str] = None,
-    body_text: Optional[str] = None,
-    reply_to: Optional[str] = None,
-    task_id: Optional[str] = None,
-    session_id: Optional[str] = None,
-    workspace_id: Optional[str] = None,
-    worker_id: Optional[str] = None,
+    body_html: str | None = None,
+    body_text: str | None = None,
+    reply_to: str | None = None,
+    task_id: str | None = None,
+    session_id: str | None = None,
+    workspace_id: str | None = None,
+    worker_id: str | None = None,
     status: str = 'queued',
-    sendgrid_message_id: Optional[str] = None,
-    error: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
-    tenant_id: Optional[str] = None,
-) -> Optional[str]:
-    """
-    Log an outbound email to the database.
+    sendgrid_message_id: str | None = None,
+    error: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    tenant_id: str | None = None,
+) -> str | None:
+    """Log an outbound email to the database.
 
     Args:
         to_email: Recipient email address
@@ -3393,12 +3402,11 @@ async def db_log_outbound_email(
 
 async def db_update_outbound_email(
     email_id: str,
-    status: Optional[str] = None,
-    sendgrid_message_id: Optional[str] = None,
-    error: Optional[str] = None,
+    status: str | None = None,
+    sendgrid_message_id: str | None = None,
+    error: str | None = None,
 ) -> bool:
-    """
-    Update an outbound email record after sending.
+    """Update an outbound email record after sending.
 
     Args:
         email_id: The email record ID
@@ -3449,14 +3457,13 @@ async def db_update_outbound_email(
 
 
 async def db_list_inbound_emails(
-    session_id: Optional[str] = None,
-    from_email: Optional[str] = None,
-    status: Optional[str] = None,
+    session_id: str | None = None,
+    from_email: str | None = None,
+    status: str | None = None,
     limit: int = 50,
     offset: int = 0,
-) -> List[Dict[str, Any]]:
-    """
-    List inbound emails with optional filtering.
+) -> list[dict[str, Any]]:
+    """List inbound emails with optional filtering.
 
     Args:
         session_id: Filter by session ID
@@ -3513,15 +3520,14 @@ async def db_list_inbound_emails(
 
 
 async def db_list_outbound_emails(
-    task_id: Optional[str] = None,
-    session_id: Optional[str] = None,
-    to_email: Optional[str] = None,
-    status: Optional[str] = None,
+    task_id: str | None = None,
+    session_id: str | None = None,
+    to_email: str | None = None,
+    status: str | None = None,
     limit: int = 50,
     offset: int = 0,
-) -> List[Dict[str, Any]]:
-    """
-    List outbound emails with optional filtering.
+) -> list[dict[str, Any]]:
+    """List outbound emails with optional filtering.
 
     Args:
         task_id: Filter by task ID
@@ -3591,7 +3597,7 @@ async def db_list_outbound_emails(
 async def db_upsert_prd_chat_session(
     workspace_id: str,
     session_id: str,
-    title: Optional[str] = None,
+    title: str | None = None,
 ) -> bool:
     """Upsert a PRD chat session link."""
     pool = await get_pool()
@@ -3619,7 +3625,7 @@ async def db_upsert_prd_chat_session(
 
 async def db_list_prd_chat_sessions(
     workspace_id: str, limit: int = 50
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """List PRD chat sessions for a workspace."""
     pool = await get_pool()
     if not pool:
@@ -3652,16 +3658,15 @@ async def db_list_prd_chat_sessions(
 
 async def db_create_ralph_run(
     run_id: str,
-    prd: Dict[str, Any],
-    workspace_id: Optional[str] = None,
-    model: Optional[str] = None,
+    prd: dict[str, Any],
+    workspace_id: str | None = None,
+    model: str | None = None,
     max_iterations: int = 10,
     run_mode: str = 'sequential',
     max_parallel: int = 3,
-    tenant_id: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
-    """
-    Create a new Ralph run in the database.
+    tenant_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Create a new Ralph run in the database.
 
     Args:
         run_id: Unique run identifier
@@ -3725,9 +3730,8 @@ async def db_create_ralph_run(
         return None
 
 
-async def db_get_ralph_run(run_id: str) -> Optional[Dict[str, Any]]:
-    """
-    Get a Ralph run by ID.
+async def db_get_ralph_run(run_id: str) -> dict[str, Any] | None:
+    """Get a Ralph run by ID.
 
     Args:
         run_id: Run ID to retrieve
@@ -3775,16 +3779,15 @@ async def db_get_ralph_run(run_id: str) -> Optional[Dict[str, Any]]:
 
 async def db_update_ralph_run(
     run_id: str,
-    status: Optional[str] = None,
-    current_iteration: Optional[int] = None,
-    story_results: Optional[List[Dict[str, Any]]] = None,
-    logs: Optional[List[Dict[str, Any]]] = None,
-    error: Optional[str] = None,
-    started_at: Optional[datetime] = None,
-    completed_at: Optional[datetime] = None,
-) -> Optional[Dict[str, Any]]:
-    """
-    Update a Ralph run.
+    status: str | None = None,
+    current_iteration: int | None = None,
+    story_results: list[dict[str, Any]] | None = None,
+    logs: list[dict[str, Any]] | None = None,
+    error: str | None = None,
+    started_at: datetime | None = None,
+    completed_at: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Update a Ralph run.
 
     Args:
         run_id: Run ID to update
@@ -3887,14 +3890,13 @@ async def db_update_ralph_run(
 
 
 async def db_list_ralph_runs(
-    status: Optional[str] = None,
-    workspace_id: Optional[str] = None,
-    tenant_id: Optional[str] = None,
+    status: str | None = None,
+    workspace_id: str | None = None,
+    tenant_id: str | None = None,
     limit: int = 50,
     offset: int = 0,
-) -> List[Dict[str, Any]]:
-    """
-    List Ralph runs with optional filtering.
+) -> list[dict[str, Any]]:
+    """List Ralph runs with optional filtering.
 
     Args:
         status: Filter by status
@@ -3973,8 +3975,7 @@ async def db_list_ralph_runs(
 
 
 async def db_delete_ralph_run(run_id: str) -> bool:
-    """
-    Delete a Ralph run.
+    """Delete a Ralph run.
 
     Args:
         run_id: Run ID to delete
@@ -4002,10 +4003,9 @@ async def db_add_ralph_log(
     run_id: str,
     log_type: str,
     message: str,
-    story_id: Optional[str] = None,
+    story_id: str | None = None,
 ) -> bool:
-    """
-    Add a log entry to a Ralph run.
+    """Add a log entry to a Ralph run.
 
     Args:
         run_id: Run ID
@@ -4049,11 +4049,12 @@ async def db_add_ralph_log(
 # Worker Profiles CRUD
 # ---------------------------------------------------------------------------
 
+
 async def db_list_worker_profiles(
-    tenant_id: Optional[str] = None,
-    user_id: Optional[str] = None,
+    tenant_id: str | None = None,
+    user_id: str | None = None,
     builtin_only: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """List worker profiles visible to the caller.
 
     Returns builtin profiles + tenant/user-owned custom profiles.
@@ -4080,9 +4081,9 @@ async def db_list_worker_profiles(
                 parts.append(f'user_id = ${idx}')
                 params.append(user_id)
                 idx += 1
-            clauses.append(f"({' OR '.join(parts)})")
+            clauses.append(f'({" OR ".join(parts)})')
 
-        where = f"WHERE {' AND '.join(clauses)}" if clauses else ''
+        where = f'WHERE {" AND ".join(clauses)}' if clauses else ''
         query = f'SELECT * FROM worker_profiles {where} ORDER BY is_builtin DESC, name ASC'
 
         async with pool.acquire() as conn:
@@ -4093,7 +4094,7 @@ async def db_list_worker_profiles(
         return []
 
 
-async def db_get_worker_profile(profile_id: str) -> Optional[Dict[str, Any]]:
+async def db_get_worker_profile(profile_id: str) -> dict[str, Any] | None:
     """Get a single worker profile by ID or slug."""
     pool = await get_pool()
     if not pool:
@@ -4111,7 +4112,9 @@ async def db_get_worker_profile(profile_id: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-async def db_create_worker_profile(profile: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+async def db_create_worker_profile(
+    profile: dict[str, Any],
+) -> dict[str, Any] | None:
     """Create a new worker profile. Returns the created row."""
     pool = await get_pool()
     if not pool:
@@ -4151,8 +4154,8 @@ async def db_create_worker_profile(profile: Dict[str, Any]) -> Optional[Dict[str
 
 
 async def db_update_worker_profile(
-    profile_id: str, updates: Dict[str, Any]
-) -> Optional[Dict[str, Any]]:
+    profile_id: str, updates: dict[str, Any]
+) -> dict[str, Any] | None:
     """Update a worker profile. Returns the updated row.
 
     Cannot update builtin profiles except for non-critical fields.
@@ -4162,9 +4165,16 @@ async def db_update_worker_profile(
         return None
 
     allowed_fields = {
-        'name', 'slug', 'description', 'system_prompt',
-        'default_capabilities', 'default_model_tier', 'default_model_ref',
-        'default_agent_type', 'icon', 'color',
+        'name',
+        'slug',
+        'description',
+        'system_prompt',
+        'default_capabilities',
+        'default_model_tier',
+        'default_model_ref',
+        'default_agent_type',
+        'icon',
+        'color',
     }
 
     set_parts = []
@@ -4175,7 +4185,9 @@ async def db_update_worker_profile(
         if field not in allowed_fields:
             continue
         if field == 'default_capabilities':
-            value = json.dumps(value) if isinstance(value, (list, dict)) else value
+            value = (
+                json.dumps(value) if isinstance(value, (list, dict)) else value
+            )
         set_parts.append(f'{field} = ${idx}')
         params.append(value)
         idx += 1
@@ -4224,7 +4236,7 @@ async def db_delete_worker_profile(profile_id: str) -> bool:
         return False
 
 
-async def db_set_worker_profile(worker_id: str, profile_id: Optional[str]) -> bool:
+async def db_set_worker_profile(worker_id: str, profile_id: str | None) -> bool:
     """Assign (or clear) a profile on a worker."""
     pool = await get_pool()
     if not pool:

--- a/a2a_server/database.py
+++ b/a2a_server/database.py
@@ -49,6 +49,10 @@ _initialized = False
 # RLS is enabled by default for multi-tenant isolation.
 RLS_ENABLED = os.environ.get('RLS_ENABLED', 'true').lower() == 'true'
 RLS_STRICT_MODE = os.environ.get('RLS_STRICT_MODE', 'false').lower() == 'true'
+SCHEMA_INIT_ON_STARTUP = (
+    os.environ.get('A2A_SCHEMA_INIT_ON_STARTUP', 'true').lower()
+    not in {'0', 'false', 'no'}
+)
 
 
 def _parse_timestamp(value: Union[str, datetime, None]) -> Optional[datetime]:
@@ -100,7 +104,12 @@ async def get_pool():
 
             # Initialize schema if needed
             if not _initialized:
-                await _init_schema()
+                if SCHEMA_INIT_ON_STARTUP:
+                    await _init_schema()
+                else:
+                    logger.info(
+                        'Skipping PostgreSQL schema initialization on startup'
+                    )
                 _initialized = True
 
             # Initialize task queue for hosted workers

--- a/a2a_server/github_app/issue_clone_task.py
+++ b/a2a_server/github_app/issue_clone_task.py
@@ -5,6 +5,7 @@ from .issue_prompt import issue_fix_prompt
 from .routing import resolve_task_target
 from .settings import MODEL_REF
 
+
 DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
 
@@ -18,7 +19,7 @@ async def create_issue_clone_task(
     github_issue_url: str = '',
     github_installation_id: int = 0,
     github_check_head_sha: str = '',
-) -> str:
+) -> tuple[str, bool]:
     """Queue the branch preparation task for an issue fix request.
 
     Dispatches as fire-and-forget with a 7-day timeout so the persistent
@@ -26,6 +27,10 @@ async def create_issue_clone_task(
 
     The github_issue_url is propagated into the clone and follow-up build
     task metadata so the progress reporter can post periodic comments.
+
+    Returns ``(task_id, created)``. ``created`` is False when an active task
+    for the same issue/commit/stage was reused (e.g. a redelivered or
+    duplicate webhook), so the caller can skip a duplicate acceptance comment.
     """
     from ..persistent_worker_pool import create_and_dispatch_task
 
@@ -88,4 +93,5 @@ async def create_issue_clone_task(
         metadata=metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
         github_issue_url=github_issue_url,
+        with_created=True,
     )

--- a/a2a_server/github_app/issue_review_task.py
+++ b/a2a_server/github_app/issue_review_task.py
@@ -7,11 +7,13 @@ import json
 import logging
 import re
 import uuid
+
 from typing import Any
 
 from ..provenance import verify_provenance
 from .routing import resolve_task_target
 from .settings import AUTO_MERGE_ENABLED, MERGE_METHOD, MODEL_REF, get_secret
+
 
 logger = logging.getLogger(__name__)
 
@@ -1079,7 +1081,9 @@ async def ensure_pull_request_approval_review(
 
     if marker:
         try:
-            existing_reviews = await github_json('GET', reviews_path, review_token)
+            existing_reviews = await github_json(
+                'GET', reviews_path, review_token
+            )
             if isinstance(existing_reviews, list):
                 for review in existing_reviews:
                     body = str((review or {}).get('body') or '')
@@ -1102,7 +1106,10 @@ async def ensure_pull_request_approval_review(
         payload['commit_id'] = current_sha
 
     return await github_json(
-        'POST', f'/repos/{repo}/pulls/{pr_number}/reviews', review_token, payload
+        'POST',
+        f'/repos/{repo}/pulls/{pr_number}/reviews',
+        review_token,
+        payload,
     )
 
 

--- a/a2a_server/github_app/issue_review_task.py
+++ b/a2a_server/github_app/issue_review_task.py
@@ -10,7 +10,8 @@ import uuid
 from typing import Any
 
 from ..provenance import verify_provenance
-from .settings import AUTO_MERGE_ENABLED, MERGE_METHOD, MODEL_REF
+from .routing import resolve_task_target
+from .settings import AUTO_MERGE_ENABLED, MERGE_METHOD, MODEL_REF, get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -619,6 +620,7 @@ async def create_fix_followup_task(
         'fix_followup': 'true',
         'fix_attempt': attempt,
     }
+    fix_metadata.update(await resolve_task_target())
     # Propagate parent_task_id from the review task metadata chain
     parent_task_id = metadata.get('parent_task_id')
     if parent_task_id:
@@ -1023,6 +1025,87 @@ If every gate passes, merge the PR using the repository's normal merge method. I
 Final response must state MERGED or BLOCKED, plus the PR URL and policy-gate summary."""
 
 
+def approval_review_marker(task_id: str) -> str:
+    """Return the idempotency marker for a server-submitted PR approval."""
+    return f'codetether-review-task: {task_id}'
+
+
+def approval_review_body(
+    review_task: dict[str, Any], provenance: dict[str, Any]
+) -> str:
+    """Render the GitHub PR review body for a completed CodeTether approval."""
+    task_id = str(review_task.get('id') or '').strip()
+    result = str(review_task.get('result') or '').strip()
+    body = (
+        'CodeTether reviewer task approved this PR after checking the issue '
+        'Definition of Done and validation evidence.'
+    )
+    if result:
+        body += f'\n\nReviewer summary:\n\n{_truncate_for_comment(result, limit=3000)}'
+    body += provenance_footer(provenance, action='github:review_pr')
+    if task_id:
+        body += f'\n\n{approval_review_marker(task_id)}'
+    return body
+
+
+async def approval_review_token(default_token: str) -> str:
+    """Return a distinct reviewer token when configured, otherwise the app token."""
+    token = await get_secret(
+        'approval_token',
+        'GITHUB_APP_APPROVAL_TOKEN',
+        'approval_token',
+        'github_approval_token',
+        'github_review_approval_token',
+    )
+    return token or default_token
+
+
+async def ensure_pull_request_approval_review(
+    *,
+    repo: str,
+    pr_number: int,
+    current_sha: str,
+    review_task: dict[str, Any],
+    provenance: dict[str, Any],
+    token: str,
+) -> dict[str, Any] | None:
+    """Submit the actual GitHub approving review required by branch protection."""
+    from .auth import github_json
+
+    review_token = await approval_review_token(token)
+    task_id = str(review_task.get('id') or '').strip()
+    marker = approval_review_marker(task_id) if task_id else ''
+    reviews_path = f'/repos/{repo}/pulls/{pr_number}/reviews?per_page=100'
+
+    if marker:
+        try:
+            existing_reviews = await github_json('GET', reviews_path, review_token)
+            if isinstance(existing_reviews, list):
+                for review in existing_reviews:
+                    body = str((review or {}).get('body') or '')
+                    state = str((review or {}).get('state') or '').upper()
+                    if marker in body and state == 'APPROVED':
+                        return review
+        except Exception as exc:
+            logger.warning(
+                'approval_review: could not list existing reviews for %s#%s: %s',
+                repo,
+                pr_number,
+                exc,
+            )
+
+    payload: dict[str, Any] = {
+        'event': 'APPROVE',
+        'body': approval_review_body(review_task, provenance),
+    }
+    if current_sha:
+        payload['commit_id'] = current_sha
+
+    return await github_json(
+        'POST', f'/repos/{repo}/pulls/{pr_number}/reviews', review_token, payload
+    )
+
+
 async def create_issue_review_task(
     *,
     workspace_id: str,
@@ -1075,11 +1158,13 @@ async def create_issue_review_task(
             'agent_type': 'merge',
         },
     }
+    metadata.update(await resolve_task_target())
     task_id = await create_and_dispatch_task(
         workspace_id=workspace_id,
         title=f'Review issue PR #{pr.get("number")}',
         prompt=review_prompt(repo, issue_number, branch, pr, provenance),
         agent_type='review',
+        priority=50,
         model_ref=MODEL_REF,
         metadata=metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
@@ -1178,6 +1263,32 @@ async def create_issue_merge_task(
         )
         return None
 
+    try:
+        await ensure_pull_request_approval_review(
+            repo=repo,
+            pr_number=pr_number,
+            current_sha=current_sha,
+            review_task=review_task,
+            provenance=provenance,
+            token=token,
+        )
+    except Exception as exc:
+        failures = [f'GitHub approving review could not be submitted: {exc}']
+        await record_automation_decision(
+            provenance=provenance,
+            decision=_failure_decision('github:merge_pr', failures),
+            task_id=parent_task_id,
+        )
+        await post_issue_comment(
+            repo,
+            pr_number,
+            token,
+            '## 🛠️ CodeTether Auto-Merge\n\n'
+            'Blocked because CodeTether could not submit the approving PR review required by branch protection.\n\n'
+            f'{_format_blockers(failures)}',
+        )
+        return None
+
     feedback_status = await review_feedback_status(repo, pr_number, token)
     if not feedback_status['feedback_addressed']:
         failures = list(
@@ -1233,6 +1344,7 @@ async def create_issue_merge_task(
             'pr_head_sha': current_sha,
         }
     )
+    merge_metadata.update(await resolve_task_target())
 
     if AUTO_MERGE_ENABLED:
         repo_info = await github_json('GET', f'/repos/{repo}', token)
@@ -1331,6 +1443,7 @@ async def create_issue_merge_task(
         title=f'Merge issue PR #{pr_number}',
         prompt=merge_prompt(repo, issue_number, branch, pr, provenance),
         agent_type='merge',
+        priority=100,
         model_ref=MODEL_REF,
         metadata=merge_metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,

--- a/a2a_server/github_app/rudder_incidents.py
+++ b/a2a_server/github_app/rudder_incidents.py
@@ -7,6 +7,8 @@ mints a short-lived installation token, and creates or updates GitHub issues.
 
 from __future__ import annotations
 
+import hashlib
+import re
 from datetime import datetime, timezone
 from typing import Any, Optional
 from urllib.parse import quote
@@ -21,6 +23,27 @@ rudder_incident_router = APIRouter(
     prefix="/v1/integrations/rudder",
     tags=["rudder-incidents"],
 )
+
+_ASSIGNMENT_ID_RE = re.compile(
+    r"(?i)\b("
+    r"advertiser|advertiser_id|customer|customer_id|campaign|campaign_id|"
+    r"adgroup|adgroup_id|ad_group|ad_group_id|account|account_id|task|"
+    r"task_id|request|request_id|trace|trace_id|span|span_id|run|run_id|"
+    r"job|job_id|execution|execution_id"
+    r")\s*(=|:)\s*['\"]?[\w./:-]+['\"]?"
+)
+_NOUN_ID_RE = re.compile(
+    r"(?i)\b("
+    r"advertiser|customer|campaign|adgroup|ad group|account|task|request|"
+    r"trace|span|run|job|execution"
+    r")\s+[\w.-]*\d{6,}[\w.-]*\b"
+)
+_UUID_RE = re.compile(
+    r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"
+)
+_LONG_HEX_RE = re.compile(r"(?i)\b[0-9a-f]{16,}\b")
+_LONG_NUMBER_RE = re.compile(r"\b\d{6,}\b")
+_WHITESPACE_RE = re.compile(r"\s+")
 
 
 class RudderIncidentPolicy(BaseModel):
@@ -55,9 +78,52 @@ def _issue_title(incident: RudderIncidentRequest) -> str:
     return f"[{incident.severity.upper()}] {scope}: {reason}"[:240]
 
 
+def _normalize_incident_text(value: str | None) -> str:
+    """Collapse volatile ids while keeping the useful error shape."""
+    text = (value or "").strip().lower()
+    if not text:
+        return ""
+    text = _UUID_RE.sub("<uuid>", text)
+    text = _ASSIGNMENT_ID_RE.sub(lambda match: f"{match.group(1).lower()}=<id>", text)
+    text = _NOUN_ID_RE.sub(lambda match: f"{match.group(1).lower()} <id>", text)
+    text = _LONG_HEX_RE.sub("<hex>", text)
+    text = _LONG_NUMBER_RE.sub("<num>", text)
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _incident_group_fingerprint(incident: RudderIncidentRequest) -> str:
+    identity = [
+        incident.severity.lower().strip(),
+        incident.namespace.lower().strip(),
+        (incident.release or "").lower().strip(),
+        (incident.workload or "").lower().strip(),
+        (incident.container or "").lower().strip(),
+        (incident.reason or "").lower().strip(),
+        _normalize_incident_text(incident.message),
+        _normalize_incident_text(incident.log_excerpt),
+    ]
+    digest = hashlib.sha256("\n".join(identity).encode("utf-8")).hexdigest()[:16]
+    return f"sha256:{digest}"
+
+
+def _stable_message_phrase(incident: RudderIncidentRequest) -> str:
+    text = (incident.message or incident.log_excerpt or "").strip()
+    if ":" in text:
+        text = text.rsplit(":", 1)[-1]
+    text = re.sub(r"\([^)]*\)", " ", text)
+    text = _ASSIGNMENT_ID_RE.sub(" ", text)
+    text = _NOUN_ID_RE.sub(" ", text)
+    text = _UUID_RE.sub(" ", text)
+    text = _LONG_HEX_RE.sub(" ", text)
+    text = _LONG_NUMBER_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text).strip(" -:;,.")
+    return text[:120]
+
+
 def _issue_body(incident: RudderIncidentRequest) -> str:
     labels = ", ".join(incident.labels) if incident.labels else "none"
     excerpt = (incident.log_excerpt or incident.message).strip()[:12000]
+    group_fingerprint = _incident_group_fingerprint(incident)
     return f"""## Rudder Kubernetes runtime incident
 
 {incident.message}
@@ -80,19 +146,60 @@ def _issue_body(incident: RudderIncidentRequest) -> str:
 {excerpt}
 ```
 
-## Dedupe fingerprint
+## Dedupe fingerprints
+
+`rudder-log-group: {group_fingerprint}`
 
 `rudder-log-fingerprint: {incident.fingerprint}`
 
+<!-- rudder-log-group: {group_fingerprint} -->
 <!-- rudder-log-fingerprint: {incident.fingerprint} -->
 """
 
 
-async def _find_existing_issue(repo: str, fingerprint: str, token: str) -> Optional[dict[str, Any]]:
-    query = quote(f'repo:{repo} is:issue is:open "rudder-log-fingerprint: {fingerprint}"')
-    result = await github_json("GET", f"/search/issues?q={query}", token)
+async def _search_first_issue(query: str, token: str) -> Optional[dict[str, Any]]:
+    result = await github_json(
+        "GET",
+        f"/search/issues?q={quote(query)}&sort=updated&order=desc",
+        token,
+    )
     items = result.get("items") or []
     return items[0] if items else None
+
+
+async def _find_existing_issue(
+    repo: str, incident: RudderIncidentRequest, token: str
+) -> Optional[dict[str, Any]]:
+    exact = await _search_first_issue(
+        f'repo:{repo} is:issue is:open "rudder-log-fingerprint: {incident.fingerprint}"',
+        token,
+    )
+    if exact:
+        return exact
+
+    group_fingerprint = _incident_group_fingerprint(incident)
+    grouped = await _search_first_issue(
+        f'repo:{repo} is:issue is:open "rudder-log-group: {group_fingerprint}"',
+        token,
+    )
+    if grouped:
+        return grouped
+
+    phrase = _stable_message_phrase(incident)
+    if len(phrase) >= 12:
+        fallback = await _search_first_issue(
+            f'repo:{repo} is:issue is:open in:title "{_issue_title(incident)}" '
+            f'label:rudder label:k8s-log-error "{phrase}"',
+            token,
+        )
+        if fallback:
+            return fallback
+
+    return await _search_first_issue(
+        f'repo:{repo} is:issue is:open in:title "{_issue_title(incident)}" '
+        'label:rudder label:k8s-log-error',
+        token,
+    )
 
 
 @rudder_incident_router.post("/log-incidents")
@@ -106,7 +213,8 @@ async def reconcile_log_incident(request: Request, incident: RudderIncidentReque
     verify_auth(request)
 
     token, expires_at = await installation_token(incident.installation_id)
-    existing = await _find_existing_issue(incident.repo, incident.fingerprint, token)
+    group_fingerprint = _incident_group_fingerprint(incident)
+    existing = await _find_existing_issue(incident.repo, incident, token)
     body = _issue_body(incident)
 
     if existing and incident.policy.update_existing:
@@ -121,6 +229,7 @@ async def reconcile_log_incident(request: Request, incident: RudderIncidentReque
             "action": "updated_existing_issue",
             "issue_number": issue_number,
             "issue_url": existing.get("html_url"),
+            "dedupe_group": group_fingerprint,
             "token_expires_at": expires_at,
         }
 
@@ -130,6 +239,7 @@ async def reconcile_log_incident(request: Request, incident: RudderIncidentReque
             "title": _issue_title(incident),
             "body": body,
             "existing_issue_url": existing.get("html_url") if existing else None,
+            "dedupe_group": group_fingerprint,
             "token_expires_at": expires_at,
         }
 
@@ -144,5 +254,6 @@ async def reconcile_log_incident(request: Request, incident: RudderIncidentReque
         "action": "created_issue",
         "issue_number": created.get("number"),
         "issue_url": created.get("html_url"),
+        "dedupe_group": group_fingerprint,
         "token_expires_at": expires_at,
     }

--- a/a2a_server/github_app/rudder_incidents.py
+++ b/a2a_server/github_app/rudder_incidents.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import hashlib
 import re
-from datetime import datetime, timezone
-from typing import Any, Optional
+
+from datetime import UTC, datetime
+from typing import Any
 from urllib.parse import quote
 
 from fastapi import APIRouter, Request
@@ -19,31 +20,32 @@ from pydantic import BaseModel, Field
 from ..worker_auth import verify_auth
 from .auth import github_json, installation_token
 
+
 rudder_incident_router = APIRouter(
-    prefix="/v1/integrations/rudder",
-    tags=["rudder-incidents"],
+    prefix='/v1/integrations/rudder',
+    tags=['rudder-incidents'],
 )
 
 _ASSIGNMENT_ID_RE = re.compile(
-    r"(?i)\b("
-    r"advertiser|advertiser_id|customer|customer_id|campaign|campaign_id|"
-    r"adgroup|adgroup_id|ad_group|ad_group_id|account|account_id|task|"
-    r"task_id|request|request_id|trace|trace_id|span|span_id|run|run_id|"
-    r"job|job_id|execution|execution_id"
+    r'(?i)\b('
+    r'advertiser|advertiser_id|customer|customer_id|campaign|campaign_id|'
+    r'adgroup|adgroup_id|ad_group|ad_group_id|account|account_id|task|'
+    r'task_id|request|request_id|trace|trace_id|span|span_id|run|run_id|'
+    r'job|job_id|execution|execution_id'
     r")\s*(=|:)\s*['\"]?[\w./:-]+['\"]?"
 )
 _NOUN_ID_RE = re.compile(
-    r"(?i)\b("
-    r"advertiser|customer|campaign|adgroup|ad group|account|task|request|"
-    r"trace|span|run|job|execution"
-    r")\s+[\w.-]*\d{6,}[\w.-]*\b"
+    r'(?i)\b('
+    r'advertiser|customer|campaign|adgroup|ad group|account|task|request|'
+    r'trace|span|run|job|execution'
+    r')\s+[\w.-]*\d{6,}[\w.-]*\b'
 )
 _UUID_RE = re.compile(
-    r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"
+    r'(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b'
 )
-_LONG_HEX_RE = re.compile(r"(?i)\b[0-9a-f]{16,}\b")
-_LONG_NUMBER_RE = re.compile(r"\b\d{6,}\b")
-_WHITESPACE_RE = re.compile(r"\s+")
+_LONG_HEX_RE = re.compile(r'(?i)\b[0-9a-f]{16,}\b')
+_LONG_NUMBER_RE = re.compile(r'\b\d{6,}\b')
+_WHITESPACE_RE = re.compile(r'\s+')
 
 
 class RudderIncidentPolicy(BaseModel):
@@ -52,76 +54,80 @@ class RudderIncidentPolicy(BaseModel):
 
 
 class RudderIncidentRequest(BaseModel):
-    repo: str = Field(..., description="GitHub repository in owner/name form")
-    installation_id: int = Field(..., description="GitHub App installation id")
+    repo: str = Field(..., description='GitHub repository in owner/name form')
+    installation_id: int = Field(..., description='GitHub App installation id')
     fingerprint: str
-    severity: str = Field(default="error")
+    severity: str = Field(default='error')
     namespace: str
-    release: Optional[str] = None
-    workload: Optional[str] = None
-    pod: Optional[str] = None
-    container: Optional[str] = None
-    reason: Optional[str] = None
+    release: str | None = None
+    workload: str | None = None
+    pod: str | None = None
+    container: str | None = None
+    reason: str | None = None
     message: str
-    log_excerpt: Optional[str] = None
+    log_excerpt: str | None = None
     labels: list[str] = Field(default_factory=list)
     policy: RudderIncidentPolicy = Field(default_factory=RudderIncidentPolicy)
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def _issue_title(incident: RudderIncidentRequest) -> str:
     scope = incident.release or incident.workload or incident.namespace
     reason = incident.reason or incident.severity
-    return f"[{incident.severity.upper()}] {scope}: {reason}"[:240]
+    return f'[{incident.severity.upper()}] {scope}: {reason}'[:240]
 
 
 def _normalize_incident_text(value: str | None) -> str:
     """Collapse volatile ids while keeping the useful error shape."""
-    text = (value or "").strip().lower()
+    text = (value or '').strip().lower()
     if not text:
-        return ""
-    text = _UUID_RE.sub("<uuid>", text)
-    text = _ASSIGNMENT_ID_RE.sub(lambda match: f"{match.group(1).lower()}=<id>", text)
-    text = _NOUN_ID_RE.sub(lambda match: f"{match.group(1).lower()} <id>", text)
-    text = _LONG_HEX_RE.sub("<hex>", text)
-    text = _LONG_NUMBER_RE.sub("<num>", text)
-    return _WHITESPACE_RE.sub(" ", text).strip()
+        return ''
+    text = _UUID_RE.sub('<uuid>', text)
+    text = _ASSIGNMENT_ID_RE.sub(
+        lambda match: f'{match.group(1).lower()}=<id>', text
+    )
+    text = _NOUN_ID_RE.sub(lambda match: f'{match.group(1).lower()} <id>', text)
+    text = _LONG_HEX_RE.sub('<hex>', text)
+    text = _LONG_NUMBER_RE.sub('<num>', text)
+    return _WHITESPACE_RE.sub(' ', text).strip()
 
 
 def _incident_group_fingerprint(incident: RudderIncidentRequest) -> str:
     identity = [
         incident.severity.lower().strip(),
         incident.namespace.lower().strip(),
-        (incident.release or "").lower().strip(),
-        (incident.workload or "").lower().strip(),
-        (incident.container or "").lower().strip(),
-        (incident.reason or "").lower().strip(),
+        (incident.release or '').lower().strip(),
+        (incident.workload or '').lower().strip(),
+        (incident.container or '').lower().strip(),
+        (incident.reason or '').lower().strip(),
         _normalize_incident_text(incident.message),
         _normalize_incident_text(incident.log_excerpt),
     ]
-    digest = hashlib.sha256("\n".join(identity).encode("utf-8")).hexdigest()[:16]
-    return f"sha256:{digest}"
+    digest = hashlib.sha256('\n'.join(identity).encode('utf-8')).hexdigest()[
+        :16
+    ]
+    return f'sha256:{digest}'
 
 
 def _stable_message_phrase(incident: RudderIncidentRequest) -> str:
-    text = (incident.message or incident.log_excerpt or "").strip()
-    if ":" in text:
-        text = text.rsplit(":", 1)[-1]
-    text = re.sub(r"\([^)]*\)", " ", text)
-    text = _ASSIGNMENT_ID_RE.sub(" ", text)
-    text = _NOUN_ID_RE.sub(" ", text)
-    text = _UUID_RE.sub(" ", text)
-    text = _LONG_HEX_RE.sub(" ", text)
-    text = _LONG_NUMBER_RE.sub(" ", text)
-    text = _WHITESPACE_RE.sub(" ", text).strip(" -:;,.")
+    text = (incident.message or incident.log_excerpt or '').strip()
+    if ':' in text:
+        text = text.rsplit(':', 1)[-1]
+    text = re.sub(r'\([^)]*\)', ' ', text)
+    text = _ASSIGNMENT_ID_RE.sub(' ', text)
+    text = _NOUN_ID_RE.sub(' ', text)
+    text = _UUID_RE.sub(' ', text)
+    text = _LONG_HEX_RE.sub(' ', text)
+    text = _LONG_NUMBER_RE.sub(' ', text)
+    text = _WHITESPACE_RE.sub(' ', text).strip(' -:;,.')
     return text[:120]
 
 
 def _issue_body(incident: RudderIncidentRequest) -> str:
-    labels = ", ".join(incident.labels) if incident.labels else "none"
+    labels = ', '.join(incident.labels) if incident.labels else 'none'
     excerpt = (incident.log_excerpt or incident.message).strip()[:12000]
     group_fingerprint = _incident_group_fingerprint(incident)
     return f"""## Rudder Kubernetes runtime incident
@@ -157,19 +163,19 @@ def _issue_body(incident: RudderIncidentRequest) -> str:
 """
 
 
-async def _search_first_issue(query: str, token: str) -> Optional[dict[str, Any]]:
+async def _search_first_issue(query: str, token: str) -> dict[str, Any] | None:
     result = await github_json(
-        "GET",
-        f"/search/issues?q={quote(query)}&sort=updated&order=desc",
+        'GET',
+        f'/search/issues?q={quote(query)}&sort=updated&order=desc',
         token,
     )
-    items = result.get("items") or []
+    items = result.get('items') or []
     return items[0] if items else None
 
 
 async def _find_existing_issue(
     repo: str, incident: RudderIncidentRequest, token: str
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     exact = await _search_first_issue(
         f'repo:{repo} is:issue is:open "rudder-log-fingerprint: {incident.fingerprint}"',
         token,
@@ -202,8 +208,10 @@ async def _find_existing_issue(
     )
 
 
-@rudder_incident_router.post("/log-incidents")
-async def reconcile_log_incident(request: Request, incident: RudderIncidentRequest) -> dict[str, Any]:
+@rudder_incident_router.post('/log-incidents')
+async def reconcile_log_incident(
+    request: Request, incident: RudderIncidentRequest
+) -> dict[str, Any]:
     """Create or update a GitHub issue for a sanitized Rudder LogIncident.
 
     Authentication uses the existing worker auth helper. If A2A_AUTH_TOKENS is
@@ -218,42 +226,48 @@ async def reconcile_log_incident(request: Request, incident: RudderIncidentReque
     body = _issue_body(incident)
 
     if existing and incident.policy.update_existing:
-        issue_number = int(existing["number"])
+        issue_number = int(existing['number'])
         await github_json(
-            "POST",
-            f"/repos/{incident.repo}/issues/{issue_number}/comments",
+            'POST',
+            f'/repos/{incident.repo}/issues/{issue_number}/comments',
             token,
-            {"body": body[:65000]},
+            {'body': body[:65000]},
         )
         return {
-            "action": "updated_existing_issue",
-            "issue_number": issue_number,
-            "issue_url": existing.get("html_url"),
-            "dedupe_group": group_fingerprint,
-            "token_expires_at": expires_at,
+            'action': 'updated_existing_issue',
+            'issue_number': issue_number,
+            'issue_url': existing.get('html_url'),
+            'dedupe_group': group_fingerprint,
+            'token_expires_at': expires_at,
         }
 
     if not incident.policy.auto_create:
         return {
-            "action": "drafted",
-            "title": _issue_title(incident),
-            "body": body,
-            "existing_issue_url": existing.get("html_url") if existing else None,
-            "dedupe_group": group_fingerprint,
-            "token_expires_at": expires_at,
+            'action': 'drafted',
+            'title': _issue_title(incident),
+            'body': body,
+            'existing_issue_url': existing.get('html_url')
+            if existing
+            else None,
+            'dedupe_group': group_fingerprint,
+            'token_expires_at': expires_at,
         }
 
-    labels = sorted(set(["rudder", "k8s-log-error", *incident.labels]))
+    labels = sorted(set(['rudder', 'k8s-log-error', *incident.labels]))
     created = await github_json(
-        "POST",
-        f"/repos/{incident.repo}/issues",
+        'POST',
+        f'/repos/{incident.repo}/issues',
         token,
-        {"title": _issue_title(incident), "body": body[:65000], "labels": labels},
+        {
+            'title': _issue_title(incident),
+            'body': body[:65000],
+            'labels': labels,
+        },
     )
     return {
-        "action": "created_issue",
-        "issue_number": created.get("number"),
-        "issue_url": created.get("html_url"),
-        "dedupe_group": group_fingerprint,
-        "token_expires_at": expires_at,
+        'action': 'created_issue',
+        'issue_number': created.get('number'),
+        'issue_url': created.get('html_url'),
+        'dedupe_group': group_fingerprint,
+        'token_expires_at': expires_at,
     }

--- a/a2a_server/github_app/webhook/idempotency.py
+++ b/a2a_server/github_app/webhook/idempotency.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # Deliveries older than this are pruned opportunistically. GitHub retries
 # within ~hours, so a few days is more than enough.
-_RETENTION = "7 days"
+_RETENTION = '7 days'
 
 
 async def _ensure_table(conn) -> None:
@@ -77,7 +77,7 @@ async def claim_delivery(delivery_id: str, event_name: str = '') -> bool:
             if won:
                 # Opportunistic prune of stale rows; cheap at low volume.
                 await conn.execute(
-                    "DELETE FROM github_webhook_deliveries "
+                    'DELETE FROM github_webhook_deliveries '
                     f"WHERE claimed_at < NOW() - INTERVAL '{_RETENTION}'"
                 )
             else:

--- a/a2a_server/github_app/webhook/idempotency.py
+++ b/a2a_server/github_app/webhook/idempotency.py
@@ -1,0 +1,96 @@
+"""Cross-replica idempotency gate for GitHub webhook deliveries.
+
+GitHub redelivers webhooks when the endpoint is slow or returns a non-2xx
+status, and multiple worker replicas may receive the same delivery. Without a
+claim, each delivery runs ``handle_fix_request`` and posts a duplicate
+"Picked up this request" comment.
+
+This module provides an atomic, single-winner claim keyed on the
+``X-GitHub-Delivery`` header. The first caller to ``claim_delivery`` for a
+given delivery ID wins (returns ``True``); concurrent/repeat callers lose
+(return ``False``) and the router short-circuits before any dispatch.
+
+The claim is backed by Postgres ``INSERT ... ON CONFLICT DO NOTHING`` so it is
+correct across replicas. If the database is unavailable we fail open (allow
+the event) so a transient DB outage never silently drops real work.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+# Deliveries older than this are pruned opportunistically. GitHub retries
+# within ~hours, so a few days is more than enough.
+_RETENTION = "7 days"
+
+
+async def _ensure_table(conn) -> None:
+    await conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS github_webhook_deliveries (
+            delivery_id TEXT PRIMARY KEY,
+            event_name  TEXT,
+            claimed_at  TIMESTAMPTZ DEFAULT NOW()
+        )
+        """
+    )
+
+
+async def claim_delivery(delivery_id: str, event_name: str = '') -> bool:
+    """Atomically claim a webhook delivery. Returns True for the single winner.
+
+    - Returns ``True`` exactly once per ``delivery_id`` (the caller that should
+      process the event).
+    - Returns ``False`` for repeat/concurrent deliveries of the same id.
+    - Fails open (``True``) when no delivery id is present or the DB is
+      unavailable, so we never drop genuine first-time events.
+    """
+    if not delivery_id:
+        # No delivery header (e.g. internal dispatch or test) — can't dedupe,
+        # so allow it through rather than blocking real work.
+        return True
+    try:
+        # Imported lazily to avoid a circular import with the database layer
+        # (same pattern as ``active_work.has_active_github_app_task``).
+        from a2a_server import database as db  # noqa: PLC0415
+
+        pool = await db.get_pool()
+        if not pool:
+            return True
+
+        async with pool.acquire() as conn:
+            await _ensure_table(conn)
+            row = await conn.fetchrow(
+                """
+                INSERT INTO github_webhook_deliveries (delivery_id, event_name)
+                VALUES ($1, $2)
+                ON CONFLICT (delivery_id) DO NOTHING
+                RETURNING delivery_id
+                """,
+                delivery_id,
+                event_name,
+            )
+            won = row is not None
+            if won:
+                # Opportunistic prune of stale rows; cheap at low volume.
+                await conn.execute(
+                    "DELETE FROM github_webhook_deliveries "
+                    f"WHERE claimed_at < NOW() - INTERVAL '{_RETENTION}'"
+                )
+            else:
+                logger.info(
+                    'duplicate webhook delivery ignored id=%s event=%s',
+                    delivery_id,
+                    event_name,
+                )
+            return won
+    except Exception as exc:  # pragma: no cover - defensive fail-open
+        logger.warning(
+            'idempotency claim failed (failing open) id=%s: %s',
+            delivery_id,
+            exc,
+        )
+        return True

--- a/a2a_server/github_app/workspace.py
+++ b/a2a_server/github_app/workspace.py
@@ -15,7 +15,9 @@ DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
 def workspace_id(git_url: str, git_branch: str) -> str:
     """Derive the deterministic branch-scoped workspace ID."""
-    return hashlib.sha256(f'{git_url}::{git_branch or "main"}'.encode()).hexdigest()[:16]
+    return hashlib.sha256(
+        f'{git_url}::{git_branch or "main"}'.encode()
+    ).hexdigest()[:16]
 
 
 def checkout_branch(context: MentionContext, pr: dict[str, Any]) -> str:
@@ -31,9 +33,40 @@ async def ensure_workspace(context: MentionContext, pr: dict[str, Any]) -> str:
     git_url = pr['head']['repo']['clone_url']
     branch_name = pr['head']['ref']
     git_branch = checkout_branch(context, pr)
-    app_id = await get_secret('app_id', 'GITHUB_APP_ID', 'app_id', 'github_app_id')
+    app_id = await get_secret(
+        'app_id', 'GITHUB_APP_ID', 'app_id', 'github_app_id'
+    )
     wid = workspace_id(git_url, git_branch)
-    workspace = {'id': wid, 'name': context.repo_full_name, 'path': f'/var/lib/codetether/repos/{wid}', 'description': f'GitHub App workspace for {context.repo_full_name}', 'git_url': git_url, 'git_branch': git_branch, 'status': 'active', 'agent_config': {'source': 'github-app', 'repo': {'full_name': context.repo_full_name}, 'github': {'repo_full_name': context.repo_full_name, 'pull_request_number': context.pr_number, 'branch_name': branch_name}, 'git_auth': {'github_app': {'app_id': app_id, 'installation_id': str(context.installation_id)}}}, 'git_auth': {'github_app': {'app_id': app_id, 'installation_id': str(context.installation_id)}}}
+    workspace = {
+        'id': wid,
+        'name': context.repo_full_name,
+        'path': f'/var/lib/codetether/repos/{wid}',
+        'description': f'GitHub App workspace for {context.repo_full_name}',
+        'git_url': git_url,
+        'git_branch': git_branch,
+        'status': 'active',
+        'agent_config': {
+            'source': 'github-app',
+            'repo': {'full_name': context.repo_full_name},
+            'github': {
+                'repo_full_name': context.repo_full_name,
+                'pull_request_number': context.pr_number,
+                'branch_name': branch_name,
+            },
+            'git_auth': {
+                'github_app': {
+                    'app_id': app_id,
+                    'installation_id': str(context.installation_id),
+                }
+            },
+        },
+        'git_auth': {
+            'github_app': {
+                'app_id': app_id,
+                'installation_id': str(context.installation_id),
+            }
+        },
+    }
     await db.db_upsert_workspace(workspace)
     await _redis_upsert_workspace_meta(workspace)
     return wid

--- a/a2a_server/github_app/workspace.py
+++ b/a2a_server/github_app/workspace.py
@@ -1,11 +1,14 @@
 """Workspace and clone-task helpers for GitHub App comment execution."""
 
 import hashlib
+
 from typing import Any
 
 from .context import MentionContext
-from .prompt import fix_prompt; from .routing import resolve_task_target
+from .prompt import fix_prompt
+from .routing import resolve_task_target
 from .settings import MODEL_REF, get_secret
+
 
 DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
@@ -43,7 +46,7 @@ async def create_clone_task(
     *,
     github_issue_url: str = '',
     github_installation_id: int = 0,
-) -> str:
+) -> tuple[str, bool]:
     """Queue a targeted clone/refresh task for the PR branch.
 
     Dispatches as fire-and-forget with a 7-day timeout so the persistent
@@ -52,6 +55,10 @@ async def create_clone_task(
     The github_issue_url is stored in the clone task's post_clone_task metadata
     so it propagates to the follow-up build task, enabling the progress reporter
     to post periodic comments on the GitHub issue/PR.
+
+    Returns ``(task_id, created)``. ``created`` is False when an active task for
+    the same PR/commit/stage was reused (e.g. a redelivered or duplicate
+    webhook), so the caller can skip posting another acceptance comment.
     """
     from ..persistent_worker_pool import create_and_dispatch_task
 
@@ -102,4 +109,5 @@ async def create_clone_task(
         metadata=metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
         github_issue_url=github_issue_url,
+        with_created=True,
     )

--- a/a2a_server/monitor_api.py
+++ b/a2a_server/monitor_api.py
@@ -151,19 +151,60 @@ class AgentTaskResponse(BaseModel):
 
 def _task_metadata(task: Dict[str, Any]) -> Dict[str, Any]:
     metadata = task.get('metadata') or {}
-    if isinstance(metadata, str):
+    # Some legacy rows accidentally stored JSON as a JSON string. Decode a
+    # bounded number of times so routing fields such as required_capabilities
+    # are still honored by worker polling filters.
+    for _ in range(2):
+        if not isinstance(metadata, str):
+            break
         try:
             parsed = json.loads(metadata)
         except json.JSONDecodeError:
             return {}
-        return parsed if isinstance(parsed, dict) else {}
+        metadata = parsed
     return metadata if isinstance(metadata, dict) else {}
+
+
+def _normalize_task_capabilities(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            parsed = [value]
+        value = parsed
+    if not isinstance(value, list):
+        return []
+    return [str(cap).strip() for cap in value if str(cap).strip()]
+
+
+def _worker_satisfies_required_capabilities(
+    worker_capabilities: Optional[list[str]],
+    required_capabilities: list[str],
+) -> bool:
+    if not required_capabilities:
+        return True
+    if not worker_capabilities:
+        return False
+    worker_caps = set(worker_capabilities)
+    aliases = {
+        'persistent': {'persistent', 'persistent-workspace', 'persistent_workspace', 'harvester'},
+        'persistent-workspace': {'persistent-workspace', 'persistent_workspace', 'persistent', 'harvester'},
+        'persistent_workspace': {'persistent-workspace', 'persistent_workspace', 'persistent', 'harvester'},
+    }
+    for required in required_capabilities:
+        accepted = aliases.get(required, {required})
+        if not worker_caps.intersection(accepted):
+            return False
+    return True
 
 
 def _pending_task_visible_to_worker(
     task: Dict[str, Any],
     worker_id: Optional[str],
     agent_name: Optional[str],
+    worker_capabilities: Optional[list[str]] = None,
 ) -> bool:
     """Hide targeted pending tasks from legacy pollers that cannot claim them."""
     metadata = _task_metadata(task)
@@ -180,21 +221,35 @@ def _pending_task_visible_to_worker(
     ):
         return False
 
+    required_capabilities = _normalize_task_capabilities(
+        task.get('required_capabilities') or metadata.get('required_capabilities')
+    )
+    if not _worker_satisfies_required_capabilities(
+        worker_capabilities, required_capabilities
+    ):
+        return False
+
     return True
 
 
-async def _active_worker_id_for_agent_name(
+async def _active_worker_for_agent_name(
     agent_name: Optional[str],
-) -> Optional[str]:
+) -> Optional[Dict[str, Any]]:
     """Resolve legacy poll requests that identify the worker by agent_name only."""
     if not agent_name:
         return None
     try:
         worker = await db.db_get_active_worker_by_name(agent_name)
     except Exception as e:
-        logger.debug(f'Failed to resolve worker id for agent {agent_name}: {e}')
+        logger.debug(f'Failed to resolve worker for agent {agent_name}: {e}')
         return None
+    return worker if isinstance(worker, dict) else None
 
+
+async def _active_worker_id_for_agent_name(
+    agent_name: Optional[str],
+) -> Optional[str]:
+    worker = await _active_worker_for_agent_name(agent_name)
     if worker:
         worker_id = str(worker.get('worker_id') or '').strip()
         if worker_id:
@@ -4538,10 +4593,17 @@ async def list_all_tasks(
             from .worker_sse import get_worker_registry
 
             visible_worker_id = worker_id
-            if not visible_worker_id and agent_name:
-                visible_worker_id = await _active_worker_id_for_agent_name(
-                    agent_name
-                )
+            worker_capabilities: list[str] = []
+            if agent_name:
+                active_worker = await _active_worker_for_agent_name(agent_name)
+                if active_worker:
+                    if not visible_worker_id:
+                        visible_worker_id = str(
+                            active_worker.get('worker_id') or ''
+                        ).strip() or None
+                    worker_capabilities = _normalize_task_capabilities(
+                        active_worker.get('capabilities')
+                    )
 
             claimed = await get_worker_registry().claimed_task_ids()
             if claimed:
@@ -4557,6 +4619,7 @@ async def list_all_tasks(
                     task,
                     worker_id=visible_worker_id,
                     agent_name=agent_name,
+                    worker_capabilities=worker_capabilities,
                 )
             ]
         except Exception as e:

--- a/a2a_server/monitor_api.py
+++ b/a2a_server/monitor_api.py
@@ -1,5 +1,4 @@
-"""
-Monitoring API endpoints for A2A Server.
+"""Monitoring API endpoints for A2A Server.
 
 Provides real-time monitoring, logging, and human intervention capabilities.
 Supports multiple storage backends:
@@ -11,29 +10,29 @@ Supports multiple storage backends:
 """
 
 import asyncio
+import io
 import json
 import logging
 import os
 import sqlite3
 import threading
 import uuid
-from typing import List, Dict, Any, Optional, Literal
-from datetime import datetime, timezone, timedelta
+
 from collections import deque
-from dataclasses import dataclass, asdict
-from fastapi import APIRouter, HTTPException, Request, Depends, Security
-from fastapi.responses import (
-    StreamingResponse,
-    HTMLResponse,
-    FileResponse,
-    JSONResponse,
-)
-from pydantic import BaseModel
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-import os
-import io
-import tempfile
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
 from functools import lru_cache
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Security
+from fastapi.responses import (
+    FileResponse,
+    HTMLResponse,
+    JSONResponse,
+    StreamingResponse,
+)
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
 
 # Import PostgreSQL persistence layer
 from . import database as db
@@ -43,13 +42,16 @@ from .git_service import (
     issue_git_credentials,
     store_git_credential_record,
 )
-from .task_routing import target_agent_mismatch
 from .task_orchestration import orchestrate_task_route
+from .task_routing import target_agent_mismatch
+
 
 try:
     from .vm_workspace_provisioner import (
         VMWorkspaceSpec,
         vm_workspace_provisioner,
+    )
+    from .vm_workspace_provisioner import (
         is_enabled as is_vm_workspaces_enabled,
     )
 except ModuleNotFoundError:
@@ -114,10 +116,10 @@ class MonitorMessage:
     type: str  # agent, human, system, tool, error
     agent_name: str
     content: str
-    metadata: Dict[str, Any]
-    response_time: Optional[float] = None
-    tokens: Optional[int] = None
-    error: Optional[str] = None
+    metadata: dict[str, Any]
+    response_time: float | None = None
+    tokens: int | None = None
+    error: str | None = None
 
 
 class InterventionRequest(BaseModel):
@@ -132,24 +134,24 @@ class AgentTaskResponse(BaseModel):
     """Response model for an agent task."""
 
     id: str
-    workspace_id: Optional[str] = None
+    workspace_id: str | None = None
     title: str
     prompt: str
     agent_type: str = 'build'
-    model: Optional[str] = None
+    model: str | None = None
     status: str
     priority: int = 0
     created_at: str
-    started_at: Optional[str] = None
-    completed_at: Optional[str] = None
-    result: Optional[str] = None
-    error: Optional[str] = None
-    session_id: Optional[str] = None
-    metadata: Dict[str, Any] = {}
-    target_agent_name: Optional[str] = None
+    started_at: str | None = None
+    completed_at: str | None = None
+    result: str | None = None
+    error: str | None = None
+    session_id: str | None = None
+    metadata: dict[str, Any] = {}
+    target_agent_name: str | None = None
 
 
-def _task_metadata(task: Dict[str, Any]) -> Dict[str, Any]:
+def _task_metadata(task: dict[str, Any]) -> dict[str, Any]:
     metadata = task.get('metadata') or {}
     # Some legacy rows accidentally stored JSON as a JSON string. Decode a
     # bounded number of times so routing fields such as required_capabilities
@@ -180,7 +182,7 @@ def _normalize_task_capabilities(value: Any) -> list[str]:
 
 
 def _worker_satisfies_required_capabilities(
-    worker_capabilities: Optional[list[str]],
+    worker_capabilities: list[str] | None,
     required_capabilities: list[str],
 ) -> bool:
     if not required_capabilities:
@@ -189,9 +191,24 @@ def _worker_satisfies_required_capabilities(
         return False
     worker_caps = set(worker_capabilities)
     aliases = {
-        'persistent': {'persistent', 'persistent-workspace', 'persistent_workspace', 'harvester'},
-        'persistent-workspace': {'persistent-workspace', 'persistent_workspace', 'persistent', 'harvester'},
-        'persistent_workspace': {'persistent-workspace', 'persistent_workspace', 'persistent', 'harvester'},
+        'persistent': {
+            'persistent',
+            'persistent-workspace',
+            'persistent_workspace',
+            'harvester',
+        },
+        'persistent-workspace': {
+            'persistent-workspace',
+            'persistent_workspace',
+            'persistent',
+            'harvester',
+        },
+        'persistent_workspace': {
+            'persistent-workspace',
+            'persistent_workspace',
+            'persistent',
+            'harvester',
+        },
     }
     for required in required_capabilities:
         accepted = aliases.get(required, {required})
@@ -201,10 +218,10 @@ def _worker_satisfies_required_capabilities(
 
 
 def _pending_task_visible_to_worker(
-    task: Dict[str, Any],
-    worker_id: Optional[str],
-    agent_name: Optional[str],
-    worker_capabilities: Optional[list[str]] = None,
+    task: dict[str, Any],
+    worker_id: str | None,
+    agent_name: str | None,
+    worker_capabilities: list[str] | None = None,
 ) -> bool:
     """Hide targeted pending tasks from legacy pollers that cannot claim them."""
     metadata = _task_metadata(task)
@@ -222,7 +239,8 @@ def _pending_task_visible_to_worker(
         return False
 
     required_capabilities = _normalize_task_capabilities(
-        task.get('required_capabilities') or metadata.get('required_capabilities')
+        task.get('required_capabilities')
+        or metadata.get('required_capabilities')
     )
     if not _worker_satisfies_required_capabilities(
         worker_capabilities, required_capabilities
@@ -233,8 +251,8 @@ def _pending_task_visible_to_worker(
 
 
 async def _active_worker_for_agent_name(
-    agent_name: Optional[str],
-) -> Optional[Dict[str, Any]]:
+    agent_name: str | None,
+) -> dict[str, Any] | None:
     """Resolve legacy poll requests that identify the worker by agent_name only."""
     if not agent_name:
         return None
@@ -247,8 +265,8 @@ async def _active_worker_for_agent_name(
 
 
 async def _active_worker_id_for_agent_name(
-    agent_name: Optional[str],
-) -> Optional[str]:
+    agent_name: str | None,
+) -> str | None:
     worker = await _active_worker_for_agent_name(agent_name)
     if worker:
         worker_id = str(worker.get('worker_id') or '').strip()
@@ -260,7 +278,7 @@ async def _active_worker_id_for_agent_name(
 class PersistentMessageStore:
     """SQLite-based persistent storage for monitor messages with fallback to in-memory."""
 
-    def __init__(self, db_path: Optional[str] = None):
+    def __init__(self, db_path: str | None = None):
         self.db_path = db_path or DEFAULT_DB_PATH
         self._local = threading.local()
         self._use_sqlite = (
@@ -387,7 +405,7 @@ class PersistentMessageStore:
         except Exception as e:
             logger.debug(f'No existing MinIO data to load: {e}')
 
-    def _save_to_minio(self, message_dict: Dict[str, Any]):
+    def _save_to_minio(self, message_dict: dict[str, Any]):
         """Save a message to MinIO storage."""
         if not self._minio_client:
             return
@@ -605,12 +623,12 @@ class PersistentMessageStore:
     def _get_messages_from_memory(
         self,
         limit: int = 100,
-        message_type: Optional[str] = None,
-        agent_name: Optional[str] = None,
-        conversation_id: Optional[str] = None,
-        since: Optional[datetime] = None,
+        message_type: str | None = None,
+        agent_name: str | None = None,
+        conversation_id: str | None = None,
+        since: datetime | None = None,
         offset: int = 0,
-    ) -> List[MonitorMessage]:
+    ) -> list[MonitorMessage]:
         """Return messages from the in-memory cache (used for MinIO and in-memory fallback)."""
 
         def _parse_ts(value: Any) -> datetime:
@@ -623,7 +641,7 @@ class PersistentMessageStore:
                     return datetime.min
             return datetime.min
 
-        def _get_metadata(m: Dict[str, Any]) -> Dict[str, Any]:
+        def _get_metadata(m: dict[str, Any]) -> dict[str, Any]:
             md = m.get('metadata')
             return md if isinstance(md, dict) else {}
 
@@ -658,7 +676,7 @@ class PersistentMessageStore:
         # Apply pagination
         page = raw[offset : offset + limit]
 
-        result: List[MonitorMessage] = []
+        result: list[MonitorMessage] = []
         for m in page:
             result.append(
                 MonitorMessage(
@@ -680,12 +698,12 @@ class PersistentMessageStore:
     def get_messages(
         self,
         limit: int = 100,
-        message_type: Optional[str] = None,
-        agent_name: Optional[str] = None,
-        conversation_id: Optional[str] = None,
-        since: Optional[datetime] = None,
+        message_type: str | None = None,
+        agent_name: str | None = None,
+        conversation_id: str | None = None,
+        since: datetime | None = None,
         offset: int = 0,
-    ) -> List[MonitorMessage]:
+    ) -> list[MonitorMessage]:
         """Get messages with optional filtering."""
         # For MinIO-backed deployments, reads come from the in-memory cache.
         # (MinIO is used as the persistence layer, and the cache is populated on init and on writes.)
@@ -747,7 +765,7 @@ class PersistentMessageStore:
 
         return messages
 
-    def get_message_count(self, message_type: Optional[str] = None) -> int:
+    def get_message_count(self, message_type: str | None = None) -> int:
         """Get total message count."""
         # For MinIO (and in-memory fallback), counts are tracked in-memory.
         if not self._use_sqlite:
@@ -806,7 +824,7 @@ class PersistentMessageStore:
 
         conn.commit()
 
-    def get_interventions(self, limit: int = 100) -> List[Dict]:
+    def get_interventions(self, limit: int = 100) -> list[dict]:
         """Get recent interventions."""
         if not self._use_sqlite:
             return list(self._in_memory_interventions)[-limit:]
@@ -826,7 +844,7 @@ class PersistentMessageStore:
 
         return [dict(row) for row in cursor.fetchall()]
 
-    def get_stats(self) -> Dict[str, int]:
+    def get_stats(self) -> dict[str, int]:
         """Get aggregate statistics."""
         # For MinIO (and in-memory fallback), stats are tracked in-memory.
         if not self._use_sqlite:
@@ -848,7 +866,7 @@ class PersistentMessageStore:
 
     def search_messages(
         self, query: str, limit: int = 100
-    ) -> List[MonitorMessage]:
+    ) -> list[MonitorMessage]:
         """Full-text search in message content."""
         # For MinIO (and in-memory fallback), search the in-memory cache.
         if not self._use_sqlite:
@@ -918,7 +936,7 @@ class PersistentMessageStore:
 class MonitoringService:
     """Service for monitoring agent conversations and enabling human intervention."""
 
-    def __init__(self, db_path: Optional[str] = None):
+    def __init__(self, db_path: str | None = None):
         # Persistent storage
         self.store = PersistentMessageStore(db_path)
 
@@ -947,10 +965,10 @@ class MonitoringService:
         agent_name: str,
         content: str,
         message_type: str = 'agent',
-        metadata: Optional[Dict[str, Any]] = None,
-        response_time: Optional[float] = None,
-        tokens: Optional[int] = None,
-        error: Optional[str] = None,
+        metadata: dict[str, Any] | None = None,
+        response_time: float | None = None,
+        tokens: int | None = None,
+        error: str | None = None,
     ):
         """Log a message from an agent or system."""
         message = MonitorMessage(
@@ -1002,10 +1020,9 @@ class MonitoringService:
         for queue in self.subscribers:
             try:
                 await queue.put(f'data: {message_json}\n\n')
-                logger.debug(f'Message queued successfully')
+                logger.debug('Message queued successfully')
             except Exception as e:
                 logger.error(f'Failed to send to subscriber: {e}')
-                pass
 
     async def broadcast_agent_status(self, agent_id: str, agent_data: dict):
         """Broadcast agent status update to all SSE subscribers."""
@@ -1080,9 +1097,9 @@ class MonitoringService:
     def get_messages(
         self,
         limit: int = 100,
-        message_type: Optional[str] = None,
+        message_type: str | None = None,
         use_cache: bool = True,
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """Get recent messages."""
         if use_cache and limit <= 1000:
             # Use in-memory cache for fast access
@@ -1090,14 +1107,13 @@ class MonitoringService:
             if message_type:
                 messages = [m for m in messages if m.type == message_type]
             return [asdict(m) for m in messages[-limit:]]
-        else:
-            # Query persistent storage for larger requests
-            messages = self.store.get_messages(
-                limit=limit, message_type=message_type
-            )
-            return [asdict(m) for m in messages]
+        # Query persistent storage for larger requests
+        messages = self.store.get_messages(
+            limit=limit, message_type=message_type
+        )
+        return [asdict(m) for m in messages]
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get monitoring statistics."""
         # Get persistent stats
         db_stats = self.store.get_stats()
@@ -1119,7 +1135,7 @@ class MonitoringService:
             'interventions': db_stats.get('interventions', 0),
         }
 
-    def search_messages(self, query: str, limit: int = 100) -> List[Dict]:
+    def search_messages(self, query: str, limit: int = 100) -> list[dict]:
         """Search messages by content, agent name, or metadata."""
         messages = self.store.search_messages(query, limit)
         return [asdict(m) for m in messages]
@@ -1202,9 +1218,9 @@ async def monitor_stream(request: Request):
                         f'Sending message to SSE client: {message[:100]}'
                     )
                     yield message
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     # Send heartbeat on timeout
-                    yield f': heartbeat\n\n'
+                    yield ': heartbeat\n\n'
                 except asyncio.CancelledError:
                     logger.info('SSE stream cancelled')
                     break
@@ -1236,7 +1252,7 @@ async def get_active_agents():
 
 @monitor_router.get('/messages')
 async def get_messages(
-    limit: int = 100, type: Optional[str] = None, use_cache: bool = True
+    limit: int = 100, type: str | None = None, use_cache: bool = True
 ):
     """Get recent messages. Set use_cache=false to query all persistent logs."""
     return monitoring_service.get_messages(
@@ -1255,7 +1271,7 @@ async def search_messages(q: str, limit: int = 100):
 
 
 @monitor_router.get('/messages/count')
-async def get_message_count(type: Optional[str] = None):
+async def get_message_count(type: str | None = None):
     """Get total message count from persistent storage."""
     return {
         'total': monitoring_service.store.get_message_count(type),
@@ -1265,9 +1281,9 @@ async def get_message_count(type: Optional[str] = None):
 
 @monitor_router.get('/workers')
 async def monitor_list_workers(
-    search: Optional[str] = None,
+    search: str | None = None,
     online_only: bool = False,
-    exclude_offline_hours: Optional[int] = 24,
+    exclude_offline_hours: int | None = 24,
 ):
     """Proxy to /v1/agent/workers for backward compatibility."""
     return await list_workers(
@@ -1359,11 +1375,11 @@ async def export_csv(limit: int = 10000, all_messages: bool = False):
 _agent_bridge = None
 
 # Worker-synced session data: {workspace_id: [session_dicts]}
-_worker_sessions: Dict[str, List[Dict[str, Any]]] = {}
+_worker_sessions: dict[str, list[dict[str, Any]]] = {}
 # Worker-synced messages: {session_id: [message_dicts]}
-_worker_messages: Dict[str, List[Dict[str, Any]]] = {}
+_worker_messages: dict[str, list[dict[str, Any]]] = {}
 # Real-time task output streams: {task_id: [output_lines]}
-_task_output_streams: Dict[str, List[Dict[str, Any]]] = {}
+_task_output_streams: dict[str, list[dict[str, Any]]] = {}
 
 # Optional Redis backing store for worker-synced sessions/messages.
 #
@@ -1433,8 +1449,8 @@ def _redis_key_worker_messages(session_id: str) -> str:
 
 async def _append_worker_message(
     session_id: str,
-    message: Dict[str, Any],
-    worker_id: Optional[str] = None,
+    message: dict[str, Any],
+    worker_id: str | None = None,
 ) -> None:
     """Append a message to the worker-synced store (memory + Redis)."""
     existing = _worker_messages.get(session_id, [])
@@ -1445,7 +1461,7 @@ async def _append_worker_message(
         return
 
     try:
-        payload: Dict[str, Any] = {}
+        payload: dict[str, Any] = {}
         raw = await client.get(_redis_key_worker_messages(session_id))
         if raw:
             payload = json.loads(raw) if isinstance(raw, str) else {}
@@ -1488,7 +1504,7 @@ def _redis_key_workspace_meta(workspace_id: str) -> str:
     return f'a2a:agent:workspaces:{workspace_id}:meta'
 
 
-async def _redis_upsert_worker(worker_info: Dict[str, Any]) -> None:
+async def _redis_upsert_worker(worker_info: dict[str, Any]) -> None:
     """Best-effort: mirror worker registry to Redis so all replicas can list it."""
     client = await _get_redis_client()
     if not client:
@@ -1517,7 +1533,7 @@ async def _redis_delete_worker(worker_id: str) -> None:
         logger.debug(f'Failed to delete worker from Redis: {e}')
 
 
-async def _redis_list_workers() -> List[Dict[str, Any]]:
+async def _redis_list_workers() -> list[dict[str, Any]]:
     client = await _get_redis_client()
     if not client:
         return []
@@ -1530,7 +1546,7 @@ async def _redis_list_workers() -> List[Dict[str, Any]]:
         keys = [_redis_key_worker(wid) for wid in worker_ids]
         raw_items = await client.mget(keys)
 
-        workers: List[Dict[str, Any]] = []
+        workers: list[dict[str, Any]] = []
         for raw in raw_items:
             if not raw:
                 continue
@@ -1544,7 +1560,7 @@ async def _redis_list_workers() -> List[Dict[str, Any]]:
         return []
 
 
-async def _redis_get_worker(worker_id: str) -> Optional[Dict[str, Any]]:
+async def _redis_get_worker(worker_id: str) -> dict[str, Any] | None:
     client = await _get_redis_client()
     if not client:
         return None
@@ -1559,7 +1575,7 @@ async def _redis_get_worker(worker_id: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-async def _redis_upsert_workspace_meta(workspace: Dict[str, Any]) -> None:
+async def _redis_upsert_workspace_meta(workspace: dict[str, Any]) -> None:
     """Best-effort: mirror workspace registry to Redis for multi-replica setups."""
     client = await _get_redis_client()
     if not client:
@@ -1590,7 +1606,7 @@ async def _redis_delete_workspace_meta(workspace_id: str) -> None:
         logger.debug(f'Failed to delete workspace meta from Redis: {e}')
 
 
-async def _redis_list_workspace_meta() -> List[Dict[str, Any]]:
+async def _redis_list_workspace_meta() -> list[dict[str, Any]]:
     client = await _get_redis_client()
     if not client:
         return []
@@ -1603,7 +1619,7 @@ async def _redis_list_workspace_meta() -> List[Dict[str, Any]]:
         keys = [_redis_key_workspace_meta(cid) for cid in workspace_ids]
         raw_items = await client.mget(keys)
 
-        workspaces: List[Dict[str, Any]] = []
+        workspaces: list[dict[str, Any]] = []
         for raw in raw_items:
             if not raw:
                 continue
@@ -1619,7 +1635,7 @@ async def _redis_list_workspace_meta() -> List[Dict[str, Any]]:
 
 async def _redis_get_workspace_meta(
     workspace_id: str,
-) -> Optional[Dict[str, Any]]:
+) -> dict[str, Any] | None:
     client = await _get_redis_client()
     if not client:
         return None
@@ -1675,10 +1691,7 @@ def get_agent_bridge():
 
             # Set up SSE worker notification hook for task updates
             try:
-                from .worker_sse import (
-                    get_worker_registry,
-                    notify_workers_of_new_task,
-                )
+                from .worker_sse import notify_workers_of_new_task
 
                 async def _on_task_update(task):
                     """Notify SSE-connected workers when a task is created/updated."""
@@ -1759,7 +1772,7 @@ async def _rehydrate_workspace_into_bridge(workspace_id: str):
     if existing is not None:
         return existing
 
-    meta: Optional[Dict[str, Any]] = None
+    meta: dict[str, Any] | None = None
     try:
         meta = await _redis_get_workspace_meta(workspace_id)
     except Exception:
@@ -1802,8 +1815,8 @@ async def _rehydrate_workspace_into_bridge(workspace_id: str):
 
 
 def _extract_workspace_runtime_meta(
-    workspace: Optional[Dict[str, Any]],
-) -> Dict[str, Any]:
+    workspace: dict[str, Any] | None,
+) -> dict[str, Any]:
     """Extract runtime metadata from a workspace dict."""
     if not isinstance(workspace, dict):
         return {'runtime': 'container'}
@@ -1857,26 +1870,26 @@ class WorkspaceRegistration(BaseModel):
     """Request model for registering a workspace."""
 
     name: str
-    workspace_id: Optional[str] = None
+    workspace_id: str | None = None
     path: str = ''  # Can be empty when git_url is provided
     description: str = ''
-    agent_config: Dict[str, Any] = {}
-    worker_id: Optional[str] = None  # Associate with a specific worker
-    git_url: Optional[str] = None  # HTTPS Git URL to clone
-    git_branch: Optional[str] = None
-    git_token: Optional[str] = None  # Access token (stored in Vault, not DB)
-    git_auth: Optional[GitAuthConfig] = None
+    agent_config: dict[str, Any] = {}
+    worker_id: str | None = None  # Associate with a specific worker
+    git_url: str | None = None  # HTTPS Git URL to clone
+    git_branch: str | None = None
+    git_token: str | None = None  # Access token (stored in Vault, not DB)
+    git_auth: GitAuthConfig | None = None
     runtime: Literal['container', 'vm'] = 'container'
-    vm: Optional[Dict[str, Any]] = None
+    vm: dict[str, Any] | None = None
 
 
 class GitCredentialRequest(BaseModel):
     """Request model for worker-issued git credentials."""
 
     operation: str = 'get'
-    protocol: Optional[str] = None
-    host: Optional[str] = None
-    path: Optional[str] = None
+    protocol: str | None = None
+    host: str | None = None
+    path: str | None = None
 
 
 class AgentTrigger(BaseModel):
@@ -1884,19 +1897,19 @@ class AgentTrigger(BaseModel):
 
     prompt: str
     agent: str = 'build'
-    model: Optional[str] = None
-    model_ref: Optional[str] = None
-    files: List[str] = []
-    worker_personality: Optional[str] = None
-    notify_email: Optional[str] = None
-    metadata: Dict[str, Any] = {}
+    model: str | None = None
+    model_ref: str | None = None
+    files: list[str] = []
+    worker_personality: str | None = None
+    notify_email: str | None = None
+    metadata: dict[str, Any] = {}
 
 
 class AgentMessage(BaseModel):
     """Request model for sending a message to an agent."""
 
     message: str
-    agent: Optional[str] = None
+    agent: str | None = None
 
 
 class AgentTaskCreate(BaseModel):
@@ -1906,11 +1919,11 @@ class AgentTaskCreate(BaseModel):
     prompt: str
     agent_type: str = 'build'
     priority: int = 0
-    metadata: Dict[str, Any] = {}
-    workspace_id: Optional[str] = None  # Optional: specify target workspace
-    model: Optional[str] = None  # Optional: specify model
-    model_ref: Optional[str] = None  # Optional: normalized provider:model
-    worker_personality: Optional[str] = None
+    metadata: dict[str, Any] = {}
+    workspace_id: str | None = None  # Optional: specify target workspace
+    model: str | None = None  # Optional: specify model
+    model_ref: str | None = None  # Optional: normalized provider:model
+    worker_personality: str | None = None
 
 
 class WatchModeConfig(BaseModel):
@@ -2075,8 +2088,7 @@ async def database_sessions(
     limit: int = 100,
     offset: int = 0,
 ):
-    """
-    List all sessions from PostgreSQL database.
+    """List all sessions from PostgreSQL database.
 
     Returns sessions across all workspaces, sorted by most recently updated.
     Use this endpoint for a global view of all agent sessions.
@@ -2093,8 +2105,7 @@ async def database_sessions(
 
 @agent_router_alias.get('/database/workspaces')
 async def database_workspaces():
-    """
-    List all workspaces from PostgreSQL database.
+    """List all workspaces from PostgreSQL database.
 
     Returns all registered workspaces with their worker assignments.
     """
@@ -2108,8 +2119,7 @@ async def database_workspaces():
 
 @agent_router_alias.post('/database/workspaces/deduplicate')
 async def deduplicate_workspaces():
-    """
-    Remove duplicate workspace entries, keeping the oldest (canonical) ID for each path.
+    """Remove duplicate workspace entries, keeping the oldest (canonical) ID for each path.
 
     This is useful after server restarts or when workers have created duplicate entries.
     The canonical ID is preserved to maintain consistency with existing tasks and sessions.
@@ -2129,8 +2139,7 @@ async def deduplicate_workspaces():
 
 @agent_router_alias.get('/database/workers')
 async def database_workers():
-    """
-    List all workers from PostgreSQL database.
+    """List all workers from PostgreSQL database.
 
     Returns all registered workers with their status and capabilities.
     """
@@ -2156,7 +2165,7 @@ AGENT_DATA_DIR = os.environ.get(
 AGENT_STORAGE_DIR = os.path.join(AGENT_DATA_DIR, 'storage')
 
 
-def _get_agent_storage_path() -> Optional[str]:
+def _get_agent_storage_path() -> str | None:
     """Get the Agent storage directory path if it exists."""
     if os.path.isdir(AGENT_STORAGE_DIR):
         return AGENT_STORAGE_DIR
@@ -2171,18 +2180,18 @@ def _get_agent_storage_path() -> Optional[str]:
     return None
 
 
-async def _read_json_file(filepath: str) -> Optional[Dict[str, Any]]:
+async def _read_json_file(filepath: str) -> dict[str, Any] | None:
     """Read and parse a JSON file."""
     try:
         import aiofiles
 
-        async with aiofiles.open(filepath, 'r') as f:
+        async with aiofiles.open(filepath) as f:
             content = await f.read()
             return json.loads(content)
     except ImportError:
         # Fallback to sync if aiofiles not available
         try:
-            with open(filepath, 'r') as f:
+            with open(filepath) as f:
                 return json.load(f)
         except Exception as e:
             logger.debug(f'Failed to read {filepath}: {e}')
@@ -2194,8 +2203,7 @@ async def _read_json_file(filepath: str) -> Optional[Dict[str, Any]]:
 
 @agent_router_alias.get('/runtime/status')
 async def agent_runtime_status():
-    """
-    Check if Agent runtime is available on this system.
+    """Check if Agent runtime is available on this system.
 
     Returns information about the local agent installation and storage.
     """
@@ -2245,8 +2253,7 @@ async def agent_runtime_status():
 
 @agent_router_alias.get('/runtime/projects')
 async def list_agent_projects():
-    """
-    List all Agent projects detected on this system.
+    """List all Agent projects detected on this system.
 
     Projects are identified by their git commit hash and include
     the worktree path where the project is located.
@@ -2308,12 +2315,11 @@ async def list_agent_projects():
 
 @agent_router_alias.get('/runtime/sessions')
 async def list_all_runtime_sessions(
-    project_id: Optional[str] = None,
+    project_id: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ):
-    """
-    List all Agent sessions, optionally filtered by project.
+    """List all Agent sessions, optionally filtered by project.
 
     Sessions are sorted by most recently updated first.
     Use project_id to filter sessions for a specific project.
@@ -2391,8 +2397,7 @@ async def list_all_runtime_sessions(
 
 @agent_router_alias.get('/runtime/sessions/{session_id}')
 async def get_runtime_session(session_id: str):
-    """
-    Get details for a specific agent session.
+    """Get details for a specific agent session.
 
     Returns the full session data including metadata.
     """
@@ -2444,8 +2449,7 @@ async def get_runtime_session_messages(
     limit: int = 50,
     offset: int = 0,
 ):
-    """
-    Get messages for a specific agent session.
+    """Get messages for a specific agent session.
 
     Returns the conversation history for the session.
     """
@@ -2503,11 +2507,10 @@ async def get_runtime_session_messages(
 @agent_router_alias.get('/runtime/sessions/{session_id}/parts')
 async def get_runtime_session_parts(
     session_id: str,
-    message_id: Optional[str] = None,
+    message_id: str | None = None,
     limit: int = 100,
 ):
-    """
-    Get message parts (content chunks) for a session.
+    """Get message parts (content chunks) for a session.
 
     Parts contain the actual text content, tool calls, and other
     structured data from the conversation.
@@ -2664,7 +2667,7 @@ async def list_providers():
 
     # 2. Get unique model counts per provider from workers (deduplicate by model ID)
     workers = await list_workers()
-    provider_model_ids: Dict[str, set] = {}
+    provider_model_ids: dict[str, set] = {}
     for worker in workers:
         for m in worker.get('models', []):
             pid = m.get('provider_id', '')
@@ -2696,7 +2699,7 @@ async def list_providers():
     }
 
 
-def _normalize_workspace_path(path: Optional[str]) -> Optional[str]:
+def _normalize_workspace_path(path: str | None) -> str | None:
     if not path or not isinstance(path, str):
         return None
     try:
@@ -2707,7 +2710,7 @@ def _normalize_workspace_path(path: Optional[str]) -> Optional[str]:
 
 @agent_router_alias.get('/workspaces')
 async def get_workspaces(
-    path: Optional[str] = None,
+    path: str | None = None,
     include_duplicates: bool = False,
 ):
     """Backward-compatible GET handler.
@@ -2724,20 +2727,20 @@ async def get_workspaces(
     return await list_workspaces(include_duplicates=include_duplicates)
 
 
-def _parse_iso_datetime(value: Optional[str]) -> Optional[datetime]:
+def _parse_iso_datetime(value: str | None) -> datetime | None:
     if not value or not isinstance(value, str):
         return None
     try:
         dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
         # Normalize to naive UTC for consistent comparisons/subtraction.
         if dt.tzinfo is not None:
-            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+            dt = dt.astimezone(UTC).replace(tzinfo=None)
         return dt
     except Exception:
         return None
 
 
-def _workspace_sort_key(cb: Dict[str, Any]) -> tuple:
+def _workspace_sort_key(cb: dict[str, Any]) -> tuple:
     # Prefer most recently updated, then created, then stable id
     updated = _parse_iso_datetime(cb.get('updated_at'))
     created = _parse_iso_datetime(cb.get('created_at'))
@@ -2759,7 +2762,7 @@ async def _get_active_worker_ids() -> set:
     db_workers = await db.db_list_workers()
     redis_workers = await _redis_list_workers()
 
-    merged: Dict[str, Dict[str, Any]] = {}
+    merged: dict[str, dict[str, Any]] = {}
     # Keep the freshest last_seen per worker_id
     for w in list(_registered_workers.values()) + redis_workers + db_workers:
         wid = w.get('worker_id')
@@ -2787,11 +2790,11 @@ async def _get_active_worker_ids() -> set:
 
 
 def _dedupe_workspaces_by_path(
-    workspaces: List[Dict[str, Any]],
+    workspaces: list[dict[str, Any]],
     active_worker_ids: set,
-) -> List[Dict[str, Any]]:
-    grouped: Dict[str, List[Dict[str, Any]]] = {}
-    passthrough: List[Dict[str, Any]] = []
+) -> list[dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    passthrough: list[dict[str, Any]] = []
 
     for cb in workspaces:
         path = _normalize_workspace_path(cb.get('path'))
@@ -2800,7 +2803,7 @@ def _dedupe_workspaces_by_path(
             continue
         grouped.setdefault(path, []).append(cb)
 
-    deduped: List[Dict[str, Any]] = []
+    deduped: list[dict[str, Any]] = []
 
     for path, cbs in grouped.items():
         if len(cbs) == 1:
@@ -2856,7 +2859,7 @@ async def list_workspaces(include_duplicates: bool = False):
     redis_workspaces = await _redis_list_workspace_meta()
     db_workspaces = await db.db_list_workspaces()
 
-    merged: Dict[str, Dict[str, Any]] = {}
+    merged: dict[str, dict[str, Any]] = {}
 
     # Local first (most up-to-date for this instance)
     for cb in local_workspaces:
@@ -2890,8 +2893,7 @@ async def list_workspaces(include_duplicates: bool = False):
 
 @agent_router_alias.post('/workspaces')
 async def register_workspace(registration: WorkspaceRegistration):
-    """
-    Register a new workspace for agent work.
+    """Register a new workspace for agent work.
 
     If worker_id is provided (from a worker), the workspace is registered directly
     since the worker has already validated the path exists locally.
@@ -2909,7 +2911,7 @@ async def register_workspace(registration: WorkspaceRegistration):
     # If a git_url is provided, validate it, store credentials in Vault,
     # and create a clone task for workers. The path is resolved after cloning.
     if registration.git_url and not registration.worker_id:
-        from .git_service import validate_git_url, store_git_credentials
+        from .git_service import store_git_credentials, validate_git_url
 
         if not validate_git_url(registration.git_url):
             raise HTTPException(
@@ -3148,7 +3150,7 @@ async def register_workspace(registration: WorkspaceRegistration):
                 or registration.path
             )
 
-            desired_id: Optional[str] = registration.workspace_id
+            desired_id: str | None = registration.workspace_id
             if not desired_id and registration.git_url:
                 import hashlib
 
@@ -3277,12 +3279,11 @@ async def register_workspace(registration: WorkspaceRegistration):
             'success': True,
             'pending': True,
             'task_id': task.id,
-            'message': f'Registration task created. A worker will validate the path and confirm registration.',
+            'message': 'Registration task created. A worker will validate the path and confirm registration.',
         }
-    else:
-        raise HTTPException(
-            status_code=500, detail='Failed to create registration task'
-        )
+    raise HTTPException(
+        status_code=500, detail='Failed to create registration task'
+    )
 
 
 @agent_router_alias.get('/workspaces/{workspace_id}')
@@ -3429,7 +3430,7 @@ async def unregister_workspace(workspace_id: str):
         workspace_name = redis_workspace.get('name')
 
     runtime_meta = _extract_workspace_runtime_meta(workspace_snapshot)
-    vm_cleanup_ok: Optional[bool] = None
+    vm_cleanup_ok: bool | None = None
     if runtime_meta.get('runtime') == 'vm':
         vm_cleanup_ok = await vm_workspace_provisioner.delete_workspace_vm(
             workspace_id=workspace_id,
@@ -3513,7 +3514,7 @@ async def trigger_agent(workspace_id: str, trigger: AgentTrigger):
     # Try to use the bridge's trigger_agent for Knative support
     bridge = get_agent_bridge()
     if bridge is not None:
-        from .agent_bridge import is_knative_enabled, AgentTriggerRequest
+        from .agent_bridge import AgentTriggerRequest, is_knative_enabled
 
         # If Knative is enabled, use the bridge which has Knative integration
         if is_knative_enabled():
@@ -3545,11 +3546,10 @@ async def trigger_agent(workspace_id: str, trigger: AgentTrigger):
                         'worker_personality': routing_decision.worker_personality,
                     },
                 }
-            else:
-                # Fall through to legacy path if Knative fails
-                logger.warning(
-                    f'Knative trigger failed: {response.error}, falling back to SSE workers'
-                )
+            # Fall through to legacy path if Knative fails
+            logger.warning(
+                f'Knative trigger failed: {response.error}, falling back to SSE workers'
+            )
 
     # Legacy path: Create a task in the database for SSE workers to pick up
     task_id = str(uuid.uuid4())
@@ -3754,9 +3754,9 @@ async def get_agent_status(workspace_id: str):
 def _parse_agent_output_line(
     line: str,
     task_id: str,
-    worker_id: Optional[str],
-    session_id: Optional[str],
-) -> Optional[str]:
+    worker_id: str | None,
+    session_id: str | None,
+) -> str | None:
     """Parse an agent JSON output line and return an SSE frame.
 
     Agent with --format json outputs lines like:
@@ -3881,7 +3881,7 @@ async def stream_agent_events(workspace_id: str, request: Request):
     # Workspaces to Redis for durability and multi-replica support.
     # The SSE stream must therefore not depend solely on bridge._workspaces.
     workspace_obj = bridge.get_workspace(workspace_id)
-    workspace_meta: Optional[Dict[str, Any]] = (
+    workspace_meta: dict[str, Any] | None = (
         workspace_obj.to_dict() if workspace_obj else None
     )
 
@@ -3914,7 +3914,7 @@ async def stream_agent_events(workspace_id: str, request: Request):
             import time
 
             def _format_task_result_events(
-                raw_result: Any, session_id: Optional[str] = None
+                raw_result: Any, session_id: str | None = None
             ):
                 """Yield SSE frames for a stored task result payload."""
                 try:
@@ -3957,8 +3957,8 @@ async def stream_agent_events(workspace_id: str, request: Request):
             )
 
             emitted_task_ids: set[str] = set()
-            output_cursors: Dict[str, int] = {}
-            last_task_status: Dict[str, str] = {}
+            output_cursors: dict[str, int] = {}
+            last_task_status: dict[str, str] = {}
 
             # Emit recent completed task results on initial connect.
             all_tasks = await bridge.list_tasks(codebase_id=workspace_id)
@@ -4122,7 +4122,7 @@ async def stream_agent_events(workspace_id: str, request: Request):
             )
 
             emitted_task_ids: set[str] = set()
-            output_cursors: Dict[str, int] = {}
+            output_cursors: dict[str, int] = {}
 
             keepalive_interval_s = 15.0
             poll_interval_s = 1.0
@@ -4296,8 +4296,8 @@ async def stream_agent_events_legacy(codebase_id: str, request: Request):
 
 
 def transform_agent_event(
-    event: Dict[str, Any], workspace_id: str
-) -> Optional[Dict[str, Any]]:
+    event: dict[str, Any], workspace_id: str
+) -> dict[str, Any] | None:
     """Transform agent events into UI-friendly format."""
     event_type = event.get('type', '')
     properties = event.get('properties', {})
@@ -4333,10 +4333,7 @@ def transform_agent_event(
             'part_type': part_type,
         }
 
-        if part_type == 'text':
-            result['text'] = part.get('text', '')
-            result['delta'] = delta
-        elif part_type == 'reasoning':
+        if part_type == 'text' or part_type == 'reasoning':
             result['text'] = part.get('text', '')
             result['delta'] = delta
         elif part_type == 'tool':
@@ -4426,7 +4423,7 @@ def transform_agent_event(
             'diagnostics': properties.get('diagnostics'),
         }
 
-    # Todo updates
+    # TODO updates
     if event_type == 'todo.updated':
         return {
             'event_type': 'todo',
@@ -4462,18 +4459,20 @@ async def get_session_messages(workspace_id: str, limit: int = 50):
 
     try:
         base_url = bridge._get_agent_base_url(workspace.agent_port)
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(
                 f'{base_url}/session/{workspace.session_id}/message',
                 params={'limit': limit, 'directory': workspace.path},
-            ) as resp:
-                if resp.status == 200:
-                    messages = await resp.json()
-                    return {
-                        'messages': messages,
-                        'session_id': workspace.session_id,
-                    }
-                return {'messages': [], 'error': f'Status {resp.status}'}
+            ) as resp,
+        ):
+            if resp.status == 200:
+                messages = await resp.json()
+                return {
+                    'messages': messages,
+                    'session_id': workspace.session_id,
+                }
+            return {'messages': [], 'error': f'Status {resp.status}'}
     except Exception as e:
         return {'messages': [], 'error': str(e)}
 
@@ -4484,7 +4483,7 @@ async def get_session_messages(workspace_id: str, limit: int = 50):
 
 
 def _is_recent_heartbeat(
-    heartbeat_value: Optional[str], max_age_seconds: int = 120
+    heartbeat_value: str | None, max_age_seconds: int = 120
 ) -> bool:
     """Return True when heartbeat timestamp is within max_age_seconds."""
     if not heartbeat_value:
@@ -4493,15 +4492,15 @@ def _is_recent_heartbeat(
         normalized = heartbeat_value.replace('Z', '+00:00')
         last = datetime.fromisoformat(normalized)
         if last.tzinfo is None:
-            last = last.replace(tzinfo=timezone.utc)
-        age = (datetime.now(timezone.utc) - last).total_seconds()
+            last = last.replace(tzinfo=UTC)
+        age = (datetime.now(UTC) - last).total_seconds()
         return age <= max_age_seconds
     except Exception:
         return False
 
 
 async def _validate_target_worker_is_available(
-    metadata: Dict[str, Any], *, strict: bool = False
+    metadata: dict[str, Any], *, strict: bool = False
 ) -> None:
     """Validate target worker availability for routed tasks."""
     target_worker_id = metadata.get('target_worker_id')
@@ -4555,8 +4554,6 @@ async def _validate_target_worker_is_available(
         )
 
 
-
-
 async def get_current_policy_user(request: Request) -> dict:
     """Return the OIDC/self-service/API-key user resolved by policy middleware."""
     user = getattr(request.state, 'policy_user', None)
@@ -4573,11 +4570,11 @@ async def get_current_policy_user(request: Request) -> dict:
 
 @agent_router_alias.get('/tasks')
 async def list_all_tasks(
-    workspace_id: Optional[str] = None,
-    codebase_id: Optional[str] = None,
-    status: Optional[str] = None,
-    worker_id: Optional[str] = None,
-    agent_name: Optional[str] = None,
+    workspace_id: str | None = None,
+    codebase_id: str | None = None,
+    status: str | None = None,
+    worker_id: str | None = None,
+    agent_name: str | None = None,
 ):
     """List all agent tasks, optionally filtered by workspace, status, or worker."""
     # Use database as primary source of truth for tasks
@@ -4598,9 +4595,10 @@ async def list_all_tasks(
                 active_worker = await _active_worker_for_agent_name(agent_name)
                 if active_worker:
                     if not visible_worker_id:
-                        visible_worker_id = str(
-                            active_worker.get('worker_id') or ''
-                        ).strip() or None
+                        visible_worker_id = (
+                            str(active_worker.get('worker_id') or '').strip()
+                            or None
+                        )
                     worker_capabilities = _normalize_task_capabilities(
                         active_worker.get('capabilities')
                     )
@@ -4627,11 +4625,10 @@ async def list_all_tasks(
     return tasks
 
 
-
 @agent_router_alias.get('/workflows/github-app')
 async def get_github_app_workflows(
     request: Request,
-    repos: Optional[str] = None,
+    repos: str | None = None,
     limit: int = 250,
     user: dict = Depends(get_current_policy_user),
 ):
@@ -4643,7 +4640,6 @@ async def get_github_app_workflows(
     dashboard users and authorized agents are handled consistently.
     """
     from .workflow_monitor import load_github_app_workflows
-    from .workflow_monitor import build_response as empty_workflow_response
 
     roles = set(user.get('roles') or [])
     tenant_id = (
@@ -4922,7 +4918,7 @@ async def create_agent_task(workspace_id: str, task_data: AgentTaskCreate):
 def _is_github_app_worker_post_clone_followup(
     title: str,
     agent_type: str,
-    metadata: Dict[str, Any],
+    metadata: dict[str, Any],
 ) -> bool:
     """Return true for legacy worker-created GitHub App follow-up tasks.
 
@@ -4936,13 +4932,15 @@ def _is_github_app_worker_post_clone_followup(
         return False
     if metadata.get('source') != 'github-app':
         return False
-    if not metadata.get('github_issue_url') or not metadata.get('target_worker_id'):
+    if not metadata.get('github_issue_url') or not metadata.get(
+        'target_worker_id'
+    ):
         return False
     return title.startswith(('Apply PR fix #', 'Work issue #'))
 
 
 @agent_router_alias.get('/workspaces/{workspace_id}/tasks')
-async def list_workspace_tasks(workspace_id: str, status: Optional[str] = None):
+async def list_workspace_tasks(workspace_id: str, status: str | None = None):
     """List all tasks for a specific workspace."""
     # Use database as primary source of truth for tasks
     tasks = await db.db_list_tasks(
@@ -4995,17 +4993,17 @@ async def cancel_task(task_id: str):
 class SessionResumeRequest(BaseModel):
     """Request to resume a session."""
 
-    prompt: Optional[str] = None
+    prompt: str | None = None
     agent: str = 'build'
-    model: Optional[str] = None
-    model_ref: Optional[str] = None
-    worker_personality: Optional[str] = None
+    model: str | None = None
+    model_ref: str | None = None
+    worker_personality: str | None = None
 
 
-def _session_sort_key(session: Dict[str, Any]) -> tuple:
+def _session_sort_key(session: dict[str, Any]) -> tuple:
     """Best-effort sort key across agent/worker/DB session shapes."""
 
-    def _dt(value: Any) -> Optional[datetime]:
+    def _dt(value: Any) -> datetime | None:
         normalized = _normalize_iso_timestamp(value)
         if not normalized:
             return None
@@ -5022,9 +5020,9 @@ def _session_sort_key(session: Dict[str, Any]) -> tuple:
 
 async def _merge_sessions_with_database(
     workspace_id: str,
-    sessions: List[Dict[str, Any]],
+    sessions: list[dict[str, Any]],
     limit: int = 500,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Merge durable DB sessions into a source-specific session list."""
     if not sessions:
         return sessions
@@ -5046,7 +5044,7 @@ async def _merge_sessions_with_database(
     if not persisted:
         return sessions
 
-    by_id: Dict[str, Dict[str, Any]] = {}
+    by_id: dict[str, dict[str, Any]] = {}
     for s in sessions:
         sid = s.get('id')
         if isinstance(sid, str) and sid:
@@ -5079,7 +5077,7 @@ async def list_sessions(
     workspace_id: str,
     limit: int = 50,
     offset: int = 0,
-    q: Optional[str] = None,
+    q: str | None = None,
 ):
     """List sessions for a workspace with pagination.
 
@@ -5099,12 +5097,12 @@ async def list_sessions(
         bridge.get_workspace(workspace_id) if bridge is not None else None
     )
 
-    def _session_matches_query(session: Dict[str, Any], query: str) -> bool:
+    def _session_matches_query(session: dict[str, Any], query: str) -> bool:
         needle = query.strip().lower()
         if not needle:
             return True
 
-        values: List[str] = []
+        values: list[str] = []
         for key in ('id', 'title', 'project_id', 'directory', 'agent', 'model'):
             value = session.get(key)
             if isinstance(value, str) and value:
@@ -5181,7 +5179,7 @@ async def list_sessions(
             logger.debug(f'Failed to read worker sessions from Redis: {e}')
 
     # Check if we have worker-synced sessions first (for remote workspaces)
-    if workspace_id in _worker_sessions and _worker_sessions[workspace_id]:
+    if _worker_sessions.get(workspace_id):
         merged = await _merge_sessions_with_database(
             workspace_id, _worker_sessions[workspace_id]
         )
@@ -5248,31 +5246,30 @@ class SessionSyncRequest(BaseModel):
     """Request model for syncing sessions from a worker."""
 
     worker_id: str
-    sessions: List[Dict[str, Any]]
+    sessions: list[dict[str, Any]]
 
 
 class ExternalSessionIngestRequest(BaseModel):
     """Ingest an external chat/session transcript (e.g. VS Code chat)."""
 
-    source: Optional[str] = None
-    worker_id: Optional[str] = None
-    session: Optional[Dict[str, Any]] = None
-    messages: Optional[List[Dict[str, Any]]] = None
+    source: str | None = None
+    worker_id: str | None = None
+    session: dict[str, Any] | None = None
+    messages: list[dict[str, Any]] | None = None
 
 
-def _normalize_iso_timestamp(value: Any) -> Optional[str]:
+def _normalize_iso_timestamp(value: Any) -> str | None:
     """Normalize timestamps coming from workers.
 
     Workers may send ISO strings (preferred) or epoch times (agent often uses
     milliseconds since epoch). We normalize to an ISO-8601 string when possible
     so PostgreSQL ordering and UI displays behave consistently.
     """
-
     if value is None:
         return None
 
     if isinstance(value, datetime):
-        return value.astimezone(timezone.utc).isoformat()
+        return value.astimezone(UTC).isoformat()
 
     if isinstance(value, str):
         v = value.strip()
@@ -5284,14 +5281,14 @@ def _normalize_iso_timestamp(value: Any) -> Optional[str]:
         if ts > 1e11:
             ts = ts / 1000.0
         try:
-            return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+            return datetime.fromtimestamp(ts, tz=UTC).isoformat()
         except Exception:
             return None
 
     return None
 
 
-def _normalize_model_value(model: Any) -> Optional[str]:
+def _normalize_model_value(model: Any) -> str | None:
     """Normalize model values to string format.
 
     Agent stores models as objects like {providerID: 'anthropic', modelID: 'claude-...'}.
@@ -5329,10 +5326,10 @@ async def ingest_external_session(
     _require_ingest_auth(request)
 
     source = (payload.source or 'external').strip() or 'external'
-    session_data: Dict[str, Any] = (
+    session_data: dict[str, Any] = (
         payload.session if isinstance(payload.session, dict) else {}
     )
-    messages: List[Dict[str, Any]] = (
+    messages: list[dict[str, Any]] = (
         payload.messages if isinstance(payload.messages, list) else []
     )
 
@@ -5340,16 +5337,16 @@ async def ingest_external_session(
         _normalize_iso_timestamp(
             session_data.get('created_at') or session_data.get('created')
         )
-        or datetime.now(timezone.utc).isoformat()
+        or datetime.now(UTC).isoformat()
     )
     updated_at = (
         _normalize_iso_timestamp(
             session_data.get('updated_at') or session_data.get('updated')
         )
-        or datetime.now(timezone.utc).isoformat()
+        or datetime.now(UTC).isoformat()
     )
 
-    summary: Dict[str, Any] = {}
+    summary: dict[str, Any] = {}
     if isinstance(session_data.get('summary'), dict):
         summary = dict(session_data['summary'])
     summary.setdefault('source', source)
@@ -5372,7 +5369,7 @@ async def ingest_external_session(
         }
     )
 
-    def _stringify(value: Any) -> Optional[str]:
+    def _stringify(value: Any) -> str | None:
         if value is None:
             return None
         if isinstance(value, str):
@@ -5382,7 +5379,7 @@ async def ingest_external_session(
         except Exception:
             return str(value)
 
-    def _extract_message_content(msg: Dict[str, Any]) -> Optional[str]:
+    def _extract_message_content(msg: dict[str, Any]) -> str | None:
         c = msg.get('content')
         content_str = _stringify(c)
         if isinstance(content_str, str) and content_str.strip():
@@ -5390,7 +5387,7 @@ async def ingest_external_session(
 
         parts = msg.get('parts')
         if isinstance(parts, list):
-            texts: List[str] = []
+            texts: list[str] = []
             for p in parts:
                 if not isinstance(p, dict):
                     continue
@@ -5409,7 +5406,7 @@ async def ingest_external_session(
 
         return None
 
-    def _extract_role(msg: Dict[str, Any]) -> Optional[str]:
+    def _extract_role(msg: dict[str, Any]) -> str | None:
         r = msg.get('role')
         if isinstance(r, str) and r:
             return r
@@ -5420,7 +5417,7 @@ async def ingest_external_session(
                 return r2
         return None
 
-    def _extract_model(msg: Dict[str, Any]) -> Optional[str]:
+    def _extract_model(msg: dict[str, Any]) -> str | None:
         m = msg.get('model')
         normalized = _normalize_model_value(m)
         if normalized:
@@ -5431,7 +5428,7 @@ async def ingest_external_session(
             return _normalize_model_value(m2)
         return None
 
-    def _extract_created_at(msg: Dict[str, Any]) -> Optional[str]:
+    def _extract_created_at(msg: dict[str, Any]) -> str | None:
         ca = msg.get('created_at')
         normalized = _normalize_iso_timestamp(ca)
         if normalized:
@@ -5473,7 +5470,7 @@ async def ingest_external_session(
                 'tokens': tokens,
                 'tool_calls': tool_calls,
                 'created_at': _extract_created_at(msg_data)
-                or datetime.now(timezone.utc).isoformat(),
+                or datetime.now(UTC).isoformat(),
             }
         )
         ingested += 1
@@ -5549,7 +5546,7 @@ class MessageSyncRequest(BaseModel):
     """Request model for syncing messages from a worker."""
 
     worker_id: str
-    messages: List[Dict[str, Any]]
+    messages: list[dict[str, Any]]
 
 
 @agent_router_alias.post(
@@ -5567,7 +5564,7 @@ async def sync_session_messages(
     # Store the synced messages
     _worker_messages[session_id] = request.messages
 
-    def _extract_message_content(msg: Dict[str, Any]) -> Optional[str]:
+    def _extract_message_content(msg: dict[str, Any]) -> str | None:
         def _looks_like_worker_registry_payload(value: Any) -> bool:
             if isinstance(value, dict):
                 keys = set(value.keys())
@@ -5599,7 +5596,7 @@ async def sync_session_messages(
         # Worker-synced agent shape: parts[].text
         parts = msg.get('parts')
         if isinstance(parts, list):
-            texts: List[str] = []
+            texts: list[str] = []
             for p in parts:
                 if not isinstance(p, dict):
                     continue
@@ -5623,7 +5620,7 @@ async def sync_session_messages(
 
         return None
 
-    def _extract_role(msg: Dict[str, Any]) -> Optional[str]:
+    def _extract_role(msg: dict[str, Any]) -> str | None:
         r = msg.get('role')
         if isinstance(r, str) and r:
             return r
@@ -5634,7 +5631,7 @@ async def sync_session_messages(
                 return r2
         return None
 
-    def _extract_model(msg: Dict[str, Any]) -> Optional[str]:
+    def _extract_model(msg: dict[str, Any]) -> str | None:
         m = msg.get('model')
         normalized = _normalize_model_value(m)
         if normalized:
@@ -5645,7 +5642,7 @@ async def sync_session_messages(
             return _normalize_model_value(m2)
         return None
 
-    def _extract_created_at(msg: Dict[str, Any]) -> Optional[str]:
+    def _extract_created_at(msg: dict[str, Any]) -> str | None:
         ca = msg.get('created_at')
         normalized = _normalize_iso_timestamp(ca)
         if normalized:
@@ -5786,7 +5783,6 @@ async def get_session_messages_by_id(
     workspace_id: str, session_id: str, limit: int = 100
 ):
     """Get messages from a specific session."""
-    import aiohttp
     import traceback
 
     try:
@@ -5852,7 +5848,7 @@ async def _get_session_messages_impl(
             logger.debug(f'Failed to read worker messages from Redis: {e}')
 
     # Check if we have worker-synced messages
-    if session_id in _worker_messages and _worker_messages[session_id]:
+    if _worker_messages.get(session_id):
         messages = _worker_messages[session_id][:limit]
         return {
             'messages': messages,
@@ -5909,7 +5905,7 @@ async def _get_session_messages_impl(
         if persisted:
             # Normalize DB rows into the shape expected by the Swift client
             # (SessionMessage: {id, sessionID, role, info{...}, time{created}, model, ...}).
-            normalized: List[Dict[str, Any]] = []
+            normalized: list[dict[str, Any]] = []
             for row in persisted:
                 role = row.get('role')
                 model = row.get('model')
@@ -5964,7 +5960,7 @@ async def resume_session(
         raise HTTPException(status_code=404, detail='Workspace not found')
 
     resume_prompt = request.prompt or 'Continue where we left off'
-    resume_metadata: Dict[str, Any] = {'resume_session_id': session_id}
+    resume_metadata: dict[str, Any] = {'resume_session_id': session_id}
     if request.model:
         resume_metadata['model'] = request.model
     if request.model_ref:
@@ -6107,7 +6103,7 @@ async def resume_session(
                     if effective_resume_model:
                         payload['model'] = effective_resume_model
 
-                    async def _send_message(body: Dict[str, Any]):
+                    async def _send_message(body: dict[str, Any]):
                         async with session.post(
                             f'{base_url}/session/{session_id}/message',
                             params={'directory': workspace.path},
@@ -6180,7 +6176,7 @@ async def resume_session(
     }
 
 
-async def _read_local_sessions(workspace_path: str) -> List[Dict[str, Any]]:
+async def _read_local_sessions(workspace_path: str) -> list[dict[str, Any]]:
     """Read sessions from agent's local state directory."""
     import glob
 
@@ -6196,7 +6192,7 @@ async def _read_local_sessions(workspace_path: str) -> List[Dict[str, Any]]:
 
     for session_file in session_files:
         try:
-            with open(session_file, 'r') as f:
+            with open(session_file) as f:
                 session_data = json.load(f)
                 sessions.append(
                     {
@@ -6222,7 +6218,7 @@ async def _read_local_sessions(workspace_path: str) -> List[Dict[str, Any]]:
 
 async def _read_local_session(
     workspace_path: str, session_id: str
-) -> Optional[Dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Read a specific session from agent's local state directory."""
     session_file = os.path.join(
         workspace_path, '.codetether', 'state', 'session', f'{session_id}.json'
@@ -6232,7 +6228,7 @@ async def _read_local_session(
         return None
 
     try:
-        with open(session_file, 'r') as f:
+        with open(session_file) as f:
             return json.load(f)
     except Exception as e:
         logger.warning(f'Failed to read session file {session_file}: {e}')
@@ -6241,7 +6237,7 @@ async def _read_local_session(
 
 async def _read_local_session_messages(
     workspace_path: str, session_id: str
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Read messages from a session's local state."""
     session_data = await _read_local_session(workspace_path, session_id)
     if session_data:
@@ -6256,10 +6252,9 @@ async def _read_local_session_messages(
 
 @agent_router_alias.post('/workspaces/{workspace_id}/watch/start')
 async def start_watch_mode(
-    workspace_id: str, config: Optional[WatchModeConfig] = None
+    workspace_id: str, config: WatchModeConfig | None = None
 ):
-    """
-    Start watch mode for a workspace - agent will automatically process tasks.
+    """Start watch mode for a workspace - agent will automatically process tasks.
 
     The agent will poll for pending tasks and execute them in order of priority.
     """
@@ -6338,12 +6333,6 @@ async def get_watch_status(workspace_id: str):
     if not workspace:
         raise HTTPException(status_code=404, detail='Workspace not found')
 
-    pending_tasks = await bridge.list_tasks(
-        codebase_id=workspace_id,
-        status=bridge._tasks.__class__.PENDING
-        if hasattr(bridge._tasks, '__class__')
-        else None,
-    )
     from .agent_bridge import AgentTaskStatus
 
     pending_count = len(
@@ -6371,8 +6360,8 @@ async def get_watch_status(workspace_id: str):
 # Helper function to integrate monitoring with existing A2A server
 async def log_agent_message(
     agent_name: str,
-    content: Optional[str] = None,
-    message: Optional[str] = None,
+    content: str | None = None,
+    message: str | None = None,
     **kwargs,
 ):
     """Helper function to log agent messages.
@@ -6400,7 +6389,7 @@ async def log_agent_message(
 # ========================================
 
 # In-memory worker registry (workers are transient - they re-register on start)
-_registered_workers: Dict[str, Dict[str, Any]] = {}
+_registered_workers: dict[str, dict[str, Any]] = {}
 
 
 class WorkerRegistration(BaseModel):
@@ -6408,20 +6397,20 @@ class WorkerRegistration(BaseModel):
 
     worker_id: str
     name: str
-    capabilities: List[str] = []
-    hostname: Optional[str] = None
-    models: List[Dict[str, Any]] = []
-    global_workspace_id: Optional[str] = None
-    workspaces: List[str] = []  # List of workspace IDs this worker handles
-    agents: List[
-        Dict[str, Any]
+    capabilities: list[str] = []
+    hostname: str | None = None
+    models: list[dict[str, Any]] = []
+    global_workspace_id: str | None = None
+    workspaces: list[str] = []  # List of workspace IDs this worker handles
+    agents: list[
+        dict[str, Any]
     ] = []  # Custom agent definitions this worker supports
 
 
 def _normalized_worker_capabilities(
     name: str,
-    capabilities: Optional[List[str]],
-) -> List[str]:
+    capabilities: list[str] | None,
+) -> list[str]:
     """Return worker capabilities plus server-inferred infrastructure roles.
 
     Older codetether-agent binaries only advertise protocol/tool capabilities.
@@ -6429,7 +6418,7 @@ def _normalized_worker_capabilities(
     the control plane annotates them with durable workspace capabilities used by
     GitHub App clone/prep routing.
     """
-    ordered: List[str] = []
+    ordered: list[str] = []
     seen: set[str] = set()
 
     def add(value: str) -> None:
@@ -6460,9 +6449,9 @@ class TaskStatusUpdate(BaseModel):
 
     status: str
     worker_id: str
-    session_id: Optional[str] = None
-    result: Optional[str] = None
-    error: Optional[str] = None
+    session_id: str | None = None
+    result: str | None = None
+    error: str | None = None
 
 
 @agent_router_alias.post('/workers/register')
@@ -6559,9 +6548,9 @@ async def unregister_worker(worker_id: str):
 
 @agent_router_alias.get('/workers')
 async def list_workers(
-    search: Optional[str] = None,
+    search: str | None = None,
     online_only: bool = False,
-    exclude_offline_hours: Optional[int] = 24,
+    exclude_offline_hours: int | None = 24,
 ):
     """List all registered workers with optional model search filter.
 
@@ -6573,8 +6562,8 @@ async def list_workers(
     """
 
     def _classify_worker_runtime(
-        worker: Dict[str, Any],
-        sse_worker: Optional[Dict[str, Any]],
+        worker: dict[str, Any],
+        sse_worker: dict[str, Any] | None,
     ) -> str:
         source = str(worker.get('_registry_source') or '')
         worker_id = str(worker.get('worker_id') or '').lower()
@@ -6649,7 +6638,7 @@ async def list_workers(
     db_workers = await db.db_list_workers()
     redis_workers = await _redis_list_workers()
 
-    merged: Dict[str, Dict[str, Any]] = {}
+    merged: dict[str, dict[str, Any]] = {}
 
     # In-memory first (most up-to-date for this instance)
     for w in _registered_workers.values():
@@ -6678,7 +6667,7 @@ async def list_workers(
     workers = list(merged.values())
 
     # Include connected SSE worker metadata to improve runtime classification.
-    sse_workers_by_id: Dict[str, Dict[str, Any]] = {}
+    sse_workers_by_id: dict[str, dict[str, Any]] = {}
     try:
         from .worker_sse import get_worker_registry
 
@@ -6693,7 +6682,7 @@ async def list_workers(
             f'Unable to load SSE worker registry for classification: {e}'
         )
 
-    annotated_workers: List[Dict[str, Any]] = []
+    annotated_workers: list[dict[str, Any]] = []
     for worker in workers:
         wid = str(worker.get('worker_id') or '')
         sse_worker = sse_workers_by_id.get(wid)
@@ -6707,7 +6696,7 @@ async def list_workers(
 
     if online_only:
         sse_worker_ids = set(sse_workers_by_id.keys())
-        online_workers: List[Dict[str, Any]] = []
+        online_workers: list[dict[str, Any]] = []
         for w in workers:
             wid = str(w.get('worker_id') or '')
             if wid in sse_worker_ids:
@@ -6733,7 +6722,7 @@ async def list_workers(
         sse_worker_ids_set = (
             set(sse_workers_by_id.keys()) if exclude_offline_hours else set()
         )
-        active_workers: List[Dict[str, Any]] = []
+        active_workers: list[dict[str, Any]] = []
         for w in workers:
             wid = str(w.get('worker_id') or '')
             # SSE-connected workers are always considered active
@@ -6826,54 +6815,47 @@ async def worker_heartbeat(worker_id: str):
                     f'Re-inserted worker {worker_id} from Redis into DB during heartbeat'
                 )
                 return {'success': True}
-            else:
-                # Check if worker is connected via SSE (different registry)
-                try:
-                    from .worker_sse import get_worker_registry
+            # Check if worker is connected via SSE (different registry)
+            try:
+                from .worker_sse import get_worker_registry
 
-                    sse_registry = get_worker_registry()
-                    sse_workers = await sse_registry.list_workers()
-                    sse_worker = next(
-                        (
-                            w
-                            for w in sse_workers
-                            if w.get('worker_id') == worker_id
-                        ),
-                        None,
-                    )
-                    if sse_worker:
-                        # Auto-register SSE worker into main registry
-                        worker_info = {
-                            'worker_id': worker_id,
-                            'name': sse_worker.get('agent_name', 'unknown'),
-                            'capabilities': _normalized_worker_capabilities(
-                                sse_worker.get('agent_name', 'unknown'),
-                                sse_worker.get('capabilities', []),
-                            ),
-                            'hostname': '',
-                            'models': [],
-                            'workspaces': list(
-                                sse_worker.get('workspaces', [])
-                            ),
-                            'registered_at': now,
-                            'last_seen': now,
-                            'status': 'active',
-                        }
-                        _registered_workers[worker_id] = worker_info
-                        await db.db_upsert_worker(worker_info)
-                        await _redis_upsert_worker(worker_info)
-                        logger.info(
-                            f'Auto-registered SSE worker {worker_id} into main registry during heartbeat'
-                        )
-                        return {'success': True}
-                except Exception as e:
-                    logger.debug(f'SSE registry check failed: {e}')
-
-                # Worker not found anywhere - return 404 so worker re-registers
-                raise HTTPException(
-                    status_code=404,
-                    detail='Worker not found - please re-register',
+                sse_registry = get_worker_registry()
+                sse_workers = await sse_registry.list_workers()
+                sse_worker = next(
+                    (w for w in sse_workers if w.get('worker_id') == worker_id),
+                    None,
                 )
+                if sse_worker:
+                    # Auto-register SSE worker into main registry
+                    worker_info = {
+                        'worker_id': worker_id,
+                        'name': sse_worker.get('agent_name', 'unknown'),
+                        'capabilities': _normalized_worker_capabilities(
+                            sse_worker.get('agent_name', 'unknown'),
+                            sse_worker.get('capabilities', []),
+                        ),
+                        'hostname': '',
+                        'models': [],
+                        'workspaces': list(sse_worker.get('workspaces', [])),
+                        'registered_at': now,
+                        'last_seen': now,
+                        'status': 'active',
+                    }
+                    _registered_workers[worker_id] = worker_info
+                    await db.db_upsert_worker(worker_info)
+                    await _redis_upsert_worker(worker_info)
+                    logger.info(
+                        f'Auto-registered SSE worker {worker_id} into main registry during heartbeat'
+                    )
+                    return {'success': True}
+            except Exception as e:
+                logger.debug(f'SSE registry check failed: {e}')
+
+            # Worker not found anywhere - return 404 so worker re-registers
+            raise HTTPException(
+                status_code=404,
+                detail='Worker not found - please re-register',
+            )
 
     # Update Redis
     if worker_id in _registered_workers:
@@ -6900,9 +6882,9 @@ class WorkerProfileCreate(BaseModel):
     name: str
     description: str = ''
     system_prompt: str = ''
-    default_capabilities: List[str] = []
+    default_capabilities: list[str] = []
     default_model_tier: str = 'balanced'
-    default_model_ref: Optional[str] = None
+    default_model_ref: str | None = None
     default_agent_type: str = 'build'
     icon: str = '🤖'
     color: str = '#6366f1'
@@ -6911,22 +6893,22 @@ class WorkerProfileCreate(BaseModel):
 class WorkerProfileUpdate(BaseModel):
     """Request body for updating a custom worker profile."""
 
-    slug: Optional[str] = None
-    name: Optional[str] = None
-    description: Optional[str] = None
-    system_prompt: Optional[str] = None
-    default_capabilities: Optional[List[str]] = None
-    default_model_tier: Optional[str] = None
-    default_model_ref: Optional[str] = None
-    default_agent_type: Optional[str] = None
-    icon: Optional[str] = None
-    color: Optional[str] = None
+    slug: str | None = None
+    name: str | None = None
+    description: str | None = None
+    system_prompt: str | None = None
+    default_capabilities: list[str] | None = None
+    default_model_tier: str | None = None
+    default_model_ref: str | None = None
+    default_agent_type: str | None = None
+    icon: str | None = None
+    color: str | None = None
 
 
 class WorkerProfileAssign(BaseModel):
     """Assign a profile to a worker."""
 
-    profile_id: Optional[str] = None  # None clears the assignment
+    profile_id: str | None = None  # None clears the assignment
 
 
 # ---------------------------------------------------------------------------
@@ -6937,8 +6919,8 @@ class WorkerProfileAssign(BaseModel):
 @agent_router_alias.get('/worker-profiles')
 async def list_worker_profiles(
     builtin_only: bool = False,
-    tenant_id: Optional[str] = None,
-    user_id: Optional[str] = None,
+    tenant_id: str | None = None,
+    user_id: str | None = None,
 ):
     """List all visible worker profiles (builtins + user-owned)."""
     profiles = await db.db_list_worker_profiles(
@@ -6973,8 +6955,8 @@ async def get_worker_profile(profile_id: str):
 @agent_router_alias.post('/worker-profiles')
 async def create_worker_profile(
     body: WorkerProfileCreate,
-    tenant_id: Optional[str] = None,
-    user_id: Optional[str] = None,
+    tenant_id: str | None = None,
+    user_id: str | None = None,
 ):
     """Create a custom worker profile."""
     data = body.dict()
@@ -7057,33 +7039,33 @@ class AgentDefinitionCreate(BaseModel):
     """Request body for creating a custom agent definition."""
 
     name: str
-    description: Optional[str] = None
+    description: str | None = None
     mode: str = 'primary'
     hidden: bool = False
-    model: Optional[str] = None
-    temperature: Optional[float] = None
-    top_p: Optional[float] = None
-    max_steps: Optional[int] = None
-    system_prompt: Optional[str] = None
+    model: str | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    max_steps: int | None = None
+    system_prompt: str | None = None
 
 
 class AgentDefinitionUpdate(BaseModel):
     """Request body for updating a custom agent definition."""
 
-    name: Optional[str] = None
-    description: Optional[str] = None
-    mode: Optional[str] = None
-    hidden: Optional[bool] = None
-    model: Optional[str] = None
-    temperature: Optional[float] = None
-    top_p: Optional[float] = None
-    max_steps: Optional[int] = None
-    system_prompt: Optional[str] = None
+    name: str | None = None
+    description: str | None = None
+    mode: str | None = None
+    hidden: bool | None = None
+    model: str | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    max_steps: int | None = None
+    system_prompt: str | None = None
 
 
 @agent_router_alias.get('/agents')
 async def list_agent_definitions(
-    worker_id: Optional[str] = None,
+    worker_id: str | None = None,
     include_builtins: bool = True,
 ):
     """List all agent definitions, optionally filtered by worker.
@@ -7332,7 +7314,7 @@ class TaskOutputChunk(BaseModel):
 
     worker_id: str
     output: str
-    timestamp: Optional[str] = None
+    timestamp: str | None = None
 
 
 @agent_router_alias.post('/tasks/{task_id}/output')
@@ -7386,7 +7368,7 @@ async def stream_task_output(task_id: str, chunk: TaskOutputChunk):
 
 
 @agent_router_alias.get('/tasks/{task_id}/output')
-async def get_task_output(task_id: str, since: Optional[int] = None):
+async def get_task_output(task_id: str, since: int | None = None):
     """Get streaming output for a task."""
     outputs = _task_output_streams.get(task_id, [])
 
@@ -7442,7 +7424,7 @@ async def stream_task_output_sse(task_id: str, request: Request):
 
 
 @agent_router_alias.post('/tasks/{task_id}/cancel')
-async def cancel_task(task_id: str):
+async def cancel_task_alias(task_id: str):
     """Cancel a pending task."""
     bridge = get_agent_bridge()
     if bridge is None:
@@ -7469,8 +7451,7 @@ async def cancel_task(task_id: str):
 async def get_stuck_tasks(
     timeout_seconds: int = 300,
 ):
-    """
-    Get list of tasks that appear to be stuck.
+    """Get list of tasks that appear to be stuck.
 
     A task is considered stuck if:
     - Status is 'running'
@@ -7512,8 +7493,7 @@ async def get_stuck_tasks(
 
 @agent_router_alias.post('/tasks/stuck/recover')
 async def recover_stuck_tasks():
-    """
-    Manually trigger recovery of stuck tasks.
+    """Manually trigger recovery of stuck tasks.
 
     This will:
     1. Find all tasks stuck in 'running' status
@@ -7523,7 +7503,7 @@ async def recover_stuck_tasks():
     Returns statistics about the recovery operation.
     """
     try:
-        from .task_reaper import get_task_reaper, TaskReaper
+        from .task_reaper import TaskReaper, get_task_reaper
 
         reaper = get_task_reaper()
         if reaper is None:
@@ -7543,8 +7523,7 @@ async def recover_stuck_tasks():
 
 @agent_router_alias.post('/tasks/{task_id}/requeue')
 async def requeue_task(task_id: str):
-    """
-    Manually requeue a specific task.
+    """Manually requeue a specific task.
 
     This will reset the task to 'pending' status so it can be picked up
     by a worker again. Useful for recovering a single stuck task.
@@ -7674,9 +7653,9 @@ class LoginRequest(BaseModel):
 
     username: str
     password: str
-    device_id: Optional[str] = None
-    device_name: Optional[str] = None
-    device_type: Optional[str] = None  # ios, macos, web, linux
+    device_id: str | None = None
+    device_name: str | None = None
+    device_type: str | None = None  # ios, macos, web, linux
 
 
 class RefreshRequest(BaseModel):
@@ -7746,7 +7725,7 @@ async def refresh_token(request: RefreshRequest):
 
 @auth_router.post('/logout')
 async def logout(
-    session_id: Optional[str] = None, authorization: Optional[str] = None
+    session_id: str | None = None, authorization: str | None = None
 ):
     """Logout and invalidate session."""
     auth = get_keycloak_auth()
@@ -7762,7 +7741,7 @@ async def logout(
 
 
 @auth_router.get('/session')
-async def get_session(session_id: str):
+async def get_auth_session(session_id: str):
     """Get current session info."""
     auth = get_keycloak_auth()
     if auth is None:
@@ -7868,7 +7847,7 @@ async def create_agent_session(
     user_id: str,
     workspace_id: str,
     agent_type: str = 'build',
-    device_id: Optional[str] = None,
+    device_id: str | None = None,
 ):
     """Create a new agent session for a user."""
     auth = get_keycloak_auth()
@@ -8022,22 +8001,24 @@ async def nextauth_callback(code: str, state: str):
 
 from .vault_client import (
     KNOWN_PROVIDERS,
-    get_user_api_key,
-    set_user_api_key,
+    check_vault_connection,
     delete_user_api_key,
-    list_user_api_keys,
-    get_all_user_api_keys,
     get_all_user_api_keys_with_diagnostics,
     get_worker_sync_data,
-    check_vault_connection,
+    set_user_api_key,
+)
+from .vault_client import (
     test_api_key as vault_test_api_key,
 )
 
+
 try:
     from .keycloak_auth import (
-        get_current_user as get_keycloak_user,
-        require_auth,
         UserSession,
+        require_auth,
+    )
+    from .keycloak_auth import (
+        get_current_user as get_keycloak_user,
     )
 except ImportError:
 
@@ -8059,7 +8040,6 @@ except ImportError:
         return None
 
 
-
 @dataclass
 class ApiKeyUser:
     user_id: str
@@ -8071,10 +8051,10 @@ _api_key_auth_scheme = HTTPBearer(auto_error=False)
 
 
 async def get_current_api_key_user(
-    credentials: Optional[HTTPAuthorizationCredentials] = Security(
+    credentials: HTTPAuthorizationCredentials | None = Security(
         _api_key_auth_scheme
     ),
-) -> Optional[ApiKeyUser]:
+) -> ApiKeyUser | None:
     if not credentials:
         return None
 
@@ -8110,12 +8090,12 @@ class APIKeyCreate(BaseModel):
 
     provider_id: str  # e.g., 'anthropic', 'openai', 'minimax-m2'
     api_key: str
-    provider_name: Optional[str] = None  # Display name
-    base_url: Optional[str] = None  # Custom base URL for provider
+    provider_name: str | None = None  # Display name
+    base_url: str | None = None  # Custom base URL for provider
 
 
 @agent_router_alias.get('/providers')
-async def list_providers():
+async def list_provider_configs():
     """List all known LLM providers with their configuration."""
     return {
         'providers': [
@@ -8136,7 +8116,7 @@ async def list_providers():
 
 @agent_router_alias.get('/vault/status')
 async def vault_status(
-    user: Optional[ApiKeyUser] = Depends(get_current_api_key_user),
+    user: ApiKeyUser | None = Depends(get_current_api_key_user),
 ):
     """Check Vault connectivity status."""
     return await check_vault_connection(user_id=user.user_id if user else None)
@@ -8144,7 +8124,7 @@ async def vault_status(
 
 @agent_router_alias.get('/api-keys')
 async def list_api_keys(
-    user: Optional[ApiKeyUser] = Depends(get_current_api_key_user),
+    user: ApiKeyUser | None = Depends(get_current_api_key_user),
 ):
     """List all configured API keys for the current user (without exposing full keys)."""
     if not user:
@@ -8184,7 +8164,7 @@ async def list_api_keys(
 @agent_router_alias.post('/api-keys')
 async def create_or_update_api_key(
     key_data: APIKeyCreate,
-    user: Optional[ApiKeyUser] = Depends(get_current_api_key_user),
+    user: ApiKeyUser | None = Depends(get_current_api_key_user),
 ):
     """Create or update an API key for a provider for the current user."""
     if not user:
@@ -8224,7 +8204,7 @@ async def create_or_update_api_key(
 @agent_router_alias.delete('/api-keys/{provider_id}')
 async def delete_api_key(
     provider_id: str,
-    user: Optional[ApiKeyUser] = Depends(get_current_api_key_user),
+    user: ApiKeyUser | None = Depends(get_current_api_key_user),
 ):
     """Delete an API key for a provider for the current user."""
     if not user:
@@ -8241,12 +8221,11 @@ async def delete_api_key(
 
 @agent_router_alias.get('/api-keys/sync')
 async def get_api_keys_for_sync(
-    user_id: Optional[str] = None,
-    worker_id: Optional[str] = None,
-    user: Optional[ApiKeyUser] = Depends(get_current_api_key_user),
+    user_id: str | None = None,
+    worker_id: str | None = None,
+    user: ApiKeyUser | None = Depends(get_current_api_key_user),
 ):
-    """
-    Get all API keys for worker sync.
+    """Get all API keys for worker sync.
 
     If user_id is provided (worker request), returns that user's keys.
     Otherwise, returns the authenticated user's keys.
@@ -8274,7 +8253,7 @@ async def get_api_keys_for_sync(
 @agent_router_alias.post('/api-keys/test')
 async def test_api_key_endpoint(
     key_data: APIKeyCreate,
-    user: Optional[ApiKeyUser] = Depends(get_current_api_key_user),
+    user: ApiKeyUser | None = Depends(get_current_api_key_user),
 ):
     """Test an API key by making a simple request to the provider."""
     # Allow testing without auth (just testing the key itself)
@@ -8318,8 +8297,8 @@ def _get_minio_client():
 
 
 async def _verify_workspace_ownership(
-    workspace_id: str, tenant_id: Optional[str] = None
-) -> Optional[Dict[str, Any]]:
+    workspace_id: str, tenant_id: str | None = None
+) -> dict[str, Any] | None:
     """Verify that a workspace exists and optionally belongs to a tenant.
 
     Returns the workspace dict if valid, None otherwise.
@@ -8342,26 +8321,26 @@ class WorkspaceSyncRequest(BaseModel):
 
     size_bytes: int
     files_changed: int = 0
-    worker_id: Optional[str] = None
+    worker_id: str | None = None
 
 
 class WorkerStatusResponse(BaseModel):
     """Response model for worker status."""
 
     status: str  # pending, creating, ready, failed, not_found
-    url: Optional[str] = None
-    created_at: Optional[str] = None
-    last_activity: Optional[str] = None
-    tenant_id: Optional[str] = None
-    workspace_id: Optional[str] = None
-    error_message: Optional[str] = None
+    url: str | None = None
+    created_at: str | None = None
+    last_activity: str | None = None
+    tenant_id: str | None = None
+    workspace_id: str | None = None
+    error_message: str | None = None
 
 
 @agent_router_alias.post('/workspaces/{workspace_id}/upload')
 async def upload_workspace_tarball(
     workspace_id: str,
     request: Request,
-    user: Optional[ApiKeyUser] = Depends(get_current_api_key_user),
+    user: ApiKeyUser | None = Depends(get_current_api_key_user),
 ):
     """Upload a workspace tarball to MinIO.
 
@@ -8396,8 +8375,6 @@ async def upload_workspace_tarball(
         )
 
     # Parse multipart form data
-    from fastapi import UploadFile, File
-    import aiofiles
 
     try:
         form = await request.form()
@@ -8464,14 +8441,14 @@ async def upload_workspace_tarball(
         raise
     except Exception as e:
         logger.error(f'Failed to upload workspace {workspace_id}: {e}')
-        raise HTTPException(status_code=500, detail=f'Upload failed: {str(e)}')
+        raise HTTPException(status_code=500, detail=f'Upload failed: {e!s}')
 
 
 @agent_router_alias.get('/workspaces/{workspace_id}/download')
 async def download_workspace_tarball(
     workspace_id: str,
     stream: bool = False,
-    user: Optional[ApiKeyUser] = Depends(get_current_api_key_user),
+    user: ApiKeyUser | None = Depends(get_current_api_key_user),
 ):
     """Get a presigned URL or stream the workspace tarball from MinIO.
 
@@ -8539,7 +8516,7 @@ async def download_workspace_tarball(
         except Exception as e:
             logger.error(f'Failed to stream workspace {workspace_id}: {e}')
             raise HTTPException(
-                status_code=500, detail=f'Download failed: {str(e)}'
+                status_code=500, detail=f'Download failed: {e!s}'
             )
     else:
         # Generate presigned URL
@@ -8561,7 +8538,7 @@ async def download_workspace_tarball(
                 f'Failed to generate presigned URL for {workspace_id}: {e}'
             )
             raise HTTPException(
-                status_code=500, detail=f'Failed to generate URL: {str(e)}'
+                status_code=500, detail=f'Failed to generate URL: {e!s}'
             )
 
 
@@ -8624,13 +8601,13 @@ async def sync_workspace_from_worker(
 
     except Exception as e:
         logger.error(f'Failed to update sync status for {workspace_id}: {e}')
-        raise HTTPException(status_code=500, detail=f'Sync failed: {str(e)}')
+        raise HTTPException(status_code=500, detail=f'Sync failed: {e!s}')
 
 
 @agent_router_alias.get('/sessions/{session_id}/worker-status')
 async def get_session_worker_status(
     session_id: str,
-    user: Optional[ApiKeyUser] = Depends(get_current_api_key_user),
+    user: ApiKeyUser | None = Depends(get_current_api_key_user),
 ):
     """Get Knative worker status for a session.
 
@@ -8649,7 +8626,6 @@ async def get_session_worker_status(
     if session:
         # Check if we have Knative service info stored
         knative_service_name = session.get('knative_service_name')
-        worker_status = session.get('worker_status', 'pending')
         last_activity = session.get('last_activity_at')
 
         if not knative_service_name:
@@ -8663,7 +8639,7 @@ async def get_session_worker_status(
 
     # Try to get status from Knative spawner
     try:
-        from .knative_spawner import get_worker_status, KNATIVE_ENABLED
+        from .knative_spawner import KNATIVE_ENABLED, get_worker_status
 
         if not KNATIVE_ENABLED:
             return WorkerStatusResponse(
@@ -8711,7 +8687,7 @@ async def get_session_worker_status(
             f'Failed to get worker status for session {session_id}: {e}'
         )
         raise HTTPException(
-            status_code=500, detail=f'Failed to get worker status: {str(e)}'
+            status_code=500, detail=f'Failed to get worker status: {e!s}'
         )
 
 
@@ -8725,13 +8701,13 @@ AVAILABLE_VOICES = [
 
 
 class VoiceSessionRequest(BaseModel):
-    workspace_id: Optional[str] = None
-    worker_id: Optional[str] = None
-    session_id: Optional[str] = None
+    workspace_id: str | None = None
+    worker_id: str | None = None
+    session_id: str | None = None
     voice: str = '960f89fc'
     mode: str = 'chat'
     playback_style: str = 'verbatim'
-    user_id: Optional[str] = None
+    user_id: str | None = None
 
 
 class VoiceSessionResponse(BaseModel):
@@ -8837,7 +8813,7 @@ async def create_voice_session(request: VoiceSessionRequest):
     except Exception as e:
         logger.error(f'Failed to create LiveKit room: {e}')
         raise HTTPException(
-            status_code=500, detail=f'Failed to create voice room: {str(e)}'
+            status_code=500, detail=f'Failed to create voice room: {e!s}'
         )
 
     voice_agent_name = os.getenv(
@@ -8885,7 +8861,7 @@ async def create_voice_session(request: VoiceSessionRequest):
         except:
             pass
         raise HTTPException(
-            status_code=500, detail=f'Failed to generate access token: {str(e)}'
+            status_code=500, detail=f'Failed to generate access token: {e!s}'
         )
 
     expires_at = datetime.now() + timedelta(minutes=60)
@@ -8904,7 +8880,7 @@ async def create_voice_session(request: VoiceSessionRequest):
 
 
 @voice_router.get('/sessions/{room_name}')
-async def get_voice_session(room_name: str, user_id: Optional[str] = None):
+async def get_voice_session(room_name: str, user_id: str | None = None):
     """Get session info for a voice session.
 
     If user_id is provided, a new access token will be generated for reconnection.
@@ -9040,14 +9016,14 @@ async def get_voice_session_state(room_name: str):
 
 # Export the monitoring service, routers and helpers
 __all__ = [
-    'monitor_router',
     'agent_router',
     'agent_router_alias',  # backward-compat alias for agent_router
-    'voice_router',
     'auth_router',
-    'nextauth_router',
-    'monitoring_service',
-    'log_agent_message',
     'get_agent_bridge',
     'get_keycloak_auth',
+    'log_agent_message',
+    'monitor_router',
+    'monitoring_service',
+    'nextauth_router',
+    'voice_router',
 ]

--- a/a2a_server/persistent_worker_pool.py
+++ b/a2a_server/persistent_worker_pool.py
@@ -26,9 +26,9 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-PERSISTENT_WORKER_ENABLED = os.environ.get(
-    'PERSISTENT_WORKER_ENABLED', 'false'
-).lower() == 'true'
+PERSISTENT_WORKER_ENABLED = (
+    os.environ.get('PERSISTENT_WORKER_ENABLED', 'false').lower() == 'true'
+)
 PERSISTENT_WORKER_LEASE_SECONDS = int(
     os.environ.get('PERSISTENT_WORKER_LEASE_SECONDS', '3600')
 )
@@ -58,7 +58,9 @@ def _github_work_key(metadata: dict[str, Any]) -> str | None:
 
     repo = str(metadata.get('repo') or '').strip()
     number = metadata.get('pr_number') or metadata.get('issue_number')
-    stage = str(metadata.get('workflow_stage') or metadata.get('agent_type') or '').strip()
+    stage = str(
+        metadata.get('workflow_stage') or metadata.get('agent_type') or ''
+    ).strip()
     head_sha = str(
         metadata.get('pr_head_sha')
         or metadata.get('github_check_head_sha')
@@ -98,7 +100,9 @@ async def _resolve_github_app_tenant_id(
 
     pool = await db.get_pool()
     if not pool:
-        raise RuntimeError('Database not available for GitHub App tenant resolution')
+        raise RuntimeError(
+            'Database not available for GitHub App tenant resolution'
+        )
     async with pool.acquire() as conn:
         if workspace_id:
             tenant_id = await conn.fetchval(
@@ -115,7 +119,9 @@ async def _resolve_github_app_tenant_id(
     raise RuntimeError('GitHub App task tenant_id is required')
 
 
-async def _bind_workspace_tenant(workspace_id: str | None, tenant_id: str) -> None:
+async def _bind_workspace_tenant(
+    workspace_id: str | None, tenant_id: str
+) -> None:
     if not workspace_id or not tenant_id:
         return
     from . import database as db
@@ -130,6 +136,7 @@ async def _bind_workspace_tenant(workspace_id: str | None, tenant_id: str) -> No
             workspace_id,
             tenant_id,
         )
+
 
 @asynccontextmanager
 async def _github_work_dedupe_lock(metadata: dict[str, Any]):
@@ -148,11 +155,15 @@ async def _github_work_dedupe_lock(metadata: dict[str, Any]):
 
     conn = await pool.acquire()
     try:
-        await conn.execute('SELECT pg_advisory_lock(hashtextextended($1, 0))', work_key)
+        await conn.execute(
+            'SELECT pg_advisory_lock(hashtextextended($1, 0))', work_key
+        )
         yield work_key
     finally:
         try:
-            await conn.execute('SELECT pg_advisory_unlock(hashtextextended($1, 0))', work_key)
+            await conn.execute(
+                'SELECT pg_advisory_unlock(hashtextextended($1, 0))', work_key
+            )
         finally:
             await pool.release(conn)
 
@@ -223,6 +234,7 @@ async def create_and_dispatch_task(
     if not workspace:
         try:
             from .monitor_api import _rehydrate_workspace_into_bridge
+
             workspace = await _rehydrate_workspace_into_bridge(workspace_id)
         except Exception:
             workspace = None
@@ -233,11 +245,15 @@ async def create_and_dispatch_task(
         effective_metadata['model_ref'] = model_ref
 
     if _is_github_app_task(effective_metadata):
-        tenant_id = await _resolve_github_app_tenant_id(effective_metadata, workspace_id)
+        tenant_id = await _resolve_github_app_tenant_id(
+            effective_metadata, workspace_id
+        )
         effective_metadata['tenant_id'] = tenant_id
         await _bind_workspace_tenant(workspace_id, tenant_id)
     else:
-        tenant_id = str(effective_metadata.get('tenant_id') or '').strip() or None
+        tenant_id = (
+            str(effective_metadata.get('tenant_id') or '').strip() or None
+        )
 
     work_key = _github_work_key(effective_metadata)
     if work_key:
@@ -252,7 +268,9 @@ async def create_and_dispatch_task(
                 existing_task_id,
                 locked_work_key,
             )
-            return (existing_task_id, False) if with_created else existing_task_id
+            return (
+                (existing_task_id, False) if with_created else existing_task_id
+            )
 
         # 1. Create the task via the bridge (standard task row in tasks table)
         task = await bridge.create_task(
@@ -314,7 +332,10 @@ async def dispatch_fire_and_forget(
     async with pool.acquire() as conn:
         run_id = await conn.fetchval(
             'SELECT create_fire_and_forget_run($1, $2, $3, $4, $5, $6)',
-            task_id, user_id, tenant_id, priority,
+            task_id,
+            user_id,
+            tenant_id,
+            priority,
             min(task_timeout_seconds, PERSISTENT_WORKER_MAX_TIMEOUT),
             github_issue_url,
         )
@@ -322,20 +343,31 @@ async def dispatch_fire_and_forget(
     async with pool.acquire() as conn:
         await conn.execute(
             "UPDATE tasks SET dispatch_mode = 'fire_and_forget', updated_at = NOW() "
-            "WHERE id = $1", task_id,
+            'WHERE id = $1',
+            task_id,
         )
 
     # Notify SSE workers
     try:
         from .worker_sse import notify_workers_of_new_task
+
         task_data = {
-            'id': task_id, 'title': title, 'prompt': description,
-            'agent_type': agent_type, 'model': model, 'priority': priority,
-            'metadata': metadata or {}, 'dispatch_mode': 'fire_and_forget',
+            'id': task_id,
+            'title': title,
+            'prompt': description,
+            'agent_type': agent_type,
+            'model': model,
+            'priority': priority,
+            'metadata': metadata or {},
+            'dispatch_mode': 'fire_and_forget',
             'task_timeout_seconds': task_timeout_seconds,
         }
         routed_metadata = metadata or {}
-        for key in ('target_agent_name', 'target_worker_id', 'required_capabilities'):
+        for key in (
+            'target_agent_name',
+            'target_worker_id',
+            'required_capabilities',
+        ):
             if routed_metadata.get(key):
                 task_data[key] = routed_metadata[key]
         notified = await notify_workers_of_new_task(task_data)
@@ -347,7 +379,9 @@ async def dispatch_fire_and_forget(
         logger.warning(f'SSE notify failed for {task_id}: {e}')
 
     return {
-        'task_id': task_id, 'run_id': run_id, 'status': 'queued',
+        'task_id': task_id,
+        'run_id': run_id,
+        'status': 'queued',
         'dispatch_mode': 'fire_and_forget',
         'task_timeout_seconds': task_timeout_seconds,
         'message': 'Task dispatched. Monitor via heartbeat API or GitHub comments.',
@@ -364,9 +398,7 @@ async def claim_extended_task(
     from . import database as db
 
     worker_capabilities = [
-        str(cap).strip()
-        for cap in (capabilities or [])
-        if str(cap).strip()
+        str(cap).strip() for cap in (capabilities or []) if str(cap).strip()
     ]
 
     # Extended polling is load-balanced independently of the SSE connection.
@@ -388,7 +420,10 @@ async def claim_extended_task(
                 f'Failed to load registered capabilities for worker {worker_id}: {e}'
             )
 
-    if 'knative' in worker_capabilities and 'persistent' not in worker_capabilities:
+    if (
+        'knative' in worker_capabilities
+        and 'persistent' not in worker_capabilities
+    ):
         logger.debug(
             f'Worker {worker_id} is knative-only; skipping extended persistent claim'
         )
@@ -401,9 +436,12 @@ async def claim_extended_task(
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             'SELECT * FROM claim_next_task_run_extended($1, $2, $3, $4, $5, $6)',
-            worker_id, PERSISTENT_WORKER_LEASE_SECONDS,
-            agent_name, json.dumps(worker_capabilities),
-            models_supported or None, PERSISTENT_WORKER_MAX_TIMEOUT,
+            worker_id,
+            PERSISTENT_WORKER_LEASE_SECONDS,
+            agent_name,
+            json.dumps(worker_capabilities),
+            models_supported or None,
+            PERSISTENT_WORKER_MAX_TIMEOUT,
         )
 
     if not row or not row.get('run_id'):
@@ -438,12 +476,14 @@ async def post_extended_heartbeat(
 
     progress_json = None
     if progress_pct is not None or status_message is not None:
-        progress_json = json.dumps({
-            'progress_pct': progress_pct,
-            'status_message': status_message,
-            'worker_id': worker_id,
-            'heartbeat_at': datetime.now(UTC).isoformat(),
-        })
+        progress_json = json.dumps(
+            {
+                'progress_pct': progress_pct,
+                'status_message': status_message,
+                'worker_id': worker_id,
+                'heartbeat_at': datetime.now(UTC).isoformat(),
+            }
+        )
 
     checkpoint_json = json.dumps(checkpoint) if checkpoint else None
     lease_seconds = lease_extension_seconds or PERSISTENT_WORKER_LEASE_SECONDS
@@ -451,8 +491,13 @@ async def post_extended_heartbeat(
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             'SELECT * FROM extended_heartbeat($1, $2, $3, $4, $5, $6, $7)',
-            task_id, worker_id, progress_json, checkpoint_json,
-            checkpoint_seq, lease_seconds, log_tail,
+            task_id,
+            worker_id,
+            progress_json,
+            checkpoint_json,
+            checkpoint_seq,
+            lease_seconds,
+            log_tail,
         )
 
     if not row or not row['success']:
@@ -464,7 +509,8 @@ async def post_extended_heartbeat(
     return {
         'success': True,
         'lease_expires_at': row['lease_expires_at'].isoformat()
-            if row['lease_expires_at'] else None,
+        if row['lease_expires_at']
+        else None,
         'within_timeout': row['within_timeout'],
         'elapsed_seconds': row['elapsed_seconds'],
         'resume_attempt': row['resume_attempt'],

--- a/a2a_server/persistent_worker_pool.py
+++ b/a2a_server/persistent_worker_pool.py
@@ -1,5 +1,4 @@
-"""
-Persistent Worker Pool — 7-Day Task Execution Infrastructure.
+"""Persistent Worker Pool — 7-Day Task Execution Infrastructure.
 
 Replaces Knative-based ephemeral model with persistent worker pool:
 - StatefulSets (not Knative) — workers stay running 24/7
@@ -16,13 +15,14 @@ Configuration:
     GITHUB_PROGRESS_INTERVAL_SECONDS: GitHub comment frequency (default: 300)
 """
 
-import asyncio
 import json
 import logging
 import os
+
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from datetime import UTC, datetime
+from typing import Any
+
 
 logger = logging.getLogger(__name__)
 
@@ -40,9 +40,12 @@ GITHUB_PROGRESS_INTERVAL_SECONDS = int(
 )
 
 DEFAULT_TASK_TIMEOUT = 604800  # 7 days
+GITHUB_APP_TENANT_EMAIL = os.environ.get(
+    'GITHUB_APP_TENANT_EMAIL', 'github-actions@codetether.run'
+)
 
 
-def _github_work_key(metadata: Dict[str, Any]) -> Optional[str]:
+def _github_work_key(metadata: dict[str, Any]) -> str | None:
     """Return a stable idempotency key for active GitHub App work.
 
     The key is intentionally scoped to one workflow stage and head SHA so a PR can
@@ -68,8 +71,68 @@ def _github_work_key(metadata: Dict[str, Any]) -> Optional[str]:
     return f'github-app:{repo}:{number}:{stage}:{head_sha}'
 
 
+def _is_github_app_task(metadata: dict[str, Any]) -> bool:
+    return bool(
+        metadata.get('source') == 'github-app'
+        or metadata.get('github_installation_id')
+        or metadata.get('github_issue_url')
+    )
+
+
+async def _resolve_github_app_tenant_id(
+    metadata: dict[str, Any], workspace_id: str | None
+) -> str:
+    tenant_id = str(metadata.get('tenant_id') or '').strip()
+    if tenant_id:
+        return tenant_id
+
+    env_tenant_id = str(
+        os.environ.get('GITHUB_APP_TENANT_ID')
+        or os.environ.get('A2A_GITHUB_APP_TENANT_ID')
+        or ''
+    ).strip()
+    if env_tenant_id:
+        return env_tenant_id
+
+    from . import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        raise RuntimeError('Database not available for GitHub App tenant resolution')
+    async with pool.acquire() as conn:
+        if workspace_id:
+            tenant_id = await conn.fetchval(
+                'SELECT tenant_id FROM workspaces WHERE id = $1', workspace_id
+            )
+            if tenant_id:
+                return str(tenant_id)
+        tenant_id = await conn.fetchval(
+            'SELECT tenant_id FROM users WHERE lower(email) = lower($1) LIMIT 1',
+            GITHUB_APP_TENANT_EMAIL,
+        )
+        if tenant_id:
+            return str(tenant_id)
+    raise RuntimeError('GitHub App task tenant_id is required')
+
+
+async def _bind_workspace_tenant(workspace_id: str | None, tenant_id: str) -> None:
+    if not workspace_id or not tenant_id:
+        return
+    from . import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        return
+    async with pool.acquire() as conn:
+        await conn.execute(
+            'UPDATE workspaces SET tenant_id = $2, updated_at = NOW() '
+            'WHERE id = $1 AND tenant_id IS NULL',
+            workspace_id,
+            tenant_id,
+        )
+
 @asynccontextmanager
-async def _github_work_dedupe_lock(metadata: Dict[str, Any]):
+async def _github_work_dedupe_lock(metadata: dict[str, Any]):
     """Serialize GitHub App task creation for one work key across API pods."""
     work_key = _github_work_key(metadata)
     if not work_key:
@@ -94,7 +157,7 @@ async def _github_work_dedupe_lock(metadata: Dict[str, Any]):
             await pool.release(conn)
 
 
-async def _active_github_work_task_id(work_key: Optional[str]) -> Optional[str]:
+async def _active_github_work_task_id(work_key: str | None) -> str | None:
     """Return the oldest active task for a GitHub App idempotency key."""
     if not work_key:
         return None
@@ -127,11 +190,12 @@ async def create_and_dispatch_task(
     prompt: str,
     agent_type: str = 'build',
     priority: int = 0,
-    model_ref: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
+    model_ref: str | None = None,
+    metadata: dict[str, Any] | None = None,
     task_timeout_seconds: int = DEFAULT_TASK_TIMEOUT,
-    github_issue_url: Optional[str] = None,
-) -> str:
+    github_issue_url: str | None = None,
+    with_created: bool = False,
+):
     """Create a task AND dispatch it as fire-and-forget in one call.
 
     Primary entry point for the webhook flow:
@@ -142,7 +206,11 @@ async def create_and_dispatch_task(
       2. Creates a fire-and-forget run with the given timeout
       3. Notifies SSE workers that a new task is available
 
-    Returns the task ID.
+    Returns the task ID. When ``with_created`` is True, returns
+    ``(task_id, created)`` instead, where ``created`` is False if an active
+    task for the same GitHub work key was reused instead of created. Callers
+    use this to avoid posting duplicate acceptance comments on redelivered or
+    fanned-out webhook events.
     """
     from .monitor_api import get_agent_bridge
 
@@ -164,10 +232,18 @@ async def create_and_dispatch_task(
     if model_ref:
         effective_metadata['model_ref'] = model_ref
 
+    if _is_github_app_task(effective_metadata):
+        tenant_id = await _resolve_github_app_tenant_id(effective_metadata, workspace_id)
+        effective_metadata['tenant_id'] = tenant_id
+        await _bind_workspace_tenant(workspace_id, tenant_id)
+    else:
+        tenant_id = str(effective_metadata.get('tenant_id') or '').strip() or None
+
     work_key = _github_work_key(effective_metadata)
     if work_key:
         effective_metadata['github_work_key'] = work_key
 
+    created = True
     async with _github_work_dedupe_lock(effective_metadata) as locked_work_key:
         existing_task_id = await _active_github_work_task_id(locked_work_key)
         if existing_task_id:
@@ -176,7 +252,7 @@ async def create_and_dispatch_task(
                 existing_task_id,
                 locked_work_key,
             )
-            return existing_task_id
+            return (existing_task_id, False) if with_created else existing_task_id
 
         # 1. Create the task via the bridge (standard task row in tasks table)
         task = await bridge.create_task(
@@ -205,13 +281,14 @@ async def create_and_dispatch_task(
             task_timeout_seconds=task_timeout_seconds,
             github_issue_url=github_issue_url,
             metadata=effective_metadata,
+            tenant_id=tenant_id,
         )
 
     logger.info(
         f'Created and dispatched FF task {task_id} '
         f'(timeout={task_timeout_seconds}s, github={bool(github_issue_url)})'
     )
-    return task_id
+    return (task_id, created) if with_created else task_id
 
 
 async def dispatch_fire_and_forget(
@@ -219,14 +296,14 @@ async def dispatch_fire_and_forget(
     title: str,
     description: str,
     agent_type: str = 'build',
-    model: Optional[str] = None,
+    model: str | None = None,
     priority: int = 0,
     task_timeout_seconds: int = 604800,
-    github_issue_url: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
-    tenant_id: Optional[str] = None,
-    user_id: Optional[str] = None,
-) -> Dict[str, Any]:
+    github_issue_url: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    tenant_id: str | None = None,
+    user_id: str | None = None,
+) -> dict[str, Any]:
     """Fire-and-forget dispatch: create task + run, return immediately."""
     from . import database as db
 
@@ -279,10 +356,10 @@ async def dispatch_fire_and_forget(
 
 async def claim_extended_task(
     worker_id: str,
-    agent_name: Optional[str] = None,
-    capabilities: Optional[List[str]] = None,
-    models_supported: Optional[List[str]] = None,
-) -> Optional[Dict[str, Any]]:
+    agent_name: str | None = None,
+    capabilities: list[str] | None = None,
+    models_supported: list[str] | None = None,
+) -> dict[str, Any] | None:
     """Claim next task including fire_and_forget with checkpoint resume."""
     from . import database as db
 
@@ -345,13 +422,13 @@ async def claim_extended_task(
 async def post_extended_heartbeat(
     task_id: str,
     worker_id: str,
-    progress_pct: Optional[float] = None,
-    status_message: Optional[str] = None,
-    checkpoint: Optional[Dict[str, Any]] = None,
-    checkpoint_seq: Optional[int] = None,
-    log_tail: Optional[str] = None,
-    lease_extension_seconds: Optional[int] = None,
-) -> Dict[str, Any]:
+    progress_pct: float | None = None,
+    status_message: str | None = None,
+    checkpoint: dict[str, Any] | None = None,
+    checkpoint_seq: int | None = None,
+    log_tail: str | None = None,
+    lease_extension_seconds: int | None = None,
+) -> dict[str, Any]:
     """Extended heartbeat for 7-day tasks with checkpoint and lease renewal."""
     from . import database as db
 
@@ -365,7 +442,7 @@ async def post_extended_heartbeat(
             'progress_pct': progress_pct,
             'status_message': status_message,
             'worker_id': worker_id,
-            'heartbeat_at': datetime.now(timezone.utc).isoformat(),
+            'heartbeat_at': datetime.now(UTC).isoformat(),
         })
 
     checkpoint_json = json.dumps(checkpoint) if checkpoint else None

--- a/a2a_server/worker_claim_routing.py
+++ b/a2a_server/worker_claim_routing.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
-from typing import Any, Optional
+
+from datetime import UTC, datetime
+from typing import Any
+
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +26,24 @@ def normalize_capabilities(value: Any) -> list[str]:
 
 
 _PERSISTENT_CAPABILITY_ALIASES = {
-    'persistent': {'persistent', 'persistent-workspace', 'persistent_workspace', 'harvester'},
-    'persistent-workspace': {'persistent-workspace', 'persistent_workspace', 'persistent', 'harvester'},
-    'persistent_workspace': {'persistent-workspace', 'persistent_workspace', 'persistent', 'harvester'},
+    'persistent': {
+        'persistent',
+        'persistent-workspace',
+        'persistent_workspace',
+        'harvester',
+    },
+    'persistent-workspace': {
+        'persistent-workspace',
+        'persistent_workspace',
+        'persistent',
+        'harvester',
+    },
+    'persistent_workspace': {
+        'persistent-workspace',
+        'persistent_workspace',
+        'persistent',
+        'harvester',
+    },
 }
 
 
@@ -60,7 +77,7 @@ def worker_satisfies_required_capabilities(
     return True
 
 
-async def db_worker_agent_name(worker_id: str) -> Optional[str]:
+async def db_worker_agent_name(worker_id: str) -> str | None:
     """Resolve a worker's registered agent name from durable storage."""
     try:
         from .database import db_get_worker
@@ -99,7 +116,9 @@ async def db_worker_recent(worker_id: str, max_age_seconds: int = 120) -> bool:
 
         worker = await db_get_worker(worker_id)
     except Exception as e:
-        logger.debug(f'Failed to resolve target worker freshness for {worker_id}: {e}')
+        logger.debug(
+            f'Failed to resolve target worker freshness for {worker_id}: {e}'
+        )
         return False
 
     if not worker or worker.get('status') != 'active':
@@ -114,5 +133,5 @@ async def db_worker_recent(worker_id: str, max_age_seconds: int = 120) -> bool:
         except ValueError:
             return False
     if last_seen.tzinfo is None:
-        last_seen = last_seen.replace(tzinfo=timezone.utc)
-    return (datetime.now(timezone.utc) - last_seen).total_seconds() <= max_age_seconds
+        last_seen = last_seen.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - last_seen).total_seconds() <= max_age_seconds

--- a/a2a_server/worker_claim_routing.py
+++ b/a2a_server/worker_claim_routing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -12,17 +13,51 @@ logger = logging.getLogger(__name__)
 def normalize_capabilities(value: Any) -> list[str]:
     """Normalize capability payloads from headers, JSON, or DB rows."""
     if isinstance(value, str):
-        value = [value]
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            parsed = [value]
+        value = parsed
     if not isinstance(value, list):
         return []
     return [str(cap).strip() for cap in value if str(cap).strip()]
 
 
+_PERSISTENT_CAPABILITY_ALIASES = {
+    'persistent': {'persistent', 'persistent-workspace', 'persistent_workspace', 'harvester'},
+    'persistent-workspace': {'persistent-workspace', 'persistent_workspace', 'persistent', 'harvester'},
+    'persistent_workspace': {'persistent-workspace', 'persistent_workspace', 'persistent', 'harvester'},
+}
+
+
 def has_persistent_workspace_capability(capabilities: list[str]) -> bool:
     return any(
-        cap in {'persistent-workspace', 'persistent_workspace', 'persistent', 'harvester'}
+        cap in _PERSISTENT_CAPABILITY_ALIASES['persistent']
         for cap in capabilities
     )
+
+
+def worker_satisfies_required_capabilities(
+    worker_capabilities: list[str],
+    required_capabilities: list[str],
+) -> bool:
+    """Return whether worker capabilities satisfy task requirements.
+
+    Persistent workers historically register one of several equivalent names
+    (persistent, persistent-workspace, persistent_workspace, harvester). Keep
+    claim-time eligibility aligned with polling-time eligibility so a worker is
+    not offered a task it cannot claim.
+    """
+    if not required_capabilities:
+        return True
+    if not worker_capabilities:
+        return False
+    worker_caps = set(worker_capabilities)
+    for required in required_capabilities:
+        accepted = _PERSISTENT_CAPABILITY_ALIASES.get(required, {required})
+        if not worker_caps.intersection(accepted):
+            return False
+    return True
 
 
 async def db_worker_agent_name(worker_id: str) -> Optional[str]:

--- a/a2a_server/worker_sse.py
+++ b/a2a_server/worker_sse.py
@@ -1,5 +1,4 @@
-"""
-Worker SSE Task Stream - Push-based task distribution for A2A workers.
+"""Worker SSE Task Stream - Push-based task distribution for A2A workers.
 
 This module implements "reverse-polling" via Server-Sent Events (SSE) where workers
 connect outbound to the server and receive task notifications pushed to them.
@@ -20,11 +19,13 @@ import asyncio
 import json
 import logging
 import uuid
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Set
 
-from fastapi import APIRouter, HTTPException, Request, Query, Header
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Header, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -33,24 +34,36 @@ from .task_routing import (
     is_targeted_clone_task,
     target_agent_mismatch,
 )
+from .worker_auth import verify_auth as _verify_auth
 from .worker_claim_routing import (
     db_worker_agent_name as _db_worker_agent_name,
-    db_worker_capabilities as _db_worker_capabilities,
-    db_worker_recent as _db_worker_recent,
-    has_persistent_workspace_capability as _has_persistent_workspace_capability,
-    normalize_capabilities as _normalize_capabilities,
-    worker_satisfies_required_capabilities as _worker_satisfies_required_capabilities,
 )
-from .worker_task_run_claims import (
-    claim_task_run_for_worker as _claim_task_run_for_worker,
-    mirror_release_to_task_run as _mirror_release_to_task_run,
+from .worker_claim_routing import (
+    db_worker_capabilities as _db_worker_capabilities,
+)
+from .worker_claim_routing import (
+    db_worker_recent as _db_worker_recent,
+)
+from .worker_claim_routing import (
+    has_persistent_workspace_capability as _has_persistent_workspace_capability,
+)
+from .worker_claim_routing import (
+    normalize_capabilities as _normalize_capabilities,
+)
+from .worker_claim_routing import (
+    worker_satisfies_required_capabilities as _worker_satisfies_required_capabilities,
 )
 from .worker_persistent_claim_loop import (
     start_persistent_claim_loop as _start_persistent_claim_loop,
-    stop_persistent_claim_loop,
 )
-from .worker_auth import verify_auth as _verify_auth
 from .worker_progress_routes import worker_progress_router
+from .worker_task_run_claims import (
+    claim_task_run_for_worker as _claim_task_run_for_worker,
+)
+from .worker_task_run_claims import (
+    mirror_release_to_task_run as _mirror_release_to_task_run,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -68,15 +81,14 @@ class ConnectedWorker:
     queue: asyncio.Queue
     connected_at: datetime
     last_heartbeat: datetime
-    capabilities: List[str] = field(default_factory=list)
-    codebases: Set[str] = field(default_factory=set)
+    capabilities: list[str] = field(default_factory=list)
+    codebases: set[str] = field(default_factory=set)
     is_busy: bool = False  # True when worker is processing a task
-    current_task_id: Optional[str] = None
+    current_task_id: str | None = None
 
 
 class WorkerRegistry:
-    """
-    Registry of workers connected via SSE for push-based task distribution.
+    """Registry of workers connected via SSE for push-based task distribution.
 
     Thread-safe via asyncio locks. Supports:
     - Worker registration/deregistration on SSE connect/disconnect
@@ -86,24 +98,24 @@ class WorkerRegistry:
     """
 
     def __init__(self):
-        self._workers: Dict[str, ConnectedWorker] = {}
+        self._workers: dict[str, ConnectedWorker] = {}
         self._lock = asyncio.Lock()
         # Track claimed tasks: task_id -> worker_id
-        self._claimed_tasks: Dict[str, str] = {}
+        self._claimed_tasks: dict[str, str] = {}
         # Callbacks for task creation events
-        self._task_listeners: List[Callable] = []
+        self._task_listeners: list[Callable] = []
 
     async def register_worker(
         self,
         worker_id: str,
         agent_name: str,
         queue: asyncio.Queue,
-        capabilities: Optional[List[str]] = None,
-        codebases: Optional[Set[str]] = None,
+        capabilities: list[str] | None = None,
+        codebases: set[str] | None = None,
     ) -> ConnectedWorker:
         """Register a new SSE-connected worker."""
         async with self._lock:
-            now = datetime.now(timezone.utc)
+            now = datetime.now(UTC)
             worker = ConnectedWorker(
                 worker_id=worker_id,
                 agent_name=agent_name,
@@ -120,9 +132,7 @@ class WorkerRegistry:
             )
             return worker
 
-    async def unregister_worker(
-        self, worker_id: str
-    ) -> Optional[ConnectedWorker]:
+    async def unregister_worker(self, worker_id: str) -> ConnectedWorker | None:
         """Unregister a disconnected worker."""
         async with self._lock:
             worker = self._workers.pop(worker_id, None)
@@ -150,7 +160,7 @@ class WorkerRegistry:
         async with self._lock:
             worker = self._workers.get(worker_id)
             if worker:
-                worker.last_heartbeat = datetime.now(timezone.utc)
+                worker.last_heartbeat = datetime.now(UTC)
                 # Persist to DB so task_reaper sees an active worker
                 asyncio.create_task(self._persist_heartbeat(worker_id))
                 return True
@@ -165,7 +175,7 @@ class WorkerRegistry:
         except Exception as e:
             logger.debug(f'Failed to persist heartbeat for {worker_id}: {e}')
 
-    async def _lookup_worker_agent_name(self, worker_id: str) -> Optional[str]:
+    async def _lookup_worker_agent_name(self, worker_id: str) -> str | None:
         """Resolve a worker's agent name from durable state.
 
         SSE connections are stored in-memory per API replica. A polling claim can
@@ -187,7 +197,7 @@ class WorkerRegistry:
             return None
 
     async def update_worker_codebases(
-        self, worker_id: str, codebases: Set[str]
+        self, worker_id: str, codebases: set[str]
     ) -> bool:
         """Update the codebases a worker can handle."""
         async with self._lock:
@@ -198,8 +208,7 @@ class WorkerRegistry:
             return False
 
     async def claim_task(self, task_id: str, worker_id: str) -> bool:
-        """
-        Atomically claim a task for a worker.
+        """Atomically claim a task for a worker.
 
         Returns True if claim succeeded, False if task was already claimed
         or if the worker doesn't own the task's codebase.
@@ -230,7 +239,9 @@ class WorkerRegistry:
                     worker_capabilities
                 )
                 if target_worker_id and target_worker_id != worker_id:
-                    if not persistent_worker or await _db_worker_recent(target_worker_id):
+                    if not persistent_worker or await _db_worker_recent(
+                        target_worker_id
+                    ):
                         logger.debug(
                             f'Worker {worker_id} skipped task {task_id} '
                             f'(target_worker_id={target_worker_id})'
@@ -288,7 +299,9 @@ class WorkerRegistry:
                     stable_persistent_route = (
                         bool(task_target_agent)
                         and task_target_agent == worker_agent_name
-                        and _has_persistent_workspace_capability(required_capabilities)
+                        and _has_persistent_workspace_capability(
+                            required_capabilities
+                        )
                         and persistent_worker
                     )
                     if stable_persistent_route:
@@ -298,48 +311,46 @@ class WorkerRegistry:
                             f'for codebase {codebase_id}'
                         )
                         # Fall through to the claim lock below.
+                    elif not worker:
+                        # Worker not SSE-connected; allow claim anyway so
+                        # polling-only / reconnecting workers aren't locked out.
+                        logger.debug(
+                            f'Worker {worker_id} not in SSE registry, '
+                            f'allowing claim attempt for task {task_id}'
+                        )
                     else:
-                        if not worker:
-                            # Worker not SSE-connected; allow claim anyway so
-                            # polling-only / reconnecting workers aren't locked out.
-                            logger.debug(
-                                f'Worker {worker_id} not in SSE registry, '
-                                f'allowing claim attempt for task {task_id}'
+                        can_handle = codebase_id in worker.codebases
+                        if not can_handle:
+                            can_handle = await self._worker_owns_codebase(
+                                worker_id, codebase_id
                             )
-                        else:
-                            can_handle = codebase_id in worker.codebases
-                            if not can_handle:
-                                can_handle = await self._worker_owns_codebase(
-                                    worker_id, codebase_id
+                        if not can_handle:
+                            # Check if ANY connected worker owns this codebase;
+                            # if not, the codebase has a stale worker_id and we
+                            # should let any worker pick it up rather than
+                            # leaving the task stuck forever.
+                            owner_connected = False
+                            async with self._lock:
+                                for w in self._workers.values():
+                                    if codebase_id in w.codebases:
+                                        owner_connected = True
+                                        break
+                            if not owner_connected:
+                                owner_connected = await self._any_connected_worker_owns_codebase(
+                                    codebase_id
                                 )
-                            if not can_handle:
-                                # Check if ANY connected worker owns this codebase;
-                                # if not, the codebase has a stale worker_id and we
-                                # should let any worker pick it up rather than
-                                # leaving the task stuck forever.
-                                owner_connected = False
-                                async with self._lock:
-                                    for w in self._workers.values():
-                                        if codebase_id in w.codebases:
-                                            owner_connected = True
-                                            break
-                                if not owner_connected:
-                                    owner_connected = await self._any_connected_worker_owns_codebase(
-                                        codebase_id
-                                    )
 
-                                if owner_connected:
-                                    logger.debug(
-                                        f'Worker {worker_id} ({worker.agent_name}) skipped task {task_id} '
-                                        f'for codebase {codebase_id} (worker codebases: {worker.codebases})'
-                                    )
-                                    return False
-                                else:
-                                    logger.warning(
-                                        f'No connected worker owns codebase {codebase_id} — '
-                                        f'allowing worker {worker_id} ({worker.agent_name}) '
-                                        f'to claim orphaned task {task_id}'
-                                    )
+                            if owner_connected:
+                                logger.debug(
+                                    f'Worker {worker_id} ({worker.agent_name}) skipped task {task_id} '
+                                    f'for codebase {codebase_id} (worker codebases: {worker.codebases})'
+                                )
+                                return False
+                            logger.warning(
+                                f'No connected worker owns codebase {codebase_id} — '
+                                f'allowing worker {worker_id} ({worker.agent_name}) '
+                                f'to claim orphaned task {task_id}'
+                            )
 
         async with self._lock:
             if task_id in self._claimed_tasks:
@@ -472,14 +483,13 @@ class WorkerRegistry:
 
     async def get_available_workers(
         self,
-        codebase_id: Optional[str] = None,
-        target_agent_name: Optional[str] = None,
-        target_worker_id: Optional[str] = None,
-        required_capabilities: Optional[List[str]] = None,
-        task_agent_type: Optional[str] = None,
-    ) -> List[ConnectedWorker]:
-        """
-        Get workers available to accept a new task.
+        codebase_id: str | None = None,
+        target_agent_name: str | None = None,
+        target_worker_id: str | None = None,
+        required_capabilities: list[str] | None = None,
+        task_agent_type: str | None = None,
+    ) -> list[ConnectedWorker]:
+        """Get workers available to accept a new task.
 
         Filters by:
         - Not currently busy
@@ -532,7 +542,9 @@ class WorkerRegistry:
                         and _has_persistent_workspace_capability(
                             required_capabilities or []
                         )
-                        and _has_persistent_workspace_capability(worker.capabilities)
+                        and _has_persistent_workspace_capability(
+                            worker.capabilities
+                        )
                     ):
                         pass
                     elif await self._worker_owns_codebase(
@@ -602,12 +614,12 @@ class WorkerRegistry:
             logger.debug(f'Error checking connected codebase owners: {e}')
         return False
 
-    async def get_worker(self, worker_id: str) -> Optional[ConnectedWorker]:
+    async def get_worker(self, worker_id: str) -> ConnectedWorker | None:
         """Get a specific worker by ID."""
         async with self._lock:
             return self._workers.get(worker_id)
 
-    async def list_idle_persistent_workers(self) -> List[ConnectedWorker]:
+    async def list_idle_persistent_workers(self) -> list[ConnectedWorker]:
         """Return connected, idle workers eligible for durable FF claims.
 
         Some deployed Rust workers register capabilities through the durable
@@ -616,9 +628,13 @@ class WorkerRegistry:
         claim bridge can still recognize harvester/persistent workers.
         """
         async with self._lock:
-            workers = [worker for worker in self._workers.values() if not worker.is_busy]
+            workers = [
+                worker
+                for worker in self._workers.values()
+                if not worker.is_busy
+            ]
 
-        eligible: List[ConnectedWorker] = []
+        eligible: list[ConnectedWorker] = []
         for worker in workers:
             capabilities = list(worker.capabilities or [])
             if not capabilities:
@@ -636,12 +652,12 @@ class WorkerRegistry:
                 eligible.append(worker)
         return eligible
 
-    async def claimed_task_ids(self) -> Set[str]:
+    async def claimed_task_ids(self) -> set[str]:
         """Return task IDs currently held by the in-memory claim registry."""
         async with self._lock:
             return set(self._claimed_tasks)
 
-    async def list_workers(self) -> List[Dict[str, Any]]:
+    async def list_workers(self) -> list[dict[str, Any]]:
         """List all connected workers."""
         async with self._lock:
             return [
@@ -661,10 +677,9 @@ class WorkerRegistry:
     async def push_task_to_worker(
         self,
         worker_id: str,
-        task: Dict[str, Any],
+        task: dict[str, Any],
     ) -> bool:
-        """
-        Push a task notification to a specific worker.
+        """Push a task notification to a specific worker.
 
         Returns True if the message was queued successfully.
         """
@@ -677,7 +692,7 @@ class WorkerRegistry:
                 event = {
                     'event': 'task_available',
                     'data': task,
-                    'timestamp': datetime.now(timezone.utc).isoformat(),
+                    'timestamp': datetime.now(UTC).isoformat(),
                 }
                 await worker.queue.put(event)
                 return True
@@ -687,14 +702,13 @@ class WorkerRegistry:
 
     async def broadcast_task(
         self,
-        task: Dict[str, Any],
-        codebase_id: Optional[str] = None,
-        target_agent_name: Optional[str] = None,
-        target_worker_id: Optional[str] = None,
-        required_capabilities: Optional[List[str]] = None,
-    ) -> List[str]:
-        """
-        Broadcast a task to all available workers that can handle it.
+        task: dict[str, Any],
+        codebase_id: str | None = None,
+        target_agent_name: str | None = None,
+        target_worker_id: str | None = None,
+        required_capabilities: list[str] | None = None,
+    ) -> list[str]:
+        """Broadcast a task to all available workers that can handle it.
 
         For targeted tasks (target_agent_name or target_worker_id set), only notifies the specific worker.
         This is notify-time filtering for efficiency; claim-time is the real enforcement.
@@ -737,10 +751,9 @@ class WorkerRegistry:
         return notified
 
     async def _enrich_task_with_persona_scoping(
-        self, task: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """
-        Enrich task metadata with permission scoping from the worker_profile
+        self, task: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Enrich task metadata with permission scoping from the worker_profile
         matching the task's worker_personality. This backs the marketing claim:
         "each agent only has the permissions it needs."
 
@@ -753,8 +766,9 @@ class WorkerRegistry:
             return task
 
         try:
-            from . import database as db
             import json as _json
+
+            from . import database as db
 
             pool = await db.get_pool()
             if not pool:
@@ -801,11 +815,10 @@ class WorkerRegistry:
     async def broadcast_task_available(
         self,
         task_id: str,
-        codebase_id: Optional[str] = None,
-        target_agent_name: Optional[str] = None,
-    ) -> List[str]:
-        """
-        Broadcast that a task is available to workers that can handle it.
+        codebase_id: str | None = None,
+        target_agent_name: str | None = None,
+    ) -> list[str]:
+        """Broadcast that a task is available to workers that can handle it.
 
         This fetches the task details and broadcasts to appropriate workers.
         Used when a task is created or becomes available for claiming.
@@ -875,7 +888,7 @@ class WorkerRegistry:
         if callback in self._task_listeners:
             self._task_listeners.remove(callback)
 
-    async def notify_task_created(self, task: Dict[str, Any]) -> None:
+    async def notify_task_created(self, task: dict[str, Any]) -> None:
         """Notify all listeners that a new task was created."""
         for callback in self._task_listeners:
             try:
@@ -888,7 +901,7 @@ class WorkerRegistry:
 
 
 # Global worker registry singleton
-_worker_registry: Optional[WorkerRegistry] = None
+_worker_registry: WorkerRegistry | None = None
 
 
 def get_worker_registry() -> WorkerRegistry:
@@ -933,8 +946,8 @@ class TaskReleaseRequest(BaseModel):
 
     task_id: str
     status: str = 'completed'  # completed, failed, cancelled
-    result: Optional[str] = None
-    error: Optional[str] = None
+    result: str | None = None
+    error: str | None = None
 
 
 async def _db_claim_allows_release(task_id: str, worker_id: str) -> bool:
@@ -974,12 +987,12 @@ async def _db_claim_allows_release(task_id: str, worker_id: str) -> bool:
 class CodebaseUpdateRequest(BaseModel):
     """Request to update worker's codebase list."""
 
-    codebases: List[str]
+    codebases: list[str]
     # Accept extra fields from workers that send full registration payloads
-    worker_id: Optional[str] = None
-    agent_name: Optional[str] = None
-    models: Optional[Any] = None
-    capabilities: Optional[List[str]] = None
+    worker_id: str | None = None
+    agent_name: str | None = None
+    models: Any | None = None
+    capabilities: list[str] | None = None
 
     model_config = {'extra': 'ignore'}
 
@@ -987,17 +1000,16 @@ class CodebaseUpdateRequest(BaseModel):
 @worker_sse_router.get('/tasks/stream')
 async def worker_task_stream(
     request: Request,
-    agent_name: Optional[str] = Query(None, description='Worker agent name'),
-    worker_id: Optional[str] = Query(
+    agent_name: str | None = Query(None, description='Worker agent name'),
+    worker_id: str | None = Query(
         None, description='Worker ID (optional, generated if not provided)'
     ),
-    x_agent_name: Optional[str] = Header(None, alias='X-Agent-Name'),
-    x_worker_id: Optional[str] = Header(None, alias='X-Worker-ID'),
-    x_capabilities: Optional[str] = Header(None, alias='X-Capabilities'),
-    x_codebases: Optional[str] = Header(None, alias='X-Codebases'),
+    x_agent_name: str | None = Header(None, alias='X-Agent-Name'),
+    x_worker_id: str | None = Header(None, alias='X-Worker-ID'),
+    x_capabilities: str | None = Header(None, alias='X-Capabilities'),
+    x_codebases: str | None = Header(None, alias='X-Codebases'),
 ):
-    """
-    SSE endpoint for workers to receive task notifications.
+    """SSE endpoint for workers to receive task notifications.
 
     Workers connect to this endpoint and receive:
     - `task_available` events when new tasks are created
@@ -1090,14 +1102,14 @@ async def worker_task_stream(
                 'worker_id': resolved_worker_id,
                 'agent_name': resolved_agent_name,
                 'message': 'Connected to task stream',
-                'timestamp': datetime.now(timezone.utc).isoformat(),
+                'timestamp': datetime.now(UTC).isoformat(),
             }
             yield f'event: connected\ndata: {json.dumps(connect_event)}\n\n'
 
             # Send any pending tasks to the newly connected worker
             try:
-                from .agent_bridge import get_bridge as get_agent_bridge
                 from .agent_bridge import AgentTaskStatus
+                from .agent_bridge import get_bridge as get_agent_bridge
 
                 bridge = get_agent_bridge()
                 if bridge:
@@ -1192,14 +1204,14 @@ async def worker_task_stream(
 
                         yield f'event: {event_type}\ndata: {json.dumps(event_data)}\n\n'
 
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         pass  # No event, check if heartbeat needed
 
                     # Send heartbeat if interval elapsed
                     current_time = asyncio.get_event_loop().time()
                     if current_time - last_heartbeat >= heartbeat_interval:
                         heartbeat_data = {
-                            'timestamp': datetime.now(timezone.utc).isoformat(),
+                            'timestamp': datetime.now(UTC).isoformat(),
                             'worker_id': resolved_worker_id,
                         }
                         yield f'event: heartbeat\ndata: {json.dumps(heartbeat_data)}\n\n'
@@ -1235,11 +1247,10 @@ async def worker_task_stream(
 async def claim_task(
     request: Request,
     claim: TaskClaimRequest,
-    worker_id: Optional[str] = Query(None),
-    x_worker_id: Optional[str] = Header(None, alias='X-Worker-ID'),
+    worker_id: str | None = Query(None),
+    x_worker_id: str | None = Header(None, alias='X-Worker-ID'),
 ):
-    """
-    Claim a task for processing.
+    """Claim a task for processing.
 
     Workers call this endpoint after receiving a task_available event
     to atomically claim the task. This prevents multiple workers from
@@ -1266,8 +1277,8 @@ async def claim_task(
         )
         # Update task status to 'running' in DB so the UI reflects reality
         try:
-            from .agent_bridge import get_bridge as get_agent_bridge
             from .agent_bridge import AgentTaskStatus
+            from .agent_bridge import get_bridge as get_agent_bridge
             from .database import db_update_task_status
 
             bridge = get_agent_bridge()
@@ -1309,25 +1320,23 @@ async def claim_task(
         }
         response.update(run_claim)
         return response
-    else:
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                f'Task {claim.task_id} cannot be claimed by worker {resolved_worker_id} '
-                '(already claimed, worker not connected, or worker not eligible for this task)'
-            ),
-        )
+    raise HTTPException(
+        status_code=409,
+        detail=(
+            f'Task {claim.task_id} cannot be claimed by worker {resolved_worker_id} '
+            '(already claimed, worker not connected, or worker not eligible for this task)'
+        ),
+    )
 
 
 @worker_sse_router.post('/tasks/release')
 async def release_task(
     request: Request,
     release: TaskReleaseRequest,
-    worker_id: Optional[str] = Query(None),
-    x_worker_id: Optional[str] = Header(None, alias='X-Worker-ID'),
+    worker_id: str | None = Query(None),
+    x_worker_id: str | None = Header(None, alias='X-Worker-ID'),
 ):
-    """
-    Release a task after completion or failure.
+    """Release a task after completion or failure.
 
     Workers call this endpoint when they finish processing a task
     to release the claim and report the result.
@@ -1516,22 +1525,20 @@ async def release_task(
             'status': release.status,
             'message': 'Task released successfully',
         }
-    else:
-        raise HTTPException(
-            status_code=404,
-            detail=f'Task {release.task_id} not claimed by worker {resolved_worker_id}',
-        )
+    raise HTTPException(
+        status_code=404,
+        detail=f'Task {release.task_id} not claimed by worker {resolved_worker_id}',
+    )
 
 
 @worker_sse_router.put('/codebases')
 async def update_worker_codebases(
     request: Request,
     update: CodebaseUpdateRequest,
-    worker_id: Optional[str] = Query(None),
-    x_worker_id: Optional[str] = Header(None, alias='X-Worker-ID'),
+    worker_id: str | None = Query(None),
+    x_worker_id: str | None = Header(None, alias='X-Worker-ID'),
 ):
-    """
-    Update the list of codebases a worker can handle.
+    """Update the list of codebases a worker can handle.
 
     Workers call this endpoint after registering new codebases
     to update the server's routing table.
@@ -1558,17 +1565,15 @@ async def update_worker_codebases(
             'codebases': update.codebases,
             'message': 'Codebases updated successfully',
         }
-    else:
-        raise HTTPException(
-            status_code=404,
-            detail=f'Worker {resolved_worker_id} not found (not connected via SSE?)',
-        )
+    raise HTTPException(
+        status_code=404,
+        detail=f'Worker {resolved_worker_id} not found (not connected via SSE?)',
+    )
 
 
 @worker_sse_router.get('/connected')
 async def list_connected_workers(request: Request):
-    """
-    List all workers currently connected via SSE.
+    """List all workers currently connected via SSE.
 
     Returns information about each connected worker including
     their capabilities, codebases, and current status.
@@ -1581,7 +1586,7 @@ async def list_connected_workers(request: Request):
     return {
         'workers': workers,
         'count': len(workers),
-        'timestamp': datetime.now(timezone.utc).isoformat(),
+        'timestamp': datetime.now(UTC).isoformat(),
     }
 
 
@@ -1619,9 +1624,8 @@ async def get_connected_worker(
 # ============================================================================
 
 
-async def notify_workers_of_new_task(task: Dict[str, Any]) -> List[str]:
-    """
-    Notify connected workers of a new task.
+async def notify_workers_of_new_task(task: dict[str, Any]) -> list[str]:
+    """Notify connected workers of a new task.
 
     This function should be called when a new task is created to push
     it to available workers via SSE.
@@ -1661,17 +1665,15 @@ async def notify_workers_of_new_task(task: Dict[str, Any]) -> List[str]:
 
 
 def setup_task_creation_hook(agent_bridge) -> None:
-    """
-    Set up a hook to notify workers when tasks are created.
+    """Set up a hook to notify workers when tasks are created.
 
     This should be called during server initialization to connect
     the task queue to the SSE push system.
     """
     registry = get_worker_registry()
 
-    async def on_task_created(task: Dict[str, Any]):
+    async def on_task_created(task: dict[str, Any]):
         await notify_workers_of_new_task(task)
 
     registry.add_task_listener(on_task_created)
     logger.info('Task creation hook installed for SSE worker notifications')
-

--- a/a2a_server/worker_sse.py
+++ b/a2a_server/worker_sse.py
@@ -39,6 +39,7 @@ from .worker_claim_routing import (
     db_worker_recent as _db_worker_recent,
     has_persistent_workspace_capability as _has_persistent_workspace_capability,
     normalize_capabilities as _normalize_capabilities,
+    worker_satisfies_required_capabilities as _worker_satisfies_required_capabilities,
 )
 from .worker_task_run_claims import (
     claim_task_run_for_worker as _claim_task_run_for_worker,
@@ -258,9 +259,8 @@ class WorkerRegistry:
                     or getattr(task, 'required_capabilities', None)
                 )
                 if required_capabilities:
-                    if not all(
-                        cap in worker_capabilities
-                        for cap in required_capabilities
+                    if not _worker_satisfies_required_capabilities(
+                        worker_capabilities, required_capabilities
                     ):
                         logger.debug(
                             f'Worker {worker_id} skipped task {task_id} '
@@ -547,9 +547,8 @@ class WorkerRegistry:
 
                 # Check capabilities filter
                 if required_capabilities:
-                    if not all(
-                        cap in worker.capabilities
-                        for cap in required_capabilities
+                    if not _worker_satisfies_required_capabilities(
+                        worker.capabilities, required_capabilities
                     ):
                         continue
 

--- a/a2a_server/worker_task_run_claims.py
+++ b/a2a_server/worker_task_run_claims.py
@@ -74,7 +74,7 @@ async def claim_task_run_for_worker(
                 )
                 UPDATE task_runs tr
                 SET lease_owner = $2,
-                    lease_expires_at = NOW() + ($3 || ' seconds')::INTERVAL,
+                    lease_expires_at = NOW() + ($3::int * INTERVAL '1 second'),
                     status = 'running',
                     started_at = COALESCE(started_at, NOW()),
                     last_heartbeat_at = NOW(),
@@ -102,7 +102,7 @@ async def claim_task_run_for_worker(
 
         return dict(row) if row else {}
     except Exception as e:
-        logger.debug(f'No task_run lease attached to claim {task_id}: {e}')
+        logger.warning(f'No task_run lease attached to claim {task_id}: {e}')
         return {}
 
 

--- a/a2a_server/worker_task_run_claims.py
+++ b/a2a_server/worker_task_run_claims.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+
 from typing import Any
 
 from .worker_claim_routing import db_worker_agent_name, db_worker_capabilities
+
 
 logger = logging.getLogger(__name__)
 
@@ -145,4 +147,6 @@ async def mirror_release_to_task_run(
                 error,
             )
     except Exception as exc:
-        logger.debug('Could not mirror release to task_runs for %s: %s', task_id, exc)
+        logger.debug(
+            'Could not mirror release to task_runs for %s: %s', task_id, exc
+        )

--- a/a2a_server/workflow_monitor_sql.py
+++ b/a2a_server/workflow_monitor_sql.py
@@ -25,7 +25,18 @@ WITH gh AS (
     t.metadata->>'target_worker_id' AS target_worker_id,
     t.metadata->>'target_agent_name' AS target_agent_name,
     w.name AS worker_name, w.status AS worker_status, w.last_seen AS worker_last_seen
-  FROM tasks t LEFT JOIN workers w ON w.worker_id = t.metadata->>'target_worker_id'
+  FROM tasks t
+  LEFT JOIN LATERAL (
+    SELECT name, status, last_seen
+    FROM workers
+    WHERE worker_id = t.metadata->>'target_worker_id'
+      OR (
+        t.metadata->>'target_agent_name' IS NOT NULL
+        AND name = t.metadata->>'target_agent_name'
+      )
+    ORDER BY last_seen DESC NULLS LAST
+    LIMIT 1
+  ) w ON TRUE
   WHERE {GITHUB_TASK_PREDICATE.replace('metadata', 't.metadata')}
     AND (cardinality($1::text[]) = 0 OR {TASK_REPO_EXPR} = ANY($1::text[]))
     AND ($2::text IS NULL OR t.tenant_id = $2::text)
@@ -46,7 +57,7 @@ SELECT repo, issue_pr, url,
   LEFT(STRING_AGG(DISTINCT COALESCE(error, ''), ' | '), 600) AS errors
 FROM (SELECT gh.*, COUNT(*) OVER (PARTITION BY repo, issue_pr, url, status) AS status_count,
   COUNT(*) OVER (PARTITION BY repo, issue_pr, url, agent_type) AS agent_count
-  FROM gh WHERE status IN ('pending', 'running', 'failed')) grouped
+  FROM gh WHERE status IN ('pending', 'running', 'failed', 'completed')) grouped
 GROUP BY repo, issue_pr, url ORDER BY MAX(updated_at) DESC NULLS LAST LIMIT $3
 """
 TASK_ROWS_SQL = f"""
@@ -59,11 +70,22 @@ SELECT t.id, t.status, t.title, t.agent_type, t.priority, t.created_at,
   t.metadata->>'target_worker_id' AS target_worker_id,
   t.metadata->>'target_agent_name' AS target_agent_name,
   w.name AS worker_name, w.status AS worker_status, w.last_seen AS worker_last_seen
-FROM tasks t LEFT JOIN workers w ON w.worker_id = t.metadata->>'target_worker_id'
+FROM tasks t
+LEFT JOIN LATERAL (
+  SELECT name, status, last_seen
+  FROM workers
+  WHERE worker_id = t.metadata->>'target_worker_id'
+    OR (
+      t.metadata->>'target_agent_name' IS NOT NULL
+      AND name = t.metadata->>'target_agent_name'
+    )
+  ORDER BY last_seen DESC NULLS LAST
+  LIMIT 1
+) w ON TRUE
 WHERE {GITHUB_TASK_PREDICATE.replace('metadata', 't.metadata')}
   AND (cardinality($1::text[]) = 0 OR {TASK_REPO_EXPR} = ANY($1::text[]))
   AND ($2::text IS NULL OR t.tenant_id = $2::text)
-  AND t.status IN ('pending', 'running', 'failed')
+  AND t.status IN ('pending', 'running', 'failed', 'completed')
 ORDER BY t.updated_at DESC NULLS LAST LIMIT $3
 """
 
@@ -78,6 +100,5 @@ FROM task_runs tr JOIN tasks t ON t.id = tr.task_id
 WHERE {GITHUB_TASK_PREDICATE.replace('metadata', 't.metadata')}
   AND (cardinality($1::text[]) = 0 OR {TASK_REPO_EXPR} = ANY($1::text[]))
   AND ($2::text IS NULL OR t.tenant_id = $2::text)
-  AND tr.status NOT IN ('completed', 'cancelled')
 ORDER BY tr.updated_at DESC NULLS LAST LIMIT $3
 """

--- a/a2a_server/workflow_monitor_types.py
+++ b/a2a_server/workflow_monitor_types.py
@@ -41,6 +41,13 @@ def _is_missing_branch_error(normalized: str) -> bool:
 
 
 def route_state(row: Any) -> str:
+    status = str(row.get('status') or '').lower()
+    if status in {'completed', 'cancelled'}:
+        return status
+    if status == 'failed':
+        return 'failed'
+    if not row.get('target_worker_id') and row.get('target_agent_name'):
+        return 'target_agent_name'
     if not row.get('target_worker_id'):
         return 'unscoped_or_missing_target'
     if not row.get('worker_name'):

--- a/a2a_server/workflow_monitor_types.py
+++ b/a2a_server/workflow_monitor_types.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, Optional
-from datetime import datetime, timezone, timedelta
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
-def parse_repo_filters(repos: Optional[str]) -> list[str]:
+
+def parse_repo_filters(repos: str | None) -> list[str]:
     return [repo.strip() for repo in (repos or '').split(',') if repo.strip()]
 
 
@@ -9,7 +10,7 @@ def serialize_dt(value: Any) -> Any:
     return value.isoformat() if hasattr(value, 'isoformat') else value
 
 
-def classify_workflow_error(error: Optional[str]) -> str:
+def classify_workflow_error(error: str | None) -> str:
     if not error:
         return 'none'
     normalized = error.lower()
@@ -21,7 +22,10 @@ def classify_workflow_error(error: Optional[str]) -> str:
         return 'provider_unavailable'
     if _is_missing_branch_error(normalized):
         return 'missing_branch'
-    if 'could not lock config file' in normalized or 'credential.helper' in normalized:
+    if (
+        'could not lock config file' in normalized
+        or 'credential.helper' in normalized
+    ):
         return 'git_workspace_lock'
     if 'failed to register cloned workspace' in normalized:
         return 'workspace_registration'
@@ -52,10 +56,14 @@ def route_state(row: Any) -> str:
         return 'unscoped_or_missing_target'
     if not row.get('worker_name'):
         return 'missing_worker'
-    cutoff = datetime.now(timezone.utc) - timedelta(minutes=15)
+    cutoff = datetime.now(UTC) - timedelta(minutes=15)
     last_seen = row.get('worker_last_seen')
-    return 'stale_worker' if not last_seen or last_seen < cutoff else 'active_worker'
+    return (
+        'stale_worker'
+        if not last_seen or last_seen < cutoff
+        else 'active_worker'
+    )
 
 
-def increment(target: Dict[str, int], key: str) -> None:
+def increment(target: dict[str, int], key: str) -> None:
     target[key] = target.get(key, 0) + 1

--- a/scripts/backfill_github_app_tenant.py
+++ b/scripts/backfill_github_app_tenant.py
@@ -9,6 +9,7 @@ import os
 
 import asyncpg
 
+
 GITHUB_TASK_PREDICATE = """
 (metadata->>'source' = 'github-app'
  OR metadata ? 'github_installation_id'
@@ -22,18 +23,22 @@ async def main() -> None:
     parser.add_argument('--dry-run', action='store_true')
     args = parser.parse_args()
 
-    database_url = os.environ.get('DATABASE_URL') or os.environ.get('A2A_DATABASE_URL')
+    database_url = os.environ.get('DATABASE_URL') or os.environ.get(
+        'A2A_DATABASE_URL'
+    )
     if not database_url:
         raise SystemExit('DATABASE_URL or A2A_DATABASE_URL is required')
 
     conn = await asyncpg.connect(database_url)
     try:
-        tenant_exists = await conn.fetchval('SELECT EXISTS(SELECT 1 FROM tenants WHERE id = $1)', args.tenant_id)
+        tenant_exists = await conn.fetchval(
+            'SELECT EXISTS(SELECT 1 FROM tenants WHERE id = $1)', args.tenant_id
+        )
         if not tenant_exists:
             raise SystemExit(f'tenant_id not found: {args.tenant_id}')
 
         task_count = await conn.fetchval(
-            f"SELECT COUNT(*) FROM tasks WHERE tenant_id IS NULL AND {GITHUB_TASK_PREDICATE}"
+            f'SELECT COUNT(*) FROM tasks WHERE tenant_id IS NULL AND {GITHUB_TASK_PREDICATE}'
         )
         workspace_count = await conn.fetchval(
             f"""
@@ -50,7 +55,11 @@ async def main() -> None:
               AND EXISTS (SELECT 1 FROM tasks t WHERE t.id = tr.task_id AND {GITHUB_TASK_PREDICATE.replace('metadata', 't.metadata')})
             """
         )
-        counts = {'tasks': task_count, 'workspaces': workspace_count, 'runs': run_count}
+        counts = {
+            'tasks': task_count,
+            'workspaces': workspace_count,
+            'runs': run_count,
+        }
         print(counts)
         if args.dry_run:
             return
@@ -92,7 +101,7 @@ async def main() -> None:
             )
 
         remaining_tasks = await conn.fetchval(
-            f"SELECT COUNT(*) FROM tasks WHERE tenant_id IS NULL AND {GITHUB_TASK_PREDICATE}"
+            f'SELECT COUNT(*) FROM tasks WHERE tenant_id IS NULL AND {GITHUB_TASK_PREDICATE}'
         )
         remaining_runs = await conn.fetchval(
             f"""

--- a/scripts/backfill_github_app_tenant.py
+++ b/scripts/backfill_github_app_tenant.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Backfill tenant_id for legacy GitHub App tasks that were created unscoped."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+import asyncpg
+
+GITHUB_TASK_PREDICATE = """
+(metadata->>'source' = 'github-app'
+ OR metadata ? 'github_installation_id'
+ OR metadata ? 'github_issue_url')
+"""
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--tenant-id', required=True)
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+
+    database_url = os.environ.get('DATABASE_URL') or os.environ.get('A2A_DATABASE_URL')
+    if not database_url:
+        raise SystemExit('DATABASE_URL or A2A_DATABASE_URL is required')
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        tenant_exists = await conn.fetchval('SELECT EXISTS(SELECT 1 FROM tenants WHERE id = $1)', args.tenant_id)
+        if not tenant_exists:
+            raise SystemExit(f'tenant_id not found: {args.tenant_id}')
+
+        task_count = await conn.fetchval(
+            f"SELECT COUNT(*) FROM tasks WHERE tenant_id IS NULL AND {GITHUB_TASK_PREDICATE}"
+        )
+        workspace_count = await conn.fetchval(
+            f"""
+            SELECT COUNT(DISTINCT workspace_id)
+            FROM tasks
+            WHERE tenant_id IS NULL AND workspace_id IS NOT NULL AND {GITHUB_TASK_PREDICATE}
+            """
+        )
+        run_count = await conn.fetchval(
+            f"""
+            SELECT COUNT(*)
+            FROM task_runs tr
+            WHERE tr.tenant_id IS NULL
+              AND EXISTS (SELECT 1 FROM tasks t WHERE t.id = tr.task_id AND {GITHUB_TASK_PREDICATE.replace('metadata', 't.metadata')})
+            """
+        )
+        counts = {'tasks': task_count, 'workspaces': workspace_count, 'runs': run_count}
+        print(counts)
+        if args.dry_run:
+            return
+
+        async with conn.transaction():
+            await conn.execute(
+                f"""
+                UPDATE tasks
+                SET tenant_id = $1::uuid,
+                    metadata = COALESCE(metadata, '{{}}'::jsonb) || jsonb_build_object('tenant_id', $1::text),
+                    updated_at = NOW()
+                WHERE tenant_id IS NULL AND {GITHUB_TASK_PREDICATE}
+                """,
+                args.tenant_id,
+            )
+            await conn.execute(
+                f"""
+                UPDATE workspaces w
+                SET tenant_id = $1::uuid, updated_at = NOW()
+                WHERE tenant_id IS NULL
+                  AND EXISTS (
+                    SELECT 1 FROM tasks t
+                    WHERE t.workspace_id = w.id AND {GITHUB_TASK_PREDICATE.replace('metadata', 't.metadata')}
+                  )
+                """,
+                args.tenant_id,
+            )
+            await conn.execute(
+                f"""
+                UPDATE task_runs tr
+                SET tenant_id = $1::uuid, updated_at = NOW()
+                WHERE tenant_id IS NULL
+                  AND EXISTS (
+                    SELECT 1 FROM tasks t
+                    WHERE t.id = tr.task_id AND {GITHUB_TASK_PREDICATE.replace('metadata', 't.metadata')}
+                  )
+                """,
+                args.tenant_id,
+            )
+
+        remaining_tasks = await conn.fetchval(
+            f"SELECT COUNT(*) FROM tasks WHERE tenant_id IS NULL AND {GITHUB_TASK_PREDICATE}"
+        )
+        remaining_runs = await conn.fetchval(
+            f"""
+            SELECT COUNT(*) FROM task_runs tr
+            WHERE tr.tenant_id IS NULL
+              AND EXISTS (SELECT 1 FROM tasks t WHERE t.id = tr.task_id AND {GITHUB_TASK_PREDICATE.replace('metadata', 't.metadata')})
+            """
+        )
+        print('remaining', {'tasks': remaining_tasks, 'runs': remaining_runs})
+    finally:
+        await conn.close()
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -1,5 +1,6 @@
 import os
 
+
 os.environ.setdefault(
     'DATABASE_URL', 'postgresql://test:test@localhost:5432/test'
 )
@@ -529,8 +530,9 @@ async def test_create_merge_task_blocks_when_approval_review_rejected(
     assert feedback_called is False
     assert decisions[-1]['decision']['allowed'] is False
     assert decisions[-1]['decision']['action'] == 'github:merge_pr'
-    assert 'approving review could not be submitted' in (
-        decisions[-1]['decision']['provenance']['failures'][0]
+    assert (
+        'approving review could not be submitted'
+        in (decisions[-1]['decision']['provenance']['failures'][0])
     )
     assert 'could not submit the approving PR review' in comments[0]
 
@@ -1432,7 +1434,6 @@ async def test_create_merge_task_falls_back_to_mention_on_fix_failure(
 
     async def fake_fix_followup(*, review_task, token):
         fix_created.append(True)
-        return None  # fix follow-up could not create task
 
     async def fake_fallback(*, review_task, token):
         fallback_called.append(True)
@@ -1466,7 +1467,6 @@ async def test_create_merge_task_does_not_call_fix_on_approval(
 
     async def fake_fix_followup(*, review_task, token):
         fix_created.append(True)
-        return None
 
     async def fake_github_json(method, path, token, payload=None):
         if path == '/repos/acme/widgets/pulls/77':

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -478,7 +478,7 @@ async def test_create_merge_task_blocks_when_approval_review_rejected(
         raise AssertionError(f'unexpected GitHub call: {method} {path}')
 
     async def fake_approval_review(**kwargs):
-        raise RuntimeError('Can not approve your own pull request')
+        raise RuntimeError('Cannot approve your own pull request')
 
     async def fake_feedback_status(repo, pr_number, token):
         nonlocal feedback_called

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -14,6 +14,13 @@ from a2a_server.github_app import (
 )
 
 
+async def _fake_harvester_route():
+    return {
+        'target_agent_name': 'harvester',
+        'required_capabilities': ['persistent-workspace'],
+    }
+
+
 @pytest.fixture
 def pr_payload():
     return {
@@ -168,6 +175,9 @@ async def test_create_review_task_records_allow_decision_without_builder_target(
     monkeypatch.setattr(
         issue_review_task, 'record_automation_decision', fake_record
     )
+    monkeypatch.setattr(
+        issue_review_task, 'resolve_task_target', _fake_harvester_route
+    )
 
     task_id = await issue_review_task.create_issue_review_task(
         workspace_id='ws1',
@@ -182,8 +192,13 @@ async def test_create_review_task_records_allow_decision_without_builder_target(
     )
 
     assert task_id == 'task-review-1'
+    assert created[0]['priority'] == 50
     assert created[0]['metadata']['worker_personality'] == 'reviewer'
     assert 'target_worker_id' not in created[0]['metadata']
+    assert created[0]['metadata']['target_agent_name'] == 'harvester'
+    assert created[0]['metadata']['required_capabilities'] == [
+        'persistent-workspace'
+    ]
     assert (
         '@codetether please address the requested PR changes'
         in created[0]['prompt']
@@ -353,6 +368,174 @@ def test_reviewer_approval_ignores_blocked_prose():
 
 
 @pytest.mark.asyncio
+async def test_approval_review_submits_github_pr_review(
+    monkeypatch, pr_payload
+):
+    calls = []
+
+    async def fake_github_json(method, path, token, payload=None):
+        calls.append((method, path, payload))
+        if method == 'GET' and path == (
+            '/repos/acme/widgets/pulls/77/reviews?per_page=100'
+        ):
+            return []
+        if method == 'POST' and path == '/repos/acme/widgets/pulls/77/reviews':
+            assert payload['event'] == 'APPROVE'
+            assert payload['commit_id'] == 'abc123'
+            assert 'codetether-review-task: task-review-1' in payload['body']
+            assert 'Automation provenance:' in payload['body']
+            return {'id': 99, 'state': 'APPROVED'}
+        raise AssertionError(f'unexpected GitHub call: {method} {path}')
+
+    async def fake_get_secret(*args):
+        return None
+
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(issue_review_task, 'get_secret', fake_get_secret)
+    provenance = issue_review_task.issue_pr_provenance(
+        repo='acme/widgets',
+        issue_number=12,
+        branch='codetether/issue-12',
+        pr=pr_payload,
+        installation_id=123,
+        action='github:merge_pr',
+        parent_task_id='task-review-1',
+    )
+
+    result = await issue_review_task.ensure_pull_request_approval_review(
+        repo='acme/widgets',
+        pr_number=77,
+        current_sha='abc123',
+        review_task={
+            'id': 'task-review-1',
+            'result': 'APPROVED: validation passed',
+        },
+        provenance=provenance,
+        token='token',
+    )
+
+    assert result == {'id': 99, 'state': 'APPROVED'}
+    assert calls[-1][0] == 'POST'
+
+
+@pytest.mark.asyncio
+async def test_approval_review_uses_configured_approval_token(
+    monkeypatch, pr_payload
+):
+    tokens = []
+
+    async def fake_get_secret(*args):
+        return 'approval-token'
+
+    async def fake_github_json(method, path, token, payload=None):
+        tokens.append(token)
+        if method == 'GET':
+            return []
+        if method == 'POST':
+            return {'id': 100, 'state': 'APPROVED'}
+        raise AssertionError(f'unexpected GitHub call: {method} {path}')
+
+    monkeypatch.setattr(issue_review_task, 'get_secret', fake_get_secret)
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    provenance = issue_review_task.issue_pr_provenance(
+        repo='acme/widgets',
+        issue_number=12,
+        branch='codetether/issue-12',
+        pr=pr_payload,
+        installation_id=123,
+        action='github:merge_pr',
+        parent_task_id='task-review-1',
+    )
+
+    await issue_review_task.ensure_pull_request_approval_review(
+        repo='acme/widgets',
+        pr_number=77,
+        current_sha='abc123',
+        review_task={'id': 'task-review-1', 'result': 'APPROVED'},
+        provenance=provenance,
+        token='app-token',
+    )
+
+    assert tokens == ['approval-token', 'approval-token']
+
+
+@pytest.mark.asyncio
+async def test_create_merge_task_blocks_when_approval_review_rejected(
+    monkeypatch, pr_payload
+):
+    decisions = []
+    comments = []
+    feedback_called = False
+
+    async def fake_github_json(method, path, token, payload=None):
+        if path == '/repos/acme/widgets/pulls/77':
+            return pr_payload
+        raise AssertionError(f'unexpected GitHub call: {method} {path}')
+
+    async def fake_approval_review(**kwargs):
+        raise RuntimeError('Can not approve your own pull request')
+
+    async def fake_feedback_status(repo, pr_number, token):
+        nonlocal feedback_called
+        feedback_called = True
+        return {'feedback_addressed': True, 'blockers': []}
+
+    async def fake_record(**kwargs):
+        decisions.append(kwargs)
+
+    async def fake_post(repo, issue_number, token, body):
+        comments.append(body)
+
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        issue_review_task,
+        'ensure_pull_request_approval_review',
+        fake_approval_review,
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'review_feedback_status', fake_feedback_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.post_issue_comment', fake_post
+    )
+
+    result = await issue_review_task.create_issue_merge_task(
+        review_task={
+            'id': 'task-review-1',
+            'result': 'APPROVED: looks safe',
+            'metadata': {
+                'workspace_id': 'ws1',
+                'repo': 'acme/widgets',
+                'issue_number': 12,
+                'pr_number': 77,
+                'branch_name': 'codetether/issue-12',
+                'pr_head_sha': 'abc123',
+                'github_installation_id': 123,
+            },
+        },
+        token='token',
+    )
+
+    assert result is None
+    assert feedback_called is False
+    assert decisions[-1]['decision']['allowed'] is False
+    assert decisions[-1]['decision']['action'] == 'github:merge_pr'
+    assert 'approving review could not be submitted' in (
+        decisions[-1]['decision']['provenance']['failures'][0]
+    )
+    assert 'could not submit the approving PR review' in comments[0]
+
+
+@pytest.mark.asyncio
 async def test_create_merge_task_records_sha_mismatch(monkeypatch, pr_payload):
     decisions = []
     comments = []
@@ -430,11 +613,19 @@ async def test_create_merge_task_blocks_unresolved_review_feedback(
     async def fake_post(repo, issue_number, token, body):
         comments.append(body)
 
+    async def fake_approval_review(**kwargs):
+        return {'id': 1}
+
     monkeypatch.setattr(
         'a2a_server.github_app.auth.github_json', fake_github_json
     )
     monkeypatch.setattr(
         issue_review_task, 'review_feedback_status', fake_feedback_status
+    )
+    monkeypatch.setattr(
+        issue_review_task,
+        'ensure_pull_request_approval_review',
+        fake_approval_review,
     )
     monkeypatch.setattr(
         issue_review_task, 'record_automation_decision', fake_record
@@ -505,6 +696,9 @@ async def test_create_merge_task_auto_merges_when_feedback_addressed(
     async def fake_post(repo, issue_number, token, body):
         comments.append(body)
 
+    async def fake_approval_review(**kwargs):
+        return {'id': 1}
+
     monkeypatch.setattr(
         'a2a_server.github_app.auth.github_json', fake_github_json
     )
@@ -513,6 +707,11 @@ async def test_create_merge_task_auto_merges_when_feedback_addressed(
     )
     monkeypatch.setattr(
         issue_review_task, 'status_check_status', fake_status_check_status
+    )
+    monkeypatch.setattr(
+        issue_review_task,
+        'ensure_pull_request_approval_review',
+        fake_approval_review,
     )
     monkeypatch.setattr(
         issue_review_task, 'record_automation_decision', fake_record
@@ -598,6 +797,9 @@ async def test_create_merge_task_enables_github_auto_merge_when_direct_merge_blo
     async def fake_post(repo, issue_number, token, body):
         comments.append(body)
 
+    async def fake_approval_review(**kwargs):
+        return {'id': 1}
+
     monkeypatch.setattr(
         'a2a_server.github_app.auth.github_json', fake_github_json
     )
@@ -609,6 +811,11 @@ async def test_create_merge_task_enables_github_auto_merge_when_direct_merge_blo
     )
     monkeypatch.setattr(
         issue_review_task, 'status_check_status', fake_status_check_status
+    )
+    monkeypatch.setattr(
+        issue_review_task,
+        'ensure_pull_request_approval_review',
+        fake_approval_review,
     )
     monkeypatch.setattr(
         issue_review_task, 'record_automation_decision', fake_record
@@ -644,6 +851,85 @@ async def test_create_merge_task_enables_github_auto_merge_when_direct_merge_blo
 
 
 @pytest.mark.asyncio
+async def test_create_merge_task_dispatches_high_priority_merge_when_auto_merge_disabled(
+    monkeypatch, pr_payload
+):
+    dispatched = []
+
+    async def fake_github_json(method, path, token):
+        if path == '/repos/acme/widgets/pulls/77':
+            return pr_payload
+        raise AssertionError(f'unexpected GitHub call: {method} {path}')
+
+    async def fake_feedback_status(repo, pr_number, token):
+        return {'feedback_addressed': True, 'blockers': []}
+
+    async def fake_status_check_status(repo, sha, token):
+        return {'checks_green': True, 'blockers': []}
+
+    async def fake_approval_review(**kwargs):
+        return {'id': 1}
+
+    async def fake_dispatch(**kwargs):
+        dispatched.append(kwargs)
+        return 'task-merge-1'
+
+    async def fake_record(**kwargs):
+        pass
+
+    monkeypatch.setattr(
+        'a2a_server.github_app.auth.github_json', fake_github_json
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'review_feedback_status', fake_feedback_status
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'status_check_status', fake_status_check_status
+    )
+    monkeypatch.setattr(
+        issue_review_task,
+        'ensure_pull_request_approval_review',
+        fake_approval_review,
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(issue_review_task, 'AUTO_MERGE_ENABLED', False)
+    monkeypatch.setattr(
+        issue_review_task, 'resolve_task_target', _fake_harvester_route
+    )
+
+    task_id = await issue_review_task.create_issue_merge_task(
+        review_task={
+            'id': 'task-review-1',
+            'result': 'APPROVED: looks safe',
+            'metadata': {
+                'workspace_id': 'ws1',
+                'repo': 'acme/widgets',
+                'issue_number': 12,
+                'pr_number': 77,
+                'branch_name': 'codetether/issue-12',
+                'pr_head_sha': 'abc123',
+                'github_installation_id': 123,
+            },
+        },
+        token='token',
+    )
+
+    assert task_id == 'task-merge-1'
+    assert dispatched[0]['title'] == 'Merge issue PR #77'
+    assert dispatched[0]['priority'] == 100
+    assert dispatched[0]['metadata']['target_agent_name'] == 'harvester'
+    assert dispatched[0]['metadata']['required_capabilities'] == [
+        'persistent-workspace'
+    ]
+
+
+@pytest.mark.asyncio
 async def test_create_merge_task_blocks_failed_status_checks(
     monkeypatch, pr_payload
 ):
@@ -672,6 +958,9 @@ async def test_create_merge_task_blocks_failed_status_checks(
     async def fake_post(repo, issue_number, token, body):
         comments.append(body)
 
+    async def fake_approval_review(**kwargs):
+        return {'id': 1}
+
     monkeypatch.setattr(
         'a2a_server.github_app.auth.github_json', fake_github_json
     )
@@ -680,6 +969,11 @@ async def test_create_merge_task_blocks_failed_status_checks(
     )
     monkeypatch.setattr(
         issue_review_task, 'status_check_status', fake_status_check_status
+    )
+    monkeypatch.setattr(
+        issue_review_task,
+        'ensure_pull_request_approval_review',
+        fake_approval_review,
     )
     monkeypatch.setattr(
         issue_review_task, 'record_automation_decision', fake_record
@@ -796,6 +1090,9 @@ async def test_fix_followup_creates_task_on_changes_requested(
         'a2a_server.github_app.watch.post_issue_comment', fake_post
     )
     monkeypatch.setattr(issue_review_task, '_count_fix_attempts', fake_count)
+    monkeypatch.setattr(
+        issue_review_task, 'resolve_task_target', _fake_harvester_route
+    )
 
     task_id = await issue_review_task.create_fix_followup_task(
         review_task=_make_review_task('CHANGES_REQUESTED: tests failed'),
@@ -864,6 +1161,9 @@ async def test_fix_followup_creates_task_on_blocked(monkeypatch, pr_payload):
         'a2a_server.github_app.watch.post_issue_comment', fake_post
     )
     monkeypatch.setattr(issue_review_task, '_count_fix_attempts', fake_count)
+    monkeypatch.setattr(
+        issue_review_task, 'resolve_task_target', _fake_harvester_route
+    )
 
     task_id = await issue_review_task.create_fix_followup_task(
         review_task=_make_review_task('BLOCKED: provenance mismatch'),
@@ -1059,6 +1359,9 @@ async def test_fix_followup_includes_review_context_in_prompt(
         'a2a_server.github_app.watch.post_issue_comment', fake_post
     )
     monkeypatch.setattr(issue_review_task, '_count_fix_attempts', fake_count)
+    monkeypatch.setattr(
+        issue_review_task, 'resolve_task_target', _fake_harvester_route
+    )
 
     task_id = await issue_review_task.create_fix_followup_task(
         review_task=_make_review_task(
@@ -1078,6 +1381,10 @@ async def test_fix_followup_includes_review_context_in_prompt(
     assert 'Test test_foo fails' in prompt
     assert 'FAILED test_foo' in prompt
     assert 'CHANGES_REQUESTED' in prompt
+    assert dispatched[0]['metadata']['target_agent_name'] == 'harvester'
+    assert dispatched[0]['metadata']['required_capabilities'] == [
+        'persistent-workspace'
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_app_rudder_incidents.py
+++ b/tests/test_github_app_rudder_incidents.py
@@ -6,96 +6,100 @@ from a2a_server.github_app import rudder_incidents
 from a2a_server.github_app.rudder_incidents import RudderIncidentRequest
 
 
-def _incident(message: str, fingerprint: str = "sha256:raw") -> RudderIncidentRequest:
+def _incident(
+    message: str, fingerprint: str = 'sha256:raw'
+) -> RudderIncidentRequest:
     return RudderIncidentRequest(
-        repo="owner/repo",
+        repo='owner/repo',
         installation_id=123,
         fingerprint=fingerprint,
-        severity="error",
-        namespace="production",
-        release="spotlessbinco",
-        workload="spotlessbinco-api",
-        pod="spotlessbinco-api-123",
-        container="api",
-        reason="LogErrorPattern",
+        severity='error',
+        namespace='production',
+        release='spotlessbinco',
+        workload='spotlessbinco-api',
+        pod='spotlessbinco-api-123',
+        container='api',
+        reason='LogErrorPattern',
         message=message,
         log_excerpt=message,
-        labels=["production", "spotlessbinco"],
+        labels=['production', 'spotlessbinco'],
     )
 
 
 def test_rudder_group_fingerprint_ignores_volatile_ids():
     first = _incident(
-        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
-        "Timed out waiting for TikTok download_url (task_id=7648847897416761352)",
-        "sha256:first",
+        '[tiktok-async-report] Failed for advertiser 7426011654007128082: '
+        'Timed out waiting for TikTok download_url (task_id=7648847897416761352)',
+        'sha256:first',
     )
     second = _incident(
-        "[tiktok-async-report] Failed for advertiser 7500239282796576785: "
-        "Timed out waiting for TikTok download_url (task_id=7648848098168422408)",
-        "sha256:second",
+        '[tiktok-async-report] Failed for advertiser 7500239282796576785: '
+        'Timed out waiting for TikTok download_url (task_id=7648848098168422408)',
+        'sha256:second',
     )
 
-    assert (
-        rudder_incidents._incident_group_fingerprint(first)
-        == rudder_incidents._incident_group_fingerprint(second)
-    )
+    assert rudder_incidents._incident_group_fingerprint(
+        first
+    ) == rudder_incidents._incident_group_fingerprint(second)
 
 
 def test_rudder_group_fingerprint_keeps_error_shape():
     timeout = _incident(
-        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
-        "Timed out waiting for TikTok download_url (task_id=7648847897416761352)"
+        '[tiktok-async-report] Failed for advertiser 7426011654007128082: '
+        'Timed out waiting for TikTok download_url (task_id=7648847897416761352)'
     )
     auth = _incident(
-        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
-        "TikTok API returned 401 Unauthorized (task_id=7648847897416761352)"
+        '[tiktok-async-report] Failed for advertiser 7426011654007128082: '
+        'TikTok API returned 401 Unauthorized (task_id=7648847897416761352)'
     )
 
-    assert (
-        rudder_incidents._incident_group_fingerprint(timeout)
-        != rudder_incidents._incident_group_fingerprint(auth)
-    )
+    assert rudder_incidents._incident_group_fingerprint(
+        timeout
+    ) != rudder_incidents._incident_group_fingerprint(auth)
 
 
 def test_rudder_issue_body_includes_exact_and_group_markers():
     incident = _incident(
-        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
-        "Timed out waiting for TikTok download_url (task_id=7648847897416761352)",
-        "sha256:raw-fingerprint",
+        '[tiktok-async-report] Failed for advertiser 7426011654007128082: '
+        'Timed out waiting for TikTok download_url (task_id=7648847897416761352)',
+        'sha256:raw-fingerprint',
     )
 
     body = rudder_incidents._issue_body(incident)
 
-    assert "rudder-log-group: sha256:" in body
-    assert "rudder-log-fingerprint: sha256:raw-fingerprint" in body
+    assert 'rudder-log-group: sha256:' in body
+    assert 'rudder-log-fingerprint: sha256:raw-fingerprint' in body
 
 
 @pytest.mark.asyncio
-async def test_rudder_existing_issue_search_falls_back_to_stable_phrase(monkeypatch):
+async def test_rudder_existing_issue_search_falls_back_to_stable_phrase(
+    monkeypatch,
+):
     incident = _incident(
-        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
-        "Timed out waiting for TikTok download_url (task_id=7648847897416761352)",
-        "sha256:raw-fingerprint",
+        '[tiktok-async-report] Failed for advertiser 7426011654007128082: '
+        'Timed out waiting for TikTok download_url (task_id=7648847897416761352)',
+        'sha256:raw-fingerprint',
     )
     calls: list[str] = []
 
     async def fake_github_json(method, path, token, payload=None):
         calls.append(path)
-        query = parse_qs(urlparse(path).query).get("q", [""])[0]
-        if "rudder-log-fingerprint:" in query:
-            return {"items": []}
-        if "rudder-log-group:" in query:
-            return {"items": []}
-        if "Timed out waiting for TikTok download_url" in query:
-            return {"items": [{"number": 42, "html_url": "https://example.test/42"}]}
-        return {"items": []}
+        query = parse_qs(urlparse(path).query).get('q', [''])[0]
+        if 'rudder-log-fingerprint:' in query:
+            return {'items': []}
+        if 'rudder-log-group:' in query:
+            return {'items': []}
+        if 'Timed out waiting for TikTok download_url' in query:
+            return {
+                'items': [{'number': 42, 'html_url': 'https://example.test/42'}]
+            }
+        return {'items': []}
 
-    monkeypatch.setattr(rudder_incidents, "github_json", fake_github_json)
+    monkeypatch.setattr(rudder_incidents, 'github_json', fake_github_json)
 
     existing = await rudder_incidents._find_existing_issue(
-        "owner/repo", incident, "token"
+        'owner/repo', incident, 'token'
     )
 
-    assert existing == {"number": 42, "html_url": "https://example.test/42"}
+    assert existing == {'number': 42, 'html_url': 'https://example.test/42'}
     assert len(calls) == 3

--- a/tests/test_github_app_rudder_incidents.py
+++ b/tests/test_github_app_rudder_incidents.py
@@ -1,0 +1,101 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from a2a_server.github_app import rudder_incidents
+from a2a_server.github_app.rudder_incidents import RudderIncidentRequest
+
+
+def _incident(message: str, fingerprint: str = "sha256:raw") -> RudderIncidentRequest:
+    return RudderIncidentRequest(
+        repo="owner/repo",
+        installation_id=123,
+        fingerprint=fingerprint,
+        severity="error",
+        namespace="production",
+        release="spotlessbinco",
+        workload="spotlessbinco-api",
+        pod="spotlessbinco-api-123",
+        container="api",
+        reason="LogErrorPattern",
+        message=message,
+        log_excerpt=message,
+        labels=["production", "spotlessbinco"],
+    )
+
+
+def test_rudder_group_fingerprint_ignores_volatile_ids():
+    first = _incident(
+        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
+        "Timed out waiting for TikTok download_url (task_id=7648847897416761352)",
+        "sha256:first",
+    )
+    second = _incident(
+        "[tiktok-async-report] Failed for advertiser 7500239282796576785: "
+        "Timed out waiting for TikTok download_url (task_id=7648848098168422408)",
+        "sha256:second",
+    )
+
+    assert (
+        rudder_incidents._incident_group_fingerprint(first)
+        == rudder_incidents._incident_group_fingerprint(second)
+    )
+
+
+def test_rudder_group_fingerprint_keeps_error_shape():
+    timeout = _incident(
+        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
+        "Timed out waiting for TikTok download_url (task_id=7648847897416761352)"
+    )
+    auth = _incident(
+        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
+        "TikTok API returned 401 Unauthorized (task_id=7648847897416761352)"
+    )
+
+    assert (
+        rudder_incidents._incident_group_fingerprint(timeout)
+        != rudder_incidents._incident_group_fingerprint(auth)
+    )
+
+
+def test_rudder_issue_body_includes_exact_and_group_markers():
+    incident = _incident(
+        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
+        "Timed out waiting for TikTok download_url (task_id=7648847897416761352)",
+        "sha256:raw-fingerprint",
+    )
+
+    body = rudder_incidents._issue_body(incident)
+
+    assert "rudder-log-group: sha256:" in body
+    assert "rudder-log-fingerprint: sha256:raw-fingerprint" in body
+
+
+@pytest.mark.asyncio
+async def test_rudder_existing_issue_search_falls_back_to_stable_phrase(monkeypatch):
+    incident = _incident(
+        "[tiktok-async-report] Failed for advertiser 7426011654007128082: "
+        "Timed out waiting for TikTok download_url (task_id=7648847897416761352)",
+        "sha256:raw-fingerprint",
+    )
+    calls: list[str] = []
+
+    async def fake_github_json(method, path, token, payload=None):
+        calls.append(path)
+        query = parse_qs(urlparse(path).query).get("q", [""])[0]
+        if "rudder-log-fingerprint:" in query:
+            return {"items": []}
+        if "rudder-log-group:" in query:
+            return {"items": []}
+        if "Timed out waiting for TikTok download_url" in query:
+            return {"items": [{"number": 42, "html_url": "https://example.test/42"}]}
+        return {"items": []}
+
+    monkeypatch.setattr(rudder_incidents, "github_json", fake_github_json)
+
+    existing = await rudder_incidents._find_existing_issue(
+        "owner/repo", incident, "token"
+    )
+
+    assert existing == {"number": 42, "html_url": "https://example.test/42"}
+    assert len(calls) == 3


### PR DESCRIPTION
## Summary
- harden GitHub App worker routing, claim metadata, and SSE/task run monitoring
- add webhook delivery idempotency gate for duplicate GitHub deliveries
- add PR approval review idempotency helpers and Rudder incident/test coverage
- add tenant backfill utility for legacy GitHub App tasks

## Validation
- focused CI-like: `python3 -m pytest tests/test_github_app_issue_review_flow.py tests/test_github_app_rudder_incidents.py` -> 44 passed
- static/local: `git diff --cached --check` -> passed before commit

## Scope note
Excluded dirty infra, marketing generated file, agent submodule, and local evidence/session artifacts from this PR.