### PR TITLE
Forgejo-native agent orchestration with Temporal

### DIFF
--- a/.forgejo/workflows/build-and-push-harbor.yml
+++ b/.forgejo/workflows/build-and-push-harbor.yml
@@ -1,0 +1,63 @@
+name: Build and Push CodeTether to Harbor
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: codetether-harbor-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: registry.quantum-forge.net
+  IMAGE: cluster-ci-cache/a2a-server-mcp
+
+jobs:
+  test-build-push:
+    runs-on: spotlessbinco-k8s
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Forgejo and GitHub webhook regression tests
+        run: |
+          set -euo pipefail
+          python3 -m pip install --user -r requirements.txt -r requirements-test.txt
+          PYTHONPATH=. python3 -m pytest -q \
+            tests/test_forgejo_webhooks.py \
+            tests/test_github_app_mentions.py \
+            tests/test_github_app_router.py
+          python3 -m py_compile \
+            a2a_server/forgejo_webhooks.py \
+            a2a_server/server.py \
+            a2a_server/git_service.py
+
+      - name: Validate Helm chart
+        run: |
+          set -euo pipefail
+          helm lint chart/a2a-server
+          helm template codetether chart/a2a-server \
+            -f chart/a2a-server/examples/values-argocd-prod.yaml \
+            >/tmp/codetether-rendered.yaml
+          grep -q 'registry.quantum-forge.net/cluster-ci-cache/a2a-server-mcp' \
+            /tmp/codetether-rendered.yaml
+          grep -q 'FORGEJO_API_URL' /tmp/codetether-rendered.yaml
+
+      - name: Authenticate to Harbor
+        run: |
+          set -euo pipefail
+          test -n "${REGISTRY_USERNAME:-}"
+          test -n "${REGISTRY_PASSWORD:-}"
+          printf '%s' "$REGISTRY_PASSWORD" | docker login "$REGISTRY" \
+            --username "$REGISTRY_USERNAME" --password-stdin
+
+      - name: Build and push immutable Harbor image
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          image="$REGISTRY/$IMAGE:main-$short_sha"
+          docker build --pull -t "$image" .
+          docker push "$image"
+          echo "Published $image"

--- a/.forgejo/workflows/build-and-push-harbor.yml
+++ b/.forgejo/workflows/build-and-push-harbor.yml
@@ -58,13 +58,26 @@ jobs:
             /tmp/codetether-rendered.yaml
           grep -q 'FORGEJO_API_URL' /tmp/codetether-rendered.yaml
 
-      - name: Authenticate to Harbor
+      - name: Configure Harbor authentication
         run: |
           set -euo pipefail
           test -n "${REGISTRY_USERNAME:-}"
           test -n "${REGISTRY_PASSWORD:-}"
-          printf '%s' "$REGISTRY_PASSWORD" | docker login "$REGISTRY" \
-            --username "$REGISTRY_USERNAME" --password-stdin
+          docker_config="${DOCKER_CONFIG:-$HOME/.docker}"
+          install -d -m 0700 "$docker_config"
+          registry_auth="$(
+            printf '%s:%s' "$REGISTRY_USERNAME" "$REGISTRY_PASSWORD" \
+              | base64 --wrap=0
+          )"
+          umask 077
+          printf '{"auths":{"%s":{"auth":"%s"}}}\n' \
+            "$REGISTRY" "$registry_auth" >"$docker_config/config.json"
+          unset registry_auth
+          grep -q "$REGISTRY" "$docker_config/config.json"
+          docker_registry_config="$(
+            docker info --format '{{json .RegistryConfig.IndexConfigs}}'
+          )"
+          [[ "$docker_registry_config" == *"$REGISTRY"* ]]
 
       - name: Build and push immutable Harbor image
         run: |

--- a/.forgejo/workflows/build-and-push-harbor.yml
+++ b/.forgejo/workflows/build-and-push-harbor.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DOCKER_HOST: tcp://127.0.0.1:2375
   REGISTRY: registry.quantum-forge.net
   IMAGE: cluster-ci-cache/a2a-server-mcp
 

--- a/.forgejo/workflows/build-and-push-harbor.yml
+++ b/.forgejo/workflows/build-and-push-harbor.yml
@@ -41,8 +41,17 @@ jobs:
       - name: Validate Helm chart
         run: |
           set -euo pipefail
-          helm lint chart/a2a-server
-          helm template codetether chart/a2a-server \
+          helm_archive=/tmp/helm-v3.16.4-linux-amd64.tar.gz
+          curl --fail --location --silent --show-error \
+            https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz \
+            --output "$helm_archive"
+          printf '%s  %s\n' \
+            fc307327959aa38ed8f9f7e66d45492bb022a66c3e5da6063958254b9767d179 \
+            "$helm_archive" | sha256sum --check
+          tar --extract --gzip --file "$helm_archive" --directory /tmp
+          helm_bin=/tmp/linux-amd64/helm
+          "$helm_bin" lint chart/a2a-server
+          "$helm_bin" template codetether chart/a2a-server \
             -f chart/a2a-server/examples/values-argocd-prod.yaml \
             >/tmp/codetether-rendered.yaml
           grep -q 'registry.quantum-forge.net/cluster-ci-cache/a2a-server-mcp' \

--- a/.forgejo/workflows/build-and-push-harbor.yml
+++ b/.forgejo/workflows/build-and-push-harbor.yml
@@ -24,13 +24,17 @@ jobs:
       - name: Run Forgejo and GitHub webhook regression tests
         run: |
           set -euo pipefail
-          python3 -m pip install --user -r requirements.txt -r requirements-test.txt
-          PYTHONPATH=. python3 -m pytest -q \
+          python3 -m venv /tmp/codetether-ci
+          /tmp/codetether-ci/bin/python -m pip install \
+            -r requirements.txt -r requirements-test.txt
+          PYTHONPATH=. /tmp/codetether-ci/bin/python -m pytest -q \
             tests/test_forgejo_webhooks.py \
+            tests/test_forgejo_task_completion.py \
             tests/test_github_app_mentions.py \
             tests/test_github_app_router.py
-          python3 -m py_compile \
+          /tmp/codetether-ci/bin/python -m py_compile \
             a2a_server/forgejo_webhooks.py \
+            a2a_server/forgejo_task_completion.py \
             a2a_server/server.py \
             a2a_server/git_service.py
 

--- a/.forgejo/workflows/build-and-push-harbor.yml
+++ b/.forgejo/workflows/build-and-push-harbor.yml
@@ -33,7 +33,9 @@ jobs:
             tests/test_forgejo_task_completion.py \
             tests/test_github_app_mentions.py \
             tests/test_github_app_router.py
-          PYTHONPATH=. /tmp/codetether-ci/bin/python -m pytest -q \
+          DATABASE_URL=postgresql://test:test@127.0.0.1:1/test \
+            RLS_ENABLED=false PYTHONPATH=. \
+            /tmp/codetether-ci/bin/python -m pytest -q \
             tests/test_agent_bridge_task_reads.py
           /tmp/codetether-ci/bin/python -m py_compile \
             a2a_server/forgejo_webhooks.py \

--- a/.forgejo/workflows/build-and-push-harbor.yml
+++ b/.forgejo/workflows/build-and-push-harbor.yml
@@ -33,9 +33,12 @@ jobs:
             tests/test_forgejo_task_completion.py \
             tests/test_github_app_mentions.py \
             tests/test_github_app_router.py
+          PYTHONPATH=. /tmp/codetether-ci/bin/python -m pytest -q \
+            tests/test_agent_bridge_task_reads.py
           /tmp/codetether-ci/bin/python -m py_compile \
             a2a_server/forgejo_webhooks.py \
             a2a_server/forgejo_task_completion.py \
+            a2a_server/agent_bridge.py \
             a2a_server/server.py \
             a2a_server/git_service.py
 

--- a/.forgejo/workflows/pull-request-validation.yml
+++ b/.forgejo/workflows/pull-request-validation.yml
@@ -1,8 +1,7 @@
 name: Validate CodeTether Pull Request
 
 on:
-  pull_request:
-    branches: [main]
+  pull_request: {}
 
 concurrency:
   group: codetether-pr-${{ github.event.pull_request.number }}
@@ -49,6 +48,8 @@ jobs:
         run: |
           set -euo pipefail
           /tmp/codetether-pr-ci/bin/python -m compileall -q \
+            a2a_server/forgejo_agent_client.py \
+            a2a_server/forgejo_agent_controls.py \
             a2a_server/forgejo_automation.py \
             a2a_server/forgejo_webhooks.py \
             a2a_server/forgejo_task_completion.py \

--- a/.forgejo/workflows/pull-request-validation.yml
+++ b/.forgejo/workflows/pull-request-validation.yml
@@ -1,0 +1,53 @@
+name: Validate CodeTether Pull Request
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codetether-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: spotlessbinco-k8s
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Python test dependencies
+        run: |
+          set -euo pipefail
+          python3 -m venv /tmp/codetether-pr-ci
+          /tmp/codetether-pr-ci/bin/python -m pip install \
+            -r requirements.txt -r requirements-test.txt
+
+      - name: Run Forgejo and GitHub compatibility regressions
+        run: |
+          set -euo pipefail
+          PYTHONPATH=. /tmp/codetether-pr-ci/bin/python -m pytest -q \
+            tests/test_forgejo*.py \
+            tests/test_github_app*.py \
+            tests/test_github_check_failure_tasks.py
+
+      - name: Lint and format changed automation code
+        run: |
+          set -euo pipefail
+          files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}"...HEAD -- '*.py')"
+          test -n "$files"
+          /tmp/codetether-pr-ci/bin/python -m ruff check \
+            --config .github/linters/.ruff.toml $files
+          /tmp/codetether-pr-ci/bin/python -m ruff format --check $files
+
+      - name: Compile Forgejo automation modules
+        run: |
+          set -euo pipefail
+          /tmp/codetether-pr-ci/bin/python -m compileall -q \
+            a2a_server/forgejo_automation.py \
+            a2a_server/forgejo_webhooks.py \
+            a2a_server/forgejo_task_completion.py \
+            a2a_server/post_clone_followup.py \
+            a2a_server/persistent_worker_pool.py

--- a/.forgejo/workflows/pull-request-validation.yml
+++ b/.forgejo/workflows/pull-request-validation.yml
@@ -31,6 +31,7 @@ jobs:
           set -euo pipefail
           PYTHONPATH=. /tmp/codetether-pr-ci/bin/python -m pytest -q \
             tests/test_forgejo*.py \
+            tests/test_session_view*.py \
             tests/test_github_app*.py \
             tests/test_github_check_failure_tasks.py
 
@@ -50,5 +51,6 @@ jobs:
             a2a_server/forgejo_automation.py \
             a2a_server/forgejo_webhooks.py \
             a2a_server/forgejo_task_completion.py \
+            a2a_server/session_view.py \
             a2a_server/post_clone_followup.py \
             a2a_server/persistent_worker_pool.py

--- a/.forgejo/workflows/pull-request-validation.yml
+++ b/.forgejo/workflows/pull-request-validation.yml
@@ -23,7 +23,8 @@ jobs:
           set -euo pipefail
           python3 -m venv /tmp/codetether-pr-ci
           /tmp/codetether-pr-ci/bin/python -m pip install \
-            -r requirements.txt -r requirements-test.txt
+            -r requirements.txt -r requirements-test.txt \
+            ruff==0.14.10
 
       - name: Run Forgejo and GitHub compatibility regressions
         run: |

--- a/.forgejo/workflows/pull-request-validation.yml
+++ b/.forgejo/workflows/pull-request-validation.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Run Forgejo and GitHub compatibility regressions
         run: |
           set -euo pipefail
-          PYTHONPATH=. /tmp/codetether-pr-ci/bin/python -m pytest -q \
+          DATABASE_URL=postgresql://test:test@localhost:5432/test \
+            PYTHONPATH=. /tmp/codetether-pr-ci/bin/python -m pytest -q \
             tests/test_forgejo*.py \
             tests/test_session_view*.py \
             tests/test_github_app*.py \

--- a/.forgejo/workflows/pull-request-validation.yml
+++ b/.forgejo/workflows/pull-request-validation.yml
@@ -55,4 +55,16 @@ jobs:
             a2a_server/forgejo_task_completion.py \
             a2a_server/session_view.py \
             a2a_server/post_clone_followup.py \
-            a2a_server/persistent_worker_pool.py
+            a2a_server/persistent_worker_pool.py \
+            a2a_server/temporal
+
+      - name: Render Temporal Helm modes
+        run: |
+          set -euo pipefail
+          helm lint chart/a2a-server
+          helm template temporal-disabled chart/a2a-server >/dev/null
+          helm template temporal-enabled chart/a2a-server \
+            --set temporal.enabled=true \
+            --set temporal.address=temporal.example:7233 \
+            --set forgejo.apiUrl=https://forgejo.example/api/v1 \
+            >/dev/null

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,4 +1,4 @@
-name: Build and Push to Google Artifact Registry
+name: Build and Push to On-Cluster Harbor
 
 "on":
     push:
@@ -22,8 +22,8 @@ name: Build and Push to Google Artifact Registry
                     - production
 
 env:
-    REGISTRY: us-central1-docker.pkg.dev
-    PROJECT: spotlessbinco/codetether
+    REGISTRY: registry.quantum-forge.net
+    PROJECT: cluster-ci-cache
     IMAGE_NAME: a2a-server-mcp
     CHART_PATH: chart/a2a-server
     CHART_VERSION: 1.4.3
@@ -52,7 +52,7 @@ jobs:
               env:
                   DATABASE_URL: "postgresql://ci:ci@localhost:5432/ci_test"
               run: |
-                  python -m pytest tests/ -v || true
+                  python -m pytest tests/ -v
 
             - name: Run OPA policy tests
               run: |
@@ -78,12 +78,12 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 
-            - name: Log in to Google Artifact Registry
+            - name: Log in to on-cluster Harbor
               uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
-                  username: _json_key
-                  password: ${{ secrets.GCP_SA_KEY }}
+                  username: ${{ secrets.HARBOR_USERNAME }}
+                  password: ${{ secrets.HARBOR_PASSWORD }}
 
             - name: Extract metadata
               id: meta
@@ -149,12 +149,12 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 
-            - name: Log in to Google Artifact Registry
+            - name: Log in to on-cluster Harbor
               uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
-                  username: _json_key
-                  password: ${{ secrets.GCP_SA_KEY }}
+                  username: ${{ secrets.HARBOR_USERNAME }}
+                  password: ${{ secrets.HARBOR_PASSWORD }}
 
             - name: Extract metadata (Worker)
               id: meta
@@ -206,10 +206,10 @@ jobs:
               with:
                   version: "3.14.0"
 
-            - name: Log in to Google Artifact Registry (Helm)
+            - name: Log in to on-cluster Harbor (Helm)
               run: |
-                  printf '%s' '${{ secrets.GCP_SA_KEY }}' | helm registry login https://${{ env.REGISTRY }} \
-                    --username _json_key \
+                  printf '%s' '${{ secrets.HARBOR_PASSWORD }}' | helm registry login ${{ env.REGISTRY }} \
+                    --username ${{ secrets.HARBOR_USERNAME }} \
                     --password-stdin
 
             - name: Update Helm chart values
@@ -305,7 +305,7 @@ jobs:
                   echo '```bash' >> $GITHUB_STEP_SUMMARY
                   echo "# Login to registry" >> $GITHUB_STEP_SUMMARY
                   echo "cat service-account-key.json | helm registry login https://${{ env.REGISTRY }} \\" >> $GITHUB_STEP_SUMMARY
-                  echo "  --username _json_key \\" >> $GITHUB_STEP_SUMMARY
+                  echo "  --username ${{ secrets.HARBOR_USERNAME }} \\" >> $GITHUB_STEP_SUMMARY
                   echo "  --password-stdin" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "# Deploy using local script" >> $GITHUB_STEP_SUMMARY

--- a/a2a_server/agent_bridge.py
+++ b/a2a_server/agent_bridge.py
@@ -52,8 +52,12 @@ logger = logging.getLogger(__name__)
 
 # Agent host configuration - allows container to connect to host VM's agent
 # Accepts AGENT_HOST/AGENT_PORT (preferred) or legacy OPENCODE_HOST/OPENCODE_PORT
-AGENT_HOST = os.environ.get('AGENT_HOST', os.environ.get('OPENCODE_HOST', 'localhost'))
-AGENT_DEFAULT_PORT = int(os.environ.get('AGENT_PORT', os.environ.get('OPENCODE_PORT', '9777')))
+AGENT_HOST = os.environ.get(
+    'AGENT_HOST', os.environ.get('OPENCODE_HOST', 'localhost')
+)
+AGENT_DEFAULT_PORT = int(
+    os.environ.get('AGENT_PORT', os.environ.get('OPENCODE_PORT', '9777'))
+)
 
 # Backward-compatible aliases
 # Legacy OPENCODE_HOST removed
@@ -351,11 +355,9 @@ class AgentBridge:
         # HTTP session for API calls
         self._session: Optional[aiohttp.ClientSession] = None
 
-        logger.info(
-            f'Agent bridge initialized with binary: {self.agent_bin}'
-        )
+        logger.info(f'Agent bridge initialized with binary: {self.agent_bin}')
         logger.info(f'Agent host: {self.agent_host}:{self.default_port}')
-        logger.info(f'Using PostgreSQL database for persistence')
+        logger.info('Using PostgreSQL database for persistence')
 
     def _get_agent_base_url(self, port: Optional[int] = None) -> str:
         """
@@ -406,6 +408,8 @@ class AgentBridge:
                 metadata['target_agent_name'] = task.target_agent_name
             if task.model_used and 'model_used' not in metadata:
                 metadata['model_used'] = task.model_used
+            if task.session_id:
+                metadata['session_id'] = task.session_id
 
             await db.db_upsert_task(
                 {
@@ -529,7 +533,9 @@ class AgentBridge:
             # 1. Discover all tenant IDs using admin_scope (bypasses RLS).
             pool = await db.get_pool()
             if not pool:
-                logger.warning('Database pool unavailable, skipping workspace load')
+                logger.warning(
+                    'Database pool unavailable, skipping workspace load'
+                )
                 return
 
             tenant_ids: List[str] = []
@@ -902,9 +908,7 @@ class AgentBridge:
             str(port),
         ]
 
-        logger.info(
-            f'Starting agent server for {codebase.name} on port {port}'
-        )
+        logger.info(f'Starting agent server for {codebase.name} on port {port}')
         logger.debug(f'Command: {" ".join(cmd)}')
 
         try:
@@ -1140,7 +1144,6 @@ class AgentBridge:
         """
         # Generate session ID (or use existing)
         session_id = request.metadata.get('session_id') or str(uuid.uuid4())[:8]
-        task_id = str(uuid.uuid4())
 
         # Prepare model specification for CloudEvent
         model_spec = None
@@ -1407,10 +1410,7 @@ class AgentBridge:
         # 1. Try to find an active agent instance
         active_port = None
         for codebase in self._codebases.values():
-            if (
-                codebase.agent_port
-                and codebase.status == AgentStatus.RUNNING
-            ):
+            if codebase.agent_port and codebase.status == AgentStatus.RUNNING:
                 active_port = codebase.agent_port
                 break
 
@@ -1559,11 +1559,7 @@ class AgentBridge:
     async def interrupt_agent(self, codebase_id: str) -> bool:
         """Interrupt the current agent task."""
         codebase = self._codebases.get(codebase_id)
-        if (
-            not codebase
-            or not codebase.session_id
-            or not codebase.agent_port
-        ):
+        if not codebase or not codebase.session_id or not codebase.agent_port:
             return False
 
         try:

--- a/a2a_server/agent_bridge.py
+++ b/a2a_server/agent_bridge.py
@@ -1692,13 +1692,25 @@ class AgentBridge:
         return task
 
     async def get_task(self, task_id: str) -> Optional[AgentTask]:
-        """Get a task by ID. Checks in-memory cache first, then database."""
-        # Check in-memory cache first
-        task = self._tasks.get(task_id)
-        if task:
-            return task
-        # Fall back to database
-        return await self._load_task_from_db(task_id)
+        """Get a task by ID, refreshing replica-local cache from PostgreSQL."""
+        try:
+            row = await db.db_get_task(task_id)
+            if row:
+                task = self._task_from_db_row(row)
+                self._tasks[task_id] = task
+                if task.codebase_id not in self._codebase_tasks:
+                    self._codebase_tasks[task.codebase_id] = []
+                if task_id not in self._codebase_tasks[task.codebase_id]:
+                    self._codebase_tasks[task.codebase_id].append(task_id)
+                return task
+        except Exception as exc:
+            logger.warning(
+                'Failed to refresh task %s from PostgreSQL: %s', task_id, exc
+            )
+
+        # Keep reads available during a transient database outage. Mutations
+        # persist before returning, so the local cache is the safest degraded read.
+        return self._tasks.get(task_id)
 
     async def list_tasks(
         self,

--- a/a2a_server/forgejo_agent_client.py
+++ b/a2a_server/forgejo_agent_client.py
@@ -1,0 +1,248 @@
+"""Client for Forgejo's first-party repository coding-agent APIs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+
+_SECRET_KEYS = {
+    'access_token',
+    'api_key',
+    'apikey',
+    'authorization',
+    'cookie',
+    'password',
+    'passwd',
+    'private_key',
+    'refresh_token',
+    'secret',
+    'token',
+}
+
+
+def _setting(name: str, default: str = '') -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _api_base(explicit: str = '') -> str:
+    base = explicit.strip() or _setting('FORGEJO_API_URL')
+    if not base:
+        raise RuntimeError('FORGEJO_API_URL is not configured')
+    return base.rstrip('/')
+
+
+def _token() -> str:
+    token = _setting('FORGEJO_TOKEN')
+    if not token:
+        raise RuntimeError('FORGEJO_TOKEN is not configured')
+    return token
+
+
+def _repo_path(repo: str) -> str:
+    owner, name = repo.split('/', 1)
+    return f'/repos/{quote(owner, safe="")}/{quote(name, safe="")}'
+
+
+def _redact(value: Any, key: str = '') -> Any:
+    normalized = key.lower().replace('-', '_')
+    if normalized in _SECRET_KEYS:
+        return '[REDACTED]'
+    if isinstance(value, Mapping):
+        return {
+            str(child_key): _redact(child_value, str(child_key))
+            for child_key, child_value in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    base_url: str = '',
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.request(
+            method,
+            f'{_api_base(base_url)}{path}',
+            headers={
+                'Authorization': f'token {_token()}',
+                'Accept': 'application/json',
+            },
+            json=_redact(payload) if payload is not None else None,
+        )
+    if response.status_code >= 400:
+        detail = response.text[:400]
+        raise RuntimeError(
+            f'Forgejo agent API {method} {path} failed '
+            f'({response.status_code}): {detail}'
+        )
+    data = response.json() if response.content else {}
+    if not isinstance(data, dict):
+        raise RuntimeError(f'Forgejo agent API {path} returned a non-object')
+    return data
+
+
+async def create_task(
+    *,
+    repo: str,
+    operation: str,
+    prompt: str,
+    idempotency_key: str,
+    issue_index: int = 0,
+    pull_request_index: int = 0,
+    head_sha: str = '',
+    metadata: dict[str, Any] | None = None,
+    base_url: str = '',
+) -> dict[str, Any]:
+    """Create or retrieve an idempotent Forgejo-owned coding-agent task."""
+    return await _request(
+        'POST',
+        f'{_repo_path(repo)}/agent/tasks',
+        base_url=base_url,
+        payload={
+            'operation': operation,
+            'prompt': prompt,
+            'issue_index': issue_index,
+            'pull_request_index': pull_request_index,
+            'head_sha': head_sha,
+            'idempotency_key': idempotency_key,
+            'metadata': metadata or {},
+        },
+    )
+
+
+async def update_task(
+    *,
+    repo: str,
+    task_id: int,
+    base_url: str = '',
+    **fields: Any,
+) -> dict[str, Any]:
+    """Update Forgejo task lifecycle or CodeTether linkage fields."""
+    payload = {key: value for key, value in fields.items() if value is not None}
+    return await _request(
+        'PATCH',
+        f'{_repo_path(repo)}/agent/tasks/{task_id}',
+        base_url=base_url,
+        payload=payload,
+    )
+
+
+async def append_event(
+    *,
+    repo: str,
+    task_id: int,
+    sequence: int,
+    external_id: str,
+    event_type: str,
+    payload: dict[str, Any],
+    base_url: str = '',
+) -> dict[str, Any]:
+    """Append one ordered, idempotent, redacted session event."""
+    return await _request(
+        'POST',
+        f'{_repo_path(repo)}/agent/tasks/{task_id}/events',
+        base_url=base_url,
+        payload={
+            'sequence': sequence,
+            'external_id': external_id,
+            'type': event_type,
+            'payload': payload,
+        },
+    )
+
+
+def _event_id(
+    task_id: str, sequence: int, event_type: str, payload: Any
+) -> str:
+    serialized = json.dumps(payload, sort_keys=True, default=str)
+    digest = hashlib.sha256(serialized.encode()).hexdigest()[:16]
+    return f'{task_id}:{sequence}:{event_type}:{digest}'
+
+
+def normalize_session_events(
+    task_id: str,
+    messages: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Normalize CodeTether messages and tool records into Forgejo events."""
+    events: list[dict[str, Any]] = []
+    sequence = 0
+    for message in messages:
+        sequence += 1
+        message_payload = _redact(dict(message))
+        event_type = 'agent.message'
+        role = str(message.get('role') or '').lower()
+        if role in {'user', 'human'}:
+            event_type = 'user.message'
+        elif role == 'system':
+            event_type = 'system.message'
+        events.append(
+            {
+                'sequence': sequence,
+                'external_id': _event_id(
+                    task_id, sequence, event_type, message_payload
+                ),
+                'type': event_type,
+                'payload': message_payload,
+            }
+        )
+        tool_calls = message.get('tool_calls') or []
+        if isinstance(tool_calls, Mapping):
+            tool_calls = [tool_calls]
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, Mapping):
+                continue
+            sequence += 1
+            tool_payload = _redact(dict(tool_call))
+            tool_type = (
+                'tool.result'
+                if tool_payload.get('result') is not None
+                or tool_payload.get('output') is not None
+                else 'tool.call'
+            )
+            events.append(
+                {
+                    'sequence': sequence,
+                    'external_id': _event_id(
+                        task_id, sequence, tool_type, tool_payload
+                    ),
+                    'type': tool_type,
+                    'payload': tool_payload,
+                }
+            )
+    return events
+
+
+async def publish_session_events(
+    *,
+    repo: str,
+    forgejo_task_id: int,
+    codetether_task_id: str,
+    messages: Iterable[Mapping[str, Any]],
+    base_url: str = '',
+) -> int:
+    """Publish a complete normalized transcript idempotently to Forgejo."""
+    events = normalize_session_events(codetether_task_id, messages)
+    for event in events:
+        await append_event(
+            repo=repo,
+            task_id=forgejo_task_id,
+            sequence=event['sequence'],
+            external_id=event['external_id'],
+            event_type=event['type'],
+            payload=event['payload'],
+            base_url=base_url,
+        )
+    return len(events)

--- a/a2a_server/forgejo_agent_client.py
+++ b/a2a_server/forgejo_agent_client.py
@@ -123,6 +123,17 @@ async def create_task(
     )
 
 
+async def get_task(
+    *, repo: str, task_id: int, base_url: str = ''
+) -> dict[str, Any]:
+    """Read one Forgejo-owned coding-agent task."""
+    return await _request(
+        'GET',
+        f'{_repo_path(repo)}/agent/tasks/{task_id}',
+        base_url=base_url,
+    )
+
+
 async def update_task(
     *,
     repo: str,

--- a/a2a_server/forgejo_agent_client.py
+++ b/a2a_server/forgejo_agent_client.py
@@ -151,6 +151,17 @@ async def update_task(
     )
 
 
+async def list_events(
+    *, repo: str, task_id: int, base_url: str = ''
+) -> dict[str, Any]:
+    """List ordered events already published for a Forgejo task."""
+    return await _request(
+        'GET',
+        f'{_repo_path(repo)}/agent/tasks/{task_id}/events',
+        base_url=base_url,
+    )
+
+
 async def append_event(
     *,
     repo: str,
@@ -245,15 +256,36 @@ async def publish_session_events(
     base_url: str = '',
 ) -> int:
     """Publish a complete normalized transcript idempotently to Forgejo."""
+    existing = await list_events(
+        repo=repo, task_id=forgejo_task_id, base_url=base_url
+    )
+    existing_events = existing.get('events') or []
+    existing_ids = {
+        str(event.get('external_id') or '')
+        for event in existing_events
+        if isinstance(event, Mapping)
+    }
+    sequence_offset = max(
+        (
+            int(event.get('sequence') or 0)
+            for event in existing_events
+            if isinstance(event, Mapping)
+        ),
+        default=0,
+    )
     events = normalize_session_events(codetether_task_id, messages)
+    published = 0
     for event in events:
+        if event['external_id'] in existing_ids:
+            continue
         await append_event(
             repo=repo,
             task_id=forgejo_task_id,
-            sequence=event['sequence'],
+            sequence=sequence_offset + event['sequence'],
             external_id=event['external_id'],
             event_type=event['type'],
             payload=event['payload'],
             base_url=base_url,
         )
-    return len(events)
+        published += 1
+    return published

--- a/a2a_server/forgejo_agent_controls.py
+++ b/a2a_server/forgejo_agent_controls.py
@@ -1,0 +1,160 @@
+"""Reconcile native Forgejo agent controls into CodeTether execution state."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_ACTIVE_STATUSES = {'pending', 'queued', 'assigned', 'running', 'in_progress'}
+
+
+async def _linked_tasks(limit: int) -> list[dict[str, Any]]:
+    from a2a_server import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        return []
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT t.*
+            FROM tasks t
+            WHERE t.metadata ? 'forgejo_agent_task_id'
+              AND t.metadata->>'source' = 'forgejo-webhook'
+              AND t.status IN (
+                'pending', 'queued', 'assigned', 'running', 'in_progress',
+                'cancelled'
+              )
+            ORDER BY t.updated_at DESC
+            LIMIT $1
+            """,
+            limit,
+        )
+    return [dict(row) for row in rows]
+
+
+async def _cancel_codetether_task(task_id: str) -> bool:
+    """Atomically cancel a task and its latest active run."""
+    from a2a_server import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        return False
+    async with pool.acquire() as conn:
+        result = await conn.execute(
+            """
+            UPDATE tasks
+            SET status = 'cancelled', updated_at = NOW(), completed_at = NOW()
+            WHERE id = $1
+              AND status IN ('pending', 'queued', 'assigned', 'running', 'in_progress')
+            """,
+            task_id,
+        )
+        await conn.execute(
+            """
+            UPDATE task_runs
+            SET status = 'cancelled', completed_at = NOW(),
+                lease_expires_at = NOW()
+            WHERE task_id = $1 AND status IN ('queued', 'running')
+            """,
+            task_id,
+        )
+    return result.endswith('1')
+
+
+def _metadata(task: dict[str, Any]) -> dict[str, Any]:
+    value = task.get('metadata') or {}
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+async def _retry_codetether_task(
+    task: dict[str, Any], forgejo_task: dict[str, Any]
+) -> str:
+    """Create one new execution for a Forgejo task returned to pending."""
+    from a2a_server.persistent_worker_pool import create_and_dispatch_task
+
+    metadata = _metadata(task)
+    retry_generation = int(metadata.get('forgejo_retry_generation') or 0) + 1
+    metadata['forgejo_retry_generation'] = retry_generation
+    metadata['forgejo_retry_of'] = str(task.get('id') or '')
+    metadata['forgejo_work_key'] = (
+        f'{metadata.get("forgejo_work_key") or "forgejo-agent"}:'
+        f'retry:{retry_generation}'
+    )
+    workspace_id = str(
+        task.get('workspace_id')
+        or task.get('codebase_id')
+        or metadata.get('workspace_id')
+        or ''
+    )
+    if not workspace_id:
+        raise RuntimeError('linked CodeTether task has no workspace')
+    return await create_and_dispatch_task(
+        workspace_id=workspace_id,
+        title=str(task.get('title') or 'Retry Forgejo agent task'),
+        prompt=str(task.get('prompt') or task.get('description') or ''),
+        agent_type=str(
+            task.get('agent_type') or metadata.get('agent_type') or 'build'
+        ),
+        priority=int(task.get('priority') or 0),
+        model_ref=str(task.get('model_ref') or metadata.get('model_ref') or '')
+        or None,
+        metadata=metadata,
+        task_timeout_seconds=int(task.get('task_timeout_seconds') or 604800),
+    )
+
+
+async def reconcile_forgejo_agent_controls(limit: int = 50) -> int:
+    """Apply Forgejo cancel/retry state to linked CodeTether tasks."""
+    from a2a_server.forgejo_agent_client import get_task, update_task
+
+    handled = 0
+    for task in await _linked_tasks(limit):
+        metadata = _metadata(task)
+        repo = str(metadata.get('repo') or '')
+        forgejo_task_id = int(metadata.get('forgejo_agent_task_id') or 0)
+        base_url = str(metadata.get('forgejo_api_url') or '')
+        if not repo or not forgejo_task_id:
+            continue
+        forgejo_task = await get_task(
+            repo=repo, task_id=forgejo_task_id, base_url=base_url
+        )
+        forgejo_status = str(forgejo_task.get('status') or '')
+        codetether_status = str(task.get('status') or '')
+        if (
+            forgejo_status == 'cancelled'
+            and codetether_status in _ACTIVE_STATUSES
+        ):
+            if await _cancel_codetether_task(str(task['id'])):
+                handled += 1
+                logger.info(
+                    'Cancelled CodeTether task %s from Forgejo task %s',
+                    task['id'],
+                    forgejo_task_id,
+                )
+            continue
+        if forgejo_status == 'pending' and codetether_status == 'cancelled':
+            new_task_id = await _retry_codetether_task(task, forgejo_task)
+            await update_task(
+                repo=repo,
+                task_id=forgejo_task_id,
+                base_url=base_url,
+                status='accepted',
+                external_task_id=str(new_task_id),
+            )
+            handled += 1
+            logger.info(
+                'Retried Forgejo task %s as CodeTether task %s',
+                forgejo_task_id,
+                new_task_id,
+            )
+    return handled

--- a/a2a_server/forgejo_agent_controls.py
+++ b/a2a_server/forgejo_agent_controls.py
@@ -128,6 +128,9 @@ async def reconcile_forgejo_agent_controls(limit: int = 50) -> int:
         forgejo_task = await get_task(
             repo=repo, task_id=forgejo_task_id, base_url=base_url
         )
+        current_task_id = str(forgejo_task.get('external_task_id') or '')
+        if current_task_id and current_task_id != str(task.get('id') or ''):
+            continue
         forgejo_status = str(forgejo_task.get('status') or '')
         codetether_status = str(task.get('status') or '')
         if (

--- a/a2a_server/forgejo_automation.py
+++ b/a2a_server/forgejo_automation.py
@@ -1,0 +1,516 @@
+"""Forgejo-native review, remediation, and terminal workflow helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import quote
+
+from a2a_server.github_app.issue_review_task import reviewer_verdict
+from a2a_server.github_app.settings import MODEL_REF, TASK_PRIORITY
+
+from .forgejo_webhooks import forgejo_json
+
+logger = logging.getLogger(__name__)
+
+TASK_TIMEOUT_SECONDS = 604800
+MAX_FIX_ATTEMPTS_PER_SHA = 5
+_REVIEW_BODY_LIMIT = 60_000
+_FAILED_STATES = {'error', 'failure', 'warning'}
+
+
+def _repo_path(repo: str) -> str:
+    owner, name = repo.split('/', 1)
+    return f'/repos/{quote(owner, safe="")}/{quote(name, safe="")}'
+
+
+def review_marker(task_id: str) -> str:
+    return f'<!-- codetether-forgejo-review-task:{task_id} -->'
+
+
+def remediation_key(repo: str, pr_number: int, sha: str, context: str) -> str:
+    return f'forgejo:{repo}:{pr_number}:status-fix:{sha}:{context}'
+
+
+def review_event(review_task: dict[str, Any]) -> str:
+    verdict = reviewer_verdict(review_task)
+    if verdict == 'APPROVED':
+        return 'APPROVED'
+    if verdict in {'CHANGES_REQUESTED', 'BLOCKED'}:
+        return 'REQUEST_CHANGES'
+    return 'COMMENT'
+
+
+def review_body(review_task: dict[str, Any]) -> str:
+    task_id = str(review_task.get('id') or '').strip()
+    verdict = reviewer_verdict(review_task) or 'COMMENT'
+    detail = str(
+        review_task.get('result')
+        or review_task.get('error')
+        or 'CodeTether reviewer task completed without a textual summary.'
+    ).strip()
+    marker = review_marker(task_id)
+    prefix = f'## CodeTether Review\n\n**Verdict:** `{verdict}`\n\n'
+    available = max(0, _REVIEW_BODY_LIMIT - len(prefix) - len(marker) - 2)
+    return f'{prefix}{detail[:available]}\n\n{marker}'
+
+
+def is_failed_status(status: dict[str, Any]) -> bool:
+    return (
+        str(status.get('status') or status.get('state') or '').lower()
+        in _FAILED_STATES
+    )
+
+
+def is_self_status(status: dict[str, Any]) -> bool:
+    creator = status.get('creator') or {}
+    login = str(creator.get('login') or creator.get('username') or '').lower()
+    context = str(status.get('context') or '').lower()
+    return login in {'codetether', 'codetether-bot'} or context.startswith(
+        'codetether/'
+    )
+
+
+async def request_forgejo_review(
+    *, base: str, repo: str, pr_number: int, reviewer: str | None
+) -> bool:
+    login = str(reviewer or '').strip()
+    if (
+        not login
+        or login.lower() in {'codetether', 'codetether-bot'}
+        or login.lower().endswith('[bot]')
+    ):
+        return False
+    await forgejo_json(
+        'POST',
+        base,
+        f'{_repo_path(repo)}/pulls/{pr_number}/requested_reviewers',
+        {'reviewers': [login]},
+    )
+    return True
+
+
+async def publish_forgejo_review(review_task: dict[str, Any]) -> dict[str, Any]:
+    metadata = review_task.get('metadata') or {}
+    task_id = str(review_task.get('id') or '').strip()
+    repo = str(metadata.get('repo') or '').strip()
+    base = str(metadata.get('forgejo_api_url') or '').rstrip('/')
+    pr_number = int(metadata.get('pr_number') or 0)
+    head_sha = str(metadata.get('pr_head_sha') or '').strip()
+    if not (task_id and repo and base and pr_number):
+        raise ValueError('review task is missing Forgejo publication context')
+
+    path = f'{_repo_path(repo)}/pulls/{pr_number}/reviews'
+    marker = review_marker(task_id)
+    reviews = await forgejo_json('GET', base, f'{path}?limit=100')
+    for review in reviews or []:
+        if marker in str((review or {}).get('body') or ''):
+            return {
+                'published': True,
+                'duplicate': True,
+                'event': str((review or {}).get('state') or 'COMMENT'),
+                'review_id': (review or {}).get('id'),
+            }
+
+    payload: dict[str, Any] = {
+        'body': review_body(review_task),
+        'event': review_event(review_task),
+    }
+    if head_sha:
+        payload['commit_id'] = head_sha
+    published = await forgejo_json('POST', base, path, payload)
+    return {
+        'published': True,
+        'duplicate': False,
+        'event': payload['event'],
+        'review_id': (published or {}).get('id'),
+    }
+
+
+async def _task_exists(work_key: str) -> bool:
+    from a2a_server import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        return False
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """SELECT id FROM tasks
+               WHERE COALESCE(metadata, '{}'::jsonb)->>'forgejo_work_key' = $1
+               LIMIT 1""",
+            work_key,
+        )
+    return bool(row)
+
+
+async def create_forgejo_review_task(code_task: dict[str, Any]) -> str | None:
+    metadata = code_task.get('metadata') or {}
+    if str(code_task.get('status')) != 'completed':
+        return None
+    repo = str(metadata.get('repo') or '')
+    base = str(metadata.get('forgejo_api_url') or '').rstrip('/')
+    pr_number = int(metadata.get('pr_number') or 0)
+    workspace_id = str(metadata.get('workspace_id') or '')
+    branch_hint = str(metadata.get('branch_name') or '')
+    if not (repo and base and workspace_id):
+        return None
+
+    from a2a_server.persistent_worker_pool import create_and_dispatch_task
+
+    pr: dict[str, Any] | None = None
+    if pr_number:
+        pr = await forgejo_json(
+            'GET', base, f'{_repo_path(repo)}/pulls/{pr_number}'
+        )
+    elif branch_hint:
+        pulls = await forgejo_json(
+            'GET', base, f'{_repo_path(repo)}/pulls?state=open&limit=50'
+        )
+        pr = next(
+            (
+                candidate
+                for candidate in pulls or []
+                if str(((candidate or {}).get('head') or {}).get('ref') or '')
+                == branch_hint
+            ),
+            None,
+        )
+        pr_number = int(
+            (pr or {}).get('number') or (pr or {}).get('index') or 0
+        )
+    if not pr or not pr_number:
+        return None
+    head = pr.get('head') or {}
+    head_sha = str(head.get('sha') or '')
+    branch = str(head.get('ref') or metadata.get('branch_name') or '')
+    work_key = f'forgejo:{repo}:{pr_number}:review:{head_sha}'
+    if await _task_exists(work_key):
+        return None
+
+    routing = {
+        key: metadata[key]
+        for key in (
+            'target_agent_name',
+            'target_worker_id',
+            'required_capabilities',
+        )
+        if metadata.get(key)
+    }
+    review_metadata = {
+        'workspace_id': workspace_id,
+        'source': 'forgejo-webhook',
+        'platform': 'forgejo',
+        'workflow_stage': 'review',
+        'repo': repo,
+        'issue_number': metadata.get('issue_number') or pr_number,
+        'pr_number': pr_number,
+        'branch_name': branch,
+        'pr_head_sha': head_sha,
+        'forgejo_api_url': base,
+        'forgejo_issue_url': metadata.get('forgejo_issue_url')
+        or pr.get('html_url'),
+        'trigger_actor_login': metadata.get('trigger_actor_login'),
+        'parent_task_id': code_task.get('id'),
+        'forgejo_work_key': work_key,
+        **routing,
+    }
+    prompt = (
+        f'Review Forgejo pull request #{pr_number} in {repo} at head {head_sha}.\n\n'
+        'Inspect the implementation, tests, and evidence. Return exactly one '
+        'terminal verdict: APPROVED, CHANGES_REQUESTED, or BLOCKED, followed by '
+        'concise evidence. Never modify the branch during review.'
+    )
+    task_id = await create_and_dispatch_task(
+        workspace_id=workspace_id,
+        title=f'Review Forgejo PR #{pr_number}',
+        prompt=prompt,
+        agent_type='review',
+        priority=TASK_PRIORITY,
+        model_ref=MODEL_REF,
+        metadata=review_metadata,
+        task_timeout_seconds=TASK_TIMEOUT_SECONDS,
+        github_issue_url=review_metadata['forgejo_issue_url'],
+    )
+    await request_forgejo_review(
+        base=base,
+        repo=repo,
+        pr_number=pr_number,
+        reviewer=metadata.get('trigger_actor_login'),
+    )
+    return task_id
+
+
+async def create_forgejo_fix_followup(
+    review_task: dict[str, Any],
+) -> str | None:
+    verdict = reviewer_verdict(review_task)
+    if verdict not in {'CHANGES_REQUESTED', 'BLOCKED'}:
+        return None
+    metadata = review_task.get('metadata') or {}
+    repo = str(metadata.get('repo') or '')
+    base = str(metadata.get('forgejo_api_url') or '').rstrip('/')
+    pr_number = int(metadata.get('pr_number') or 0)
+    workspace_id = str(metadata.get('workspace_id') or '')
+    expected_sha = str(metadata.get('pr_head_sha') or '')
+    review_task_id = str(review_task.get('id') or '')
+    if not (
+        repo
+        and base
+        and pr_number
+        and workspace_id
+        and expected_sha
+        and review_task_id
+    ):
+        return None
+
+    pr = await forgejo_json(
+        'GET', base, f'{_repo_path(repo)}/pulls/{pr_number}'
+    )
+    if str(pr.get('state') or '').lower() != 'open':
+        return None
+    current_sha = str((pr.get('head') or {}).get('sha') or '')
+    if current_sha != expected_sha:
+        return None
+
+    from a2a_server import database as db
+    from a2a_server.persistent_worker_pool import create_and_dispatch_task
+
+    pool = await db.get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """SELECT COUNT(*)::int AS attempts,
+                      BOOL_OR(status IN ('pending','queued','running','working')) AS active,
+                      BOOL_OR(
+                        COALESCE(metadata, '{}'::jsonb)->>'review_task_id' = $4
+                      ) AS review_already_handled
+               FROM tasks
+               WHERE COALESCE(metadata, '{}'::jsonb)->>'source' = 'forgejo-webhook'
+                 AND COALESCE(metadata, '{}'::jsonb)->>'workflow_stage' = 'fix'
+                 AND COALESCE(metadata, '{}'::jsonb)->>'repo' = $1
+                 AND COALESCE(metadata, '{}'::jsonb)->>'pr_number' = $2
+                 AND COALESCE(metadata, '{}'::jsonb)->>'pr_head_sha' = $3""",
+            repo,
+            str(pr_number),
+            expected_sha,
+            review_task_id,
+        )
+    attempts = int((row or {}).get('attempts') or 0)
+    if (
+        (row or {}).get('review_already_handled')
+        or (row or {}).get('active')
+        or attempts >= MAX_FIX_ATTEMPTS_PER_SHA
+    ):
+        return None
+
+    routing = {
+        key: metadata[key]
+        for key in (
+            'target_agent_name',
+            'target_worker_id',
+            'required_capabilities',
+        )
+        if metadata.get(key)
+    }
+    fix_metadata = {
+        'workspace_id': workspace_id,
+        'source': 'forgejo-webhook',
+        'platform': 'forgejo',
+        'workflow_stage': 'fix',
+        'repo': repo,
+        'issue_number': metadata.get('issue_number') or pr_number,
+        'pr_number': pr_number,
+        'branch_name': metadata.get('branch_name')
+        or (pr.get('head') or {}).get('ref'),
+        'pr_head_sha': expected_sha,
+        'forgejo_api_url': base,
+        'forgejo_issue_url': metadata.get('forgejo_issue_url')
+        or pr.get('html_url'),
+        'review_task_id': review_task_id,
+        'review_verdict': verdict,
+        'fix_followup': 'true',
+        'fix_attempt': attempts + 1,
+        'forgejo_work_key': f'forgejo:{repo}:{pr_number}:review-fix:{expected_sha}:{attempts + 1}',
+        **routing,
+    }
+    prompt = (
+        f'Apply the requested changes from Forgejo review task {review_task_id} '
+        f'to PR #{pr_number} in {repo} at head {expected_sha}.\n\n'
+        f'Review verdict and evidence:\n{review_task.get("result") or review_task.get("error") or verdict}\n\n'
+        'Edit the existing branch, run focused validation, commit, and push. '
+        'Do not open a duplicate pull request.'
+    )
+    return await create_and_dispatch_task(
+        workspace_id=workspace_id,
+        title=f'Apply Forgejo PR fix #{pr_number}',
+        prompt=prompt,
+        agent_type='build',
+        priority=TASK_PRIORITY,
+        model_ref=MODEL_REF,
+        metadata=fix_metadata,
+        task_timeout_seconds=TASK_TIMEOUT_SECONDS,
+        github_issue_url=fix_metadata['forgejo_issue_url'],
+    )
+
+
+async def create_status_remediation_task(
+    *, base: str, repo: str, pr: dict[str, Any], status: dict[str, Any]
+) -> str | None:
+    if not is_failed_status(status) or is_self_status(status):
+        return None
+    pr_number = int(pr.get('number') or pr.get('index') or 0)
+    head = pr.get('head') or {}
+    sha = str(head.get('sha') or '')
+    branch = str(head.get('ref') or '')
+    context = str(status.get('context') or 'unknown')
+    work_key = remediation_key(repo, pr_number, sha, context)
+    if not (pr_number and sha and branch) or await _task_exists(work_key):
+        return None
+
+    from a2a_server.persistent_worker_pool import create_and_dispatch_task
+
+    clone_url = str(((head.get('repo') or {}).get('clone_url')) or '')
+    if not clone_url:
+        repo_data = await forgejo_json('GET', base, _repo_path(repo))
+        clone_url = str((repo_data or {}).get('clone_url') or '')
+    if not clone_url:
+        return None
+
+    from a2a_server.forgejo_webhooks import _ensure_workspace, _token
+    from a2a_server.github_app.routing import resolve_task_target
+
+    workspace_id = await _ensure_workspace(
+        {
+            'repo': repo,
+            'number': pr_number,
+            'repo_data': head.get('repo') or {},
+        },
+        clone_url,
+        branch,
+        _token(),
+    )
+    routing = await resolve_task_target()
+    detail = str(status.get('description') or '')
+    target_url = str(status.get('target_url') or '')
+    metadata = {
+        'workspace_id': workspace_id,
+        'source': 'forgejo-webhook',
+        'platform': 'forgejo',
+        'workflow_stage': 'fix',
+        'repo': repo,
+        'issue_number': pr_number,
+        'pr_number': pr_number,
+        'branch_name': branch,
+        'pr_head_sha': sha,
+        'forgejo_api_url': base,
+        'forgejo_issue_url': pr.get('html_url'),
+        'forgejo_status_context': context,
+        'forgejo_status_target_url': target_url,
+        'forgejo_work_key': work_key,
+        **routing,
+    }
+    prompt = (
+        f'Fix failed Forgejo status `{context}` on PR #{pr_number} in {repo} at {sha}.\n\n'
+        f'Description: {detail}\nTarget: {target_url}\n\n'
+        'Inspect the failing check evidence, edit the existing branch, run focused '
+        'validation, commit, and push. Do not open a duplicate pull request.'
+    )
+    return await create_and_dispatch_task(
+        workspace_id=workspace_id,
+        title=f'Fix Forgejo status {context} on PR #{pr_number}',
+        prompt=prompt,
+        agent_type='build',
+        priority=TASK_PRIORITY,
+        model_ref=MODEL_REF,
+        metadata=metadata,
+        task_timeout_seconds=TASK_TIMEOUT_SECONDS,
+        github_issue_url=metadata['forgejo_issue_url'],
+    )
+
+
+async def reconcile_forgejo_failures(limit: int = 20) -> int:
+    """Poll open Forgejo PR heads because Forgejo 15 has no status webhook."""
+    from a2a_server import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        return 0
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT DISTINCT metadata->>'repo' AS repo,
+                              metadata->>'forgejo_api_url' AS base
+               FROM tasks
+               WHERE metadata->>'source' = 'forgejo-webhook'
+                 AND metadata->>'repo' IS NOT NULL
+                 AND metadata->>'forgejo_api_url' IS NOT NULL
+               ORDER BY repo
+               LIMIT $1""",
+            limit,
+        )
+    handled = 0
+    for row in rows:
+        repo = str(row['repo'])
+        base = str(row['base']).rstrip('/')
+        pulls = await forgejo_json(
+            'GET', base, f'{_repo_path(repo)}/pulls?state=open&limit=50'
+        )
+        for pr in pulls or []:
+            sha = str(((pr.get('head') or {}).get('sha')) or '')
+            if not sha:
+                continue
+            statuses = await forgejo_json(
+                'GET',
+                base,
+                f'{_repo_path(repo)}/commits/{sha}/statuses?limit=50',
+            )
+            for status in statuses or []:
+                if await create_status_remediation_task(
+                    base=base, repo=repo, pr=pr, status=status
+                ):
+                    handled += 1
+    return handled
+
+
+async def reconcile_forgejo_terminal_reviews(limit: int = 20) -> int:
+    from a2a_server import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        return 0
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT id FROM tasks
+               WHERE status = 'completed'
+                 AND metadata->>'source' = 'forgejo-webhook'
+                 AND metadata->>'workflow_stage' = 'review'
+                 AND NOT (COALESCE(metadata, '{}'::jsonb) ? 'forgejo_review_reconciled_at')
+               ORDER BY completed_at
+               LIMIT $1""",
+            limit,
+        )
+    handled = 0
+    for row in rows:
+        task = await db.db_get_task(str(row['id']))
+        if not task:
+            continue
+        await publish_forgejo_review(task)
+        await create_forgejo_fix_followup(task)
+        await _mark_review_reconciled(str(row['id']))
+        handled += 1
+    return handled
+
+
+async def _mark_review_reconciled(task_id: str) -> None:
+    from a2a_server import database as db
+
+    pool = await db.get_pool()
+    if not pool:
+        return
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """UPDATE tasks
+               SET metadata = COALESCE(metadata, '{}'::jsonb)
+                   || jsonb_build_object('forgejo_review_reconciled_at', NOW()::text),
+                   updated_at = NOW()
+               WHERE id = $1""",
+            task_id,
+        )

--- a/a2a_server/forgejo_automation.py
+++ b/a2a_server/forgejo_automation.py
@@ -209,6 +209,8 @@ async def create_forgejo_review_task(code_task: dict[str, Any]) -> str | None:
         'forgejo_api_url': base,
         'forgejo_issue_url': metadata.get('forgejo_issue_url')
         or pr.get('html_url'),
+        'forgejo_agent_task_id': metadata.get('forgejo_agent_task_id'),
+        'forgejo_agent_task_url': metadata.get('forgejo_agent_task_url'),
         'trigger_actor_login': metadata.get('trigger_actor_login'),
         'parent_task_id': code_task.get('id'),
         'forgejo_work_key': work_key,
@@ -231,6 +233,19 @@ async def create_forgejo_review_task(code_task: dict[str, Any]) -> str | None:
         task_timeout_seconds=TASK_TIMEOUT_SECONDS,
         github_issue_url=review_metadata['forgejo_issue_url'],
     )
+    forgejo_task_id = int(review_metadata.get('forgejo_agent_task_id') or 0)
+    if forgejo_task_id:
+        from a2a_server.forgejo_agent_client import update_task
+
+        await update_task(
+            repo=repo,
+            task_id=forgejo_task_id,
+            base_url=base,
+            status='running',
+            external_task_id=str(task_id),
+            head_sha=head_sha,
+            branch=branch,
+        )
     await request_forgejo_review(
         base=base,
         repo=repo,
@@ -325,6 +340,8 @@ async def create_forgejo_fix_followup(
         'forgejo_api_url': base,
         'forgejo_issue_url': metadata.get('forgejo_issue_url')
         or pr.get('html_url'),
+        'forgejo_agent_task_id': metadata.get('forgejo_agent_task_id'),
+        'forgejo_agent_task_url': metadata.get('forgejo_agent_task_url'),
         'review_task_id': review_task_id,
         'review_verdict': verdict,
         'fix_followup': 'true',
@@ -339,7 +356,7 @@ async def create_forgejo_fix_followup(
         'Edit the existing branch, run focused validation, commit, and push. '
         'Do not open a duplicate pull request.'
     )
-    return await create_and_dispatch_task(
+    task_id = await create_and_dispatch_task(
         workspace_id=workspace_id,
         title=f'Apply Forgejo PR fix #{pr_number}',
         prompt=prompt,
@@ -350,6 +367,20 @@ async def create_forgejo_fix_followup(
         task_timeout_seconds=TASK_TIMEOUT_SECONDS,
         github_issue_url=fix_metadata['forgejo_issue_url'],
     )
+    forgejo_task_id = int(fix_metadata.get('forgejo_agent_task_id') or 0)
+    if forgejo_task_id:
+        from a2a_server.forgejo_agent_client import update_task
+
+        await update_task(
+            repo=repo,
+            task_id=forgejo_task_id,
+            base_url=base,
+            status='running',
+            external_task_id=str(task_id),
+            head_sha=expected_sha,
+            branch=str(fix_metadata.get('branch_name') or ''),
+        )
+    return task_id
 
 
 async def create_status_remediation_task(

--- a/a2a_server/forgejo_automation.py
+++ b/a2a_server/forgejo_automation.py
@@ -211,6 +211,9 @@ async def create_forgejo_review_task(code_task: dict[str, Any]) -> str | None:
         or pr.get('html_url'),
         'forgejo_agent_task_id': metadata.get('forgejo_agent_task_id'),
         'forgejo_agent_task_url': metadata.get('forgejo_agent_task_url'),
+        'temporal_orchestrated': metadata.get('temporal_orchestrated', False),
+        'temporal_workflow_id': metadata.get('temporal_workflow_id'),
+        'temporal_attempt': metadata.get('temporal_attempt'),
         'trigger_actor_login': metadata.get('trigger_actor_login'),
         'parent_task_id': code_task.get('id'),
         'forgejo_work_key': work_key,
@@ -342,6 +345,9 @@ async def create_forgejo_fix_followup(
         or pr.get('html_url'),
         'forgejo_agent_task_id': metadata.get('forgejo_agent_task_id'),
         'forgejo_agent_task_url': metadata.get('forgejo_agent_task_url'),
+        'temporal_orchestrated': metadata.get('temporal_orchestrated', False),
+        'temporal_workflow_id': metadata.get('temporal_workflow_id'),
+        'temporal_attempt': metadata.get('temporal_attempt'),
         'review_task_id': review_task_id,
         'review_verdict': verdict,
         'fix_followup': 'true',
@@ -513,6 +519,7 @@ async def reconcile_forgejo_terminal_reviews(limit: int = 20) -> int:
                WHERE status = 'completed'
                  AND metadata->>'source' = 'forgejo-webhook'
                  AND metadata->>'workflow_stage' = 'review'
+                 AND COALESCE(metadata->>'temporal_orchestrated', 'false') != 'true'
                  AND NOT (COALESCE(metadata, '{}'::jsonb) ? 'forgejo_review_reconciled_at')
                ORDER BY completed_at
                LIMIT $1""",

--- a/a2a_server/forgejo_automation.py
+++ b/a2a_server/forgejo_automation.py
@@ -428,7 +428,7 @@ async def create_status_remediation_task(
 
 
 async def reconcile_forgejo_failures(limit: int = 20) -> int:
-    """Poll open Forgejo PR heads because Forgejo 15 has no status webhook."""
+    """Recover missed status deliveries and support unpatched Forgejo servers."""
     from a2a_server import database as db
 
     pool = await db.get_pool()

--- a/a2a_server/forgejo_task_completion.py
+++ b/a2a_server/forgejo_task_completion.py
@@ -14,12 +14,63 @@ from a2a_server.forgejo_webhooks import forgejo_json
 from a2a_server.session_view import build_task_session_url
 
 
-def _task_footer(task_id: str) -> str:
-    session_url = build_task_session_url(task_id)
+def _task_footer(task_id: str, metadata: dict | None = None) -> str:
     footer = f'\n\nTask: `{task_id}`'
+    native_url = str((metadata or {}).get('forgejo_agent_task_url') or '')
+    session_url = native_url or build_task_session_url(task_id)
     if session_url:
         footer += f' · [View session]({session_url})'
     return footer
+
+
+async def sync_forgejo_agent_task(task: dict) -> None:
+    """Publish terminal lifecycle and complete transcript to Forgejo."""
+    metadata = task.get('metadata') or {}
+    forgejo_task_id = int(metadata.get('forgejo_agent_task_id') or 0)
+    repo = str(metadata.get('repo') or '')
+    if not forgejo_task_id or not repo:
+        return
+
+    from a2a_server.forgejo_agent_client import (
+        publish_session_events,
+        update_task,
+    )
+    from a2a_server.session_view import _task_messages
+
+    status = str(task.get('status') or 'failed').lower()
+    forgejo_status = {
+        'queued': 'pending',
+        'in_progress': 'running',
+    }.get(status, status)
+    if forgejo_status not in {
+        'pending',
+        'accepted',
+        'running',
+        'completed',
+        'failed',
+        'cancelled',
+    }:
+        forgejo_status = 'failed'
+    session_id, messages = await _task_messages(task, 10_000)
+    await update_task(
+        repo=repo,
+        task_id=forgejo_task_id,
+        base_url=str(metadata.get('forgejo_api_url') or ''),
+        status=forgejo_status,
+        external_task_id=str(task.get('id') or ''),
+        external_session_id=session_id,
+        head_sha=str(metadata.get('pr_head_sha') or ''),
+        branch=str(metadata.get('branch_name') or ''),
+        result=str(task.get('result') or ''),
+        error=str(task.get('error') or ''),
+    )
+    await publish_session_events(
+        repo=repo,
+        forgejo_task_id=forgejo_task_id,
+        codetether_task_id=str(task.get('id') or ''),
+        messages=messages,
+        base_url=str(metadata.get('forgejo_api_url') or ''),
+    )
 
 
 async def notify_forgejo_task_completion(task: dict) -> None:
@@ -38,6 +89,8 @@ async def notify_forgejo_task_completion(task: dict) -> None:
     task_id = str(task.get('id') or '')
     if not repo or not number or not base or not task_id:
         return
+
+    await sync_forgejo_agent_task(task)
 
     status = str(task.get('status') or 'unknown')
     review_evidence: dict | None = None
@@ -83,6 +136,6 @@ async def notify_forgejo_task_completion(task: dict) -> None:
         message = f'## ⚠️ CodeTether {stage.title()}\n\nTask ended with status `{status}`.'
     if detail:
         message += f'\n\n{detail}'
-    message += _task_footer(task_id)
+    message += _task_footer(task_id, metadata)
     message += f'\n\n{marker}'
     await forgejo_json('POST', base, issue_path, {'body': message})

--- a/a2a_server/forgejo_task_completion.py
+++ b/a2a_server/forgejo_task_completion.py
@@ -1,0 +1,49 @@
+"""Terminal task comments for Forgejo webhook workflows."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from a2a_server.forgejo_webhooks import forgejo_json
+
+
+async def notify_forgejo_task_completion(task: dict) -> None:
+    """Post one final Forgejo issue/PR comment for a terminal build task."""
+    metadata = task.get('metadata') or {}
+    if metadata.get('source') != 'forgejo-webhook':
+        return
+    if metadata.get('workflow_stage') != 'code':
+        return
+
+    repo = str(metadata.get('repo') or '')
+    number = int(metadata.get('issue_number') or metadata.get('pr_number') or 0)
+    base = str(metadata.get('forgejo_api_url') or '').rstrip('/')
+    task_id = str(task.get('id') or '')
+    if not repo or not number or not base or not task_id:
+        return
+
+    owner, name = repo.split('/', 1)
+    issue_path = (
+        f'/repos/{quote(owner, safe="")}/{quote(name, safe="")}'
+        f'/issues/{number}/comments'
+    )
+    marker = f'<!-- codetether-forgejo-terminal:{task_id} -->'
+    comments = await forgejo_json('GET', base, issue_path)
+    if isinstance(comments, list) and any(
+        marker in str((comment or {}).get('body') or '') for comment in comments
+    ):
+        return
+
+    status = str(task.get('status') or 'unknown')
+    detail = str(task.get('result') or task.get('error') or '').strip()
+    if status == 'completed':
+        message = (
+            '## 🛠️ CodeTether Fix\n\n'
+            'Completed and pushed the requested changes.'
+        )
+    else:
+        message = f'## ⚠️ CodeTether Fix\n\nTask ended with status `{status}`.'
+    if detail:
+        message += f'\n\n{detail}'
+    message += f'\n\nTask: `{task_id}`\n\n{marker}'
+    await forgejo_json('POST', base, issue_path, {'body': message})

--- a/a2a_server/forgejo_task_completion.py
+++ b/a2a_server/forgejo_task_completion.py
@@ -23,8 +23,14 @@ def _task_footer(task_id: str, metadata: dict | None = None) -> str:
     return footer
 
 
-async def sync_forgejo_agent_task(task: dict) -> None:
-    """Publish terminal lifecycle and complete transcript to Forgejo."""
+async def sync_forgejo_agent_task(
+    task: dict, *, workflow_terminal: bool = True
+) -> None:
+    """Publish lifecycle and complete transcript to Forgejo.
+
+    Temporal-managed stage completions remain ``running`` until the durable
+    workflow itself finalizes the Forgejo-owned task.
+    """
     metadata = task.get('metadata') or {}
     forgejo_task_id = int(metadata.get('forgejo_agent_task_id') or 0)
     repo = str(metadata.get('repo') or '')
@@ -52,17 +58,25 @@ async def sync_forgejo_agent_task(task: dict) -> None:
     }:
         forgejo_status = 'failed'
     session_id, messages = await _task_messages(task, 10_000)
+    if not workflow_terminal:
+        forgejo_status = 'running'
+    lifecycle = {
+        'status': forgejo_status,
+        'external_task_id': str(task.get('id') or ''),
+        'external_session_id': session_id,
+        'head_sha': str(metadata.get('pr_head_sha') or ''),
+        'branch': str(metadata.get('branch_name') or ''),
+    }
+    if workflow_terminal:
+        lifecycle.update(
+            result=str(task.get('result') or ''),
+            error=str(task.get('error') or ''),
+        )
     await update_task(
         repo=repo,
         task_id=forgejo_task_id,
         base_url=str(metadata.get('forgejo_api_url') or ''),
-        status=forgejo_status,
-        external_task_id=str(task.get('id') or ''),
-        external_session_id=session_id,
-        head_sha=str(metadata.get('pr_head_sha') or ''),
-        branch=str(metadata.get('branch_name') or ''),
-        result=str(task.get('result') or ''),
-        error=str(task.get('error') or ''),
+        **lifecycle,
     )
     await publish_session_events(
         repo=repo,
@@ -80,6 +94,30 @@ async def notify_forgejo_task_completion(task: dict) -> None:
         return
 
     stage = str(metadata.get('workflow_stage') or '')
+    if metadata.get('temporal_orchestrated'):
+        if stage not in {'prepare', 'code', 'fix', 'review'}:
+            return
+        await sync_forgejo_agent_task(task, workflow_terminal=False)
+        from a2a_server.forgejo_automation import reviewer_verdict
+        from a2a_server.temporal.client import signal_task_terminal
+        from a2a_server.temporal.models import ForgejoTaskTerminalSignal
+
+        await signal_task_terminal(
+            int(metadata.get('forgejo_agent_task_id') or 0),
+            ForgejoTaskTerminalSignal(
+                task_id=str(task.get('id') or ''),
+                stage=stage,
+                status=str(task.get('status') or 'failed'),
+                session_id=str(
+                    task.get('session_id') or metadata.get('session_id') or ''
+                ),
+                verdict=(reviewer_verdict(task) if stage == 'review' else ''),
+                head_sha=str(metadata.get('pr_head_sha') or ''),
+                pull_request_number=int(metadata.get('pr_number') or 0),
+            ),
+        )
+        return
+
     if stage not in {'code', 'fix', 'review'}:
         return
 

--- a/a2a_server/forgejo_task_completion.py
+++ b/a2a_server/forgejo_task_completion.py
@@ -1,18 +1,26 @@
-"""Terminal task comments for Forgejo webhook workflows."""
+"""Terminal orchestration for native Forgejo automation workflows."""
 
 from __future__ import annotations
 
 from urllib.parse import quote
 
+from a2a_server.forgejo_automation import (
+    _mark_review_reconciled,
+    create_forgejo_fix_followup,
+    create_forgejo_review_task,
+    publish_forgejo_review,
+)
 from a2a_server.forgejo_webhooks import forgejo_json
 
 
 async def notify_forgejo_task_completion(task: dict) -> None:
-    """Post one final Forgejo issue/PR comment for a terminal build task."""
+    """Advance one Forgejo workflow stage and post one terminal comment."""
     metadata = task.get('metadata') or {}
     if metadata.get('source') != 'forgejo-webhook':
         return
-    if metadata.get('workflow_stage') != 'code':
+
+    stage = str(metadata.get('workflow_stage') or '')
+    if stage not in {'code', 'fix', 'review'}:
         return
 
     repo = str(metadata.get('repo') or '')
@@ -21,6 +29,16 @@ async def notify_forgejo_task_completion(task: dict) -> None:
     task_id = str(task.get('id') or '')
     if not repo or not number or not base or not task_id:
         return
+
+    status = str(task.get('status') or 'unknown')
+    review_evidence: dict | None = None
+    followup_task_id: str | None = None
+    if stage == 'code' and status == 'completed':
+        followup_task_id = await create_forgejo_review_task(task)
+    elif stage == 'review' and status == 'completed':
+        review_evidence = await publish_forgejo_review(task)
+        followup_task_id = await create_forgejo_fix_followup(task)
+        await _mark_review_reconciled(task_id)
 
     owner, name = repo.split('/', 1)
     issue_path = (
@@ -34,15 +52,26 @@ async def notify_forgejo_task_completion(task: dict) -> None:
     ):
         return
 
-    status = str(task.get('status') or 'unknown')
     detail = str(task.get('result') or task.get('error') or '').strip()
-    if status == 'completed':
+    if stage == 'review' and status == 'completed':
+        event = str((review_evidence or {}).get('event') or 'COMMENT')
+        review_id = (review_evidence or {}).get('review_id')
         message = (
-            '## 🛠️ CodeTether Fix\n\n'
-            'Completed and pushed the requested changes.'
+            '## 🔎 CodeTether Review\n\n'
+            f'Published Forgejo review event `{event}`.'
         )
+        if review_id is not None:
+            message += f' Review: `{review_id}`.'
+        if followup_task_id:
+            message += f'\n\nQueued fix follow-up task `{followup_task_id}`.'
+    elif status == 'completed':
+        message = (
+            '## 🛠️ CodeTether Fix\n\nCompleted and pushed the requested changes.'
+        )
+        if followup_task_id:
+            message += f'\n\nQueued review task `{followup_task_id}`.'
     else:
-        message = f'## ⚠️ CodeTether Fix\n\nTask ended with status `{status}`.'
+        message = f'## ⚠️ CodeTether {stage.title()}\n\nTask ended with status `{status}`.'
     if detail:
         message += f'\n\n{detail}'
     message += f'\n\nTask: `{task_id}`\n\n{marker}'

--- a/a2a_server/forgejo_task_completion.py
+++ b/a2a_server/forgejo_task_completion.py
@@ -11,6 +11,15 @@ from a2a_server.forgejo_automation import (
     publish_forgejo_review,
 )
 from a2a_server.forgejo_webhooks import forgejo_json
+from a2a_server.session_view import build_task_session_url
+
+
+def _task_footer(task_id: str) -> str:
+    session_url = build_task_session_url(task_id)
+    footer = f'\n\nTask: `{task_id}`'
+    if session_url:
+        footer += f' · [View session]({session_url})'
+    return footer
 
 
 async def notify_forgejo_task_completion(task: dict) -> None:
@@ -74,5 +83,6 @@ async def notify_forgejo_task_completion(task: dict) -> None:
         message = f'## ⚠️ CodeTether {stage.title()}\n\nTask ended with status `{status}`.'
     if detail:
         message += f'\n\n{detail}'
-    message += f'\n\nTask: `{task_id}`\n\n{marker}'
+    message += _task_footer(task_id)
+    message += f'\n\n{marker}'
     await forgejo_json('POST', base, issue_path, {'body': message})

--- a/a2a_server/forgejo_webhooks.py
+++ b/a2a_server/forgejo_webhooks.py
@@ -275,6 +275,42 @@ Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from 
     )
     forgejo_agent_task_id = int(forgejo_agent_task['id'])
     forgejo_agent_task_url = str(forgejo_agent_task['html_url'])
+
+    from a2a_server.temporal.config import temporal_settings
+
+    if temporal_settings().enabled:
+        from a2a_server.forgejo_agent_client import (
+            update_task as update_agent_task,
+        )
+        from a2a_server.temporal.client import start_forgejo_workflow
+        from a2a_server.temporal.models import ForgejoAgentWorkflowInput
+
+        workflow_id = await start_forgejo_workflow(
+            ForgejoAgentWorkflowInput(
+                forgejo_task_id=forgejo_agent_task_id,
+                repository=repo,
+                issue_number=ctx['number'],
+                pull_request_number=ctx['number'] if ctx['is_pr'] else 0,
+                workspace_id=wid,
+                branch=work_branch,
+                head_sha=head_sha,
+                operation=operation,
+            )
+        )
+        await update_agent_task(
+            repo=repo,
+            task_id=forgejo_agent_task_id,
+            base_url=base,
+            status='accepted',
+        )
+        return {
+            'accepted': True,
+            'workspace_id': wid,
+            'temporal_workflow_id': workflow_id,
+            'forgejo_agent_task_id': forgejo_agent_task_id,
+            'forgejo_agent_task_url': forgejo_agent_task_url,
+        }
+
     followup = {
         'workspace_id': wid,
         'source': 'forgejo-webhook',
@@ -413,6 +449,42 @@ async def _handle_status_event(
         'reason': 'queued' if task_id else 'duplicate-or-ignored',
         'task_id': task_id,
     }
+
+
+@forgejo_webhook_router.post('/v1/webhooks/forgejo/agent-control')
+async def handle_forgejo_agent_control(request: Request) -> dict[str, Any]:
+    """Verify and signal a native Forgejo cancel/retry control."""
+    import json
+    import time
+
+    body = await request.body()
+    verify_forgejo_signature(_signature(request), body)
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(400, 'Invalid Forgejo control JSON') from exc
+    issued_at = int(payload.get('issued_at') or 0)
+    if not issued_at or abs(int(time.time()) - issued_at) > 300:
+        raise HTTPException(401, 'Expired Forgejo agent control')
+    action = str(payload.get('action') or '')
+    if action not in {'cancel', 'retry'}:
+        raise HTTPException(422, 'Unsupported Forgejo agent control')
+    forgejo_task_id = int(payload.get('task_id') or 0)
+    if not forgejo_task_id:
+        raise HTTPException(422, 'Forgejo task ID is required')
+
+    from a2a_server.temporal.client import signal_control
+    from a2a_server.temporal.models import ForgejoControlSignal
+
+    await signal_control(
+        ForgejoControlSignal(
+            action=action,
+            forgejo_task_id=forgejo_task_id,
+            requested_by=str(payload.get('requested_by') or ''),
+            request_id=str(payload.get('request_id') or ''),
+        )
+    )
+    return {'accepted': True, 'task_id': forgejo_task_id, 'action': action}
 
 
 @forgejo_webhook_router.post('/v1/webhooks/forgejo')

--- a/a2a_server/forgejo_webhooks.py
+++ b/a2a_server/forgejo_webhooks.py
@@ -22,9 +22,11 @@ from a2a_server.github_app.mention import is_fix_request, mentions_bot
 from a2a_server.github_app.routing import resolve_task_target
 from a2a_server.github_app.settings import TASK_PRIORITY
 from a2a_server.github_app.workspace import workspace_id
+from a2a_server.session_view import session_view_router
 
 
-forgejo_webhook_router = APIRouter(prefix='/v1/webhooks', tags=['forgejo'])
+forgejo_webhook_router = APIRouter(tags=['forgejo'])
+forgejo_webhook_router.include_router(session_view_router)
 
 
 def _setting(name: str, default: str = '') -> str:
@@ -369,7 +371,7 @@ async def _handle_status_event(
     }
 
 
-@forgejo_webhook_router.post('/forgejo')
+@forgejo_webhook_router.post('/v1/webhooks/forgejo')
 async def handle_forgejo_webhook(request: Request) -> dict[str, Any]:
     """Authenticate and process a Forgejo issue-comment delivery."""
     body = await request.body()

--- a/a2a_server/forgejo_webhooks.py
+++ b/a2a_server/forgejo_webhooks.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import importlib
 import os
 
 from typing import Any
@@ -19,6 +20,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from a2a_server.github_app.mention import is_fix_request, mentions_bot
 from a2a_server.github_app.routing import resolve_task_target
+from a2a_server.github_app.settings import TASK_PRIORITY
 from a2a_server.github_app.workspace import workspace_id
 
 
@@ -87,7 +89,14 @@ def _context(event: str, payload: dict[str, Any]) -> dict[str, Any] | None:
         'issue': issue,
         'repo_data': repo,
         'comment': comment,
+        'comment_id': int(comment.get('id') or 0),
         'html_url': str(issue.get('html_url') or ''),
+        'actor_login': str(
+            (payload.get('sender') or {}).get('login')
+            or (payload.get('sender') or {}).get('username')
+            or (comment.get('user') or {}).get('login')
+            or ''
+        ),
     }
 
 
@@ -153,9 +162,10 @@ async def _comment(base: str, repo: str, number: int, body: str) -> None:
 
 
 async def _active_task(repo: str, number: int) -> bool:
-    from a2a_server import database as db
-
+    db = importlib.import_module('a2a_server.database')
     pool = await db.get_pool()
+    if not pool:
+        return False
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """SELECT id FROM tasks WHERE status IN ('pending','queued','running','in_progress')
@@ -213,6 +223,7 @@ async def _dispatch(ctx: dict[str, Any], base: str) -> dict[str, Any]:
     )
     default_branch = str(repo_data.get('default_branch') or 'main')
     branch = default_branch
+    head_sha = ''
     if ctx['is_pr']:
         pr = await forgejo_json(
             'GET',
@@ -221,6 +232,7 @@ async def _dispatch(ctx: dict[str, Any], base: str) -> dict[str, Any]:
         )
         head = pr.get('head') or {}
         branch = str(head.get('ref') or default_branch)
+        head_sha = str(head.get('sha') or '')
     clone_url = str(
         repo_data.get('clone_url') or ctx['repo_data'].get('clone_url') or ''
     )
@@ -250,6 +262,12 @@ Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from 
         'default_branch': default_branch,
         'forgejo_api_url': base,
         'forgejo_issue_url': ctx['html_url'],
+        'trigger_actor_login': ctx.get('actor_login'),
+        'pr_head_sha': head_sha,
+        'forgejo_work_key': (
+            f'forgejo:{repo}:{ctx["number"]}:code:{head_sha or work_branch}:'
+            f'{ctx.get("comment_id") or 0}'
+        ),
         **routing,
     }
     metadata = {
@@ -260,11 +278,21 @@ Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from 
         'issue_number': ctx['number'],
         'git_url': clone_url,
         'git_branch': branch,
+        'pr_number': ctx['number'] if ctx['is_pr'] else None,
+        'pr_head_sha': head_sha,
+        'trigger_actor_login': ctx.get('actor_login'),
+        'forgejo_api_url': base,
+        'forgejo_work_key': (
+            f'forgejo:{repo}:{ctx["number"]}:clone:{head_sha or branch}:'
+            f'{ctx.get("comment_id") or 0}'
+        ),
         **routing,
         'post_clone_task': {
             'title': f'Work Forgejo {kind} #{ctx["number"]}',
             'prompt': prompt,
             'agent_type': 'build',
+            'priority': TASK_PRIORITY,
+            'model_ref': 'zai:glm-5.1',
             'metadata': followup,
         },
     }
@@ -273,6 +301,7 @@ Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from 
         title=f'Prepare Forgejo {kind} #{ctx["number"]}',
         prompt=f'Clone or refresh {repo} on branch {branch} for Forgejo automation.',
         agent_type='clone_repo',
+        priority=TASK_PRIORITY,
         metadata=metadata,
         task_timeout_seconds=604800,
     )

--- a/a2a_server/forgejo_webhooks.py
+++ b/a2a_server/forgejo_webhooks.py
@@ -1,0 +1,312 @@
+"""Native Forgejo webhook handling for @codetether issue and PR requests."""
+
+# Lazy service imports avoid the server/monitor import cycle; long SQL and worker
+# prompts remain readable as intact protocol strings.
+# ruff: noqa: E501, PLC0415, PLR2004
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+
+from typing import Any
+from urllib.parse import quote, urlparse
+
+import httpx
+
+from fastapi import APIRouter, HTTPException, Request
+
+from a2a_server.github_app.mention import is_fix_request, mentions_bot
+from a2a_server.github_app.routing import resolve_task_target
+from a2a_server.github_app.workspace import workspace_id
+
+
+forgejo_webhook_router = APIRouter(prefix='/v1/webhooks', tags=['forgejo'])
+
+
+def _setting(name: str, default: str = '') -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _event_name(request: Request) -> str:
+    return (
+        request.headers.get('X-Forgejo-Event')
+        or request.headers.get('X-Gitea-Event')
+        or ''
+    ).lower()
+
+
+def _signature(request: Request) -> str:
+    return (
+        request.headers.get('X-Forgejo-Signature')
+        or request.headers.get('X-Gitea-Signature')
+        or ''
+    )
+
+
+def verify_forgejo_signature(signature: str, body: bytes) -> None:
+    """Verify a Forgejo/Gitea webhook HMAC-SHA256 signature."""
+    secret = _setting('FORGEJO_WEBHOOK_SECRET')
+    if not secret:
+        raise HTTPException(503, 'Forgejo webhook secret is not configured')
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    supplied = signature.removeprefix('sha256=')
+    if not supplied or not hmac.compare_digest(supplied, expected):
+        raise HTTPException(401, 'Invalid Forgejo webhook signature')
+
+
+def _context(event: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+    if event != 'issue_comment' or payload.get('action') not in {
+        'created',
+        'edited',
+    }:
+        return None
+    comment = payload.get('comment') or {}
+    issue = payload.get('issue') or {}
+    repo = payload.get('repository') or {}
+    body = str(comment.get('body') or '')
+    if payload.get('action') == 'edited':
+        old = ((payload.get('changes') or {}).get('body') or {}).get(
+            'from'
+        ) or ''
+        if mentions_bot(str(old)):
+            return None
+    if not mentions_bot(body):
+        return None
+    full_name = str(repo.get('full_name') or repo.get('name') or '')
+    number = int(issue.get('number') or issue.get('index') or 0)
+    if not full_name or not number:
+        return None
+    pull = issue.get('pull_request') or {}
+    return {
+        'repo': full_name,
+        'number': number,
+        'is_pr': bool(pull),
+        'body': body,
+        'issue': issue,
+        'repo_data': repo,
+        'comment': comment,
+        'html_url': str(issue.get('html_url') or ''),
+    }
+
+
+def _is_self_authored(payload: dict[str, Any]) -> bool:
+    bot = _setting('FORGEJO_BOT_USERNAME', 'codetether').lower()
+    actors = [
+        (payload.get('comment') or {}).get('user') or {},
+        payload.get('sender') or {},
+    ]
+    return any(
+        str(actor.get('login') or actor.get('username') or '').lower() == bot
+        for actor in actors
+    )
+
+
+def _api_base(payload: dict[str, Any]) -> str:
+    configured = _setting('FORGEJO_API_URL')
+    if configured:
+        return configured.rstrip('/')
+    repo_url = str((payload.get('repository') or {}).get('html_url') or '')
+    parsed = urlparse(repo_url)
+    if parsed.scheme and parsed.netloc:
+        return f'{parsed.scheme}://{parsed.netloc}/api/v1'
+    raise HTTPException(503, 'Forgejo API URL is not configured')
+
+
+def _token() -> str:
+    token = _setting('FORGEJO_TOKEN')
+    if not token:
+        raise HTTPException(503, 'Forgejo bot token is not configured')
+    return token
+
+
+async def forgejo_json(
+    method: str, base: str, path: str, payload: dict | None = None
+) -> object:
+    """Call the configured Forgejo JSON API using the bot token."""
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.request(
+            method,
+            f'{base}{path}',
+            headers={
+                'Authorization': f'token {_token()}',
+                'Accept': 'application/json',
+            },
+            json=payload,
+        )
+    if response.status_code >= 400:
+        raise HTTPException(
+            502, f'Forgejo API {method} {path} failed: {response.text[:400]}'
+        )
+    return response.json() if response.content else {}
+
+
+async def _comment(base: str, repo: str, number: int, body: str) -> None:
+    owner, name = repo.split('/', 1)
+    await forgejo_json(
+        'POST',
+        base,
+        f'/repos/{quote(owner, safe="")}/{quote(name, safe="")}/issues/{number}/comments',
+        {'body': body},
+    )
+
+
+async def _active_task(repo: str, number: int) -> bool:
+    from a2a_server import database as db
+
+    row = await db.fetchrow(
+        """SELECT id FROM tasks WHERE status IN ('pending','queued','running','in_progress')
+           AND COALESCE(metadata, '{}'::jsonb)->>'source' = 'forgejo-webhook'
+           AND COALESCE(metadata, '{}'::jsonb)->>'repo' = $1
+           AND COALESCE(metadata, '{}'::jsonb)->>'issue_number' = $2 LIMIT 1""",
+        repo,
+        str(number),
+    )
+    return bool(row)
+
+
+async def _ensure_workspace(
+    ctx: dict[str, Any], clone_url: str, branch: str, token: str
+) -> str:
+    from a2a_server import database as db
+    from a2a_server.git_service import store_git_credential_record
+    from a2a_server.monitor_api import _redis_upsert_workspace_meta
+
+    wid = workspace_id(clone_url, branch)
+    workspace = {
+        'id': wid,
+        'name': ctx['repo'],
+        'path': f'/var/lib/codetether/repos/{wid}',
+        'description': f'Forgejo webhook workspace for {ctx["repo"]}',
+        'git_url': clone_url,
+        'git_branch': branch,
+        'status': 'active',
+        'agent_config': {
+            'source': 'forgejo-webhook',
+            'repo': {'full_name': ctx['repo']},
+        },
+    }
+    await db.db_upsert_workspace(workspace)
+    await _redis_upsert_workspace_meta(workspace)
+    if not await store_git_credential_record(
+        wid,
+        {
+            'token': token,
+            'token_type': 'forgejo_pat',
+            'git_url': clone_url,
+        },
+    ):
+        raise HTTPException(503, 'Could not store Forgejo git credentials')
+    return wid
+
+
+async def _dispatch(ctx: dict[str, Any], base: str) -> dict[str, Any]:
+    from a2a_server.persistent_worker_pool import create_and_dispatch_task
+
+    repo = ctx['repo']
+    owner, name = repo.split('/', 1)
+    repo_data = await forgejo_json(
+        'GET', base, f'/repos/{quote(owner, safe="")}/{quote(name, safe="")}'
+    )
+    default_branch = str(repo_data.get('default_branch') or 'main')
+    branch = default_branch
+    if ctx['is_pr']:
+        pr = await forgejo_json(
+            'GET',
+            base,
+            f'/repos/{quote(owner, safe="")}/{quote(name, safe="")}/pulls/{ctx["number"]}',
+        )
+        head = pr.get('head') or {}
+        branch = str(head.get('ref') or default_branch)
+    clone_url = str(
+        repo_data.get('clone_url') or ctx['repo_data'].get('clone_url') or ''
+    )
+    if not clone_url:
+        raise HTTPException(422, 'Forgejo repository clone URL is missing')
+    wid = await _ensure_workspace(ctx, clone_url, branch, _token())
+    work_branch = (
+        branch if ctx['is_pr'] else f'codetether/issue-{ctx["number"]}'
+    )
+    kind = 'pull request' if ctx['is_pr'] else 'issue'
+    prompt = f"""Handle Forgejo {kind} #{ctx['number']} in {repo}.
+
+Request:
+{ctx['body']}
+
+Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from `{default_branch}` for an issue; for a PR update its existing branch). Implement the requested changes, run focused validation, commit, and push. For an issue, open a Forgejo pull request against `{default_branch}`. Post concise progress and the final commit/PR URL back to Forgejo issue #{ctx['number']}. Do not use GitHub APIs."""
+    routing = await resolve_task_target()
+    followup = {
+        'workspace_id': wid,
+        'source': 'forgejo-webhook',
+        'workflow_stage': 'code',
+        'platform': 'forgejo',
+        'repo': repo,
+        'issue_number': ctx['number'],
+        'pr_number': ctx['number'] if ctx['is_pr'] else None,
+        'branch_name': work_branch,
+        'default_branch': default_branch,
+        'forgejo_api_url': base,
+        'forgejo_issue_url': ctx['html_url'],
+        **routing,
+    }
+    metadata = {
+        'workspace_id': wid,
+        'source': 'forgejo-webhook',
+        'platform': 'forgejo',
+        'repo': repo,
+        'issue_number': ctx['number'],
+        'git_url': clone_url,
+        'git_branch': branch,
+        **routing,
+        'post_clone_task': {
+            'title': f'Work Forgejo {kind} #{ctx["number"]}',
+            'prompt': prompt,
+            'agent_type': 'build',
+            'metadata': followup,
+        },
+    }
+    task_id = await create_and_dispatch_task(
+        workspace_id=wid,
+        title=f'Prepare Forgejo {kind} #{ctx["number"]}',
+        prompt=f'Clone or refresh {repo} on branch {branch} for Forgejo automation.',
+        agent_type='clone_repo',
+        metadata=metadata,
+        task_timeout_seconds=604800,
+    )
+    return {'accepted': True, 'workspace_id': wid, 'clone_task_id': task_id}
+
+
+@forgejo_webhook_router.post('/forgejo')
+async def handle_forgejo_webhook(request: Request) -> dict[str, Any]:
+    """Authenticate and process a Forgejo issue-comment delivery."""
+    body = await request.body()
+    verify_forgejo_signature(_signature(request), body)
+    payload = await request.json()
+    event = _event_name(request)
+    if event == 'ping':
+        return {'ok': True}
+    if _is_self_authored(payload):
+        return {'accepted': False, 'reason': 'self-authored-event'}
+    ctx = _context(event, payload)
+    if not ctx:
+        return {'accepted': False, 'reason': 'unsupported-or-no-mention'}
+    base = _api_base(payload)
+    if await _active_task(ctx['repo'], ctx['number']):
+        return {'accepted': False, 'reason': 'active-task-exists'}
+    if not is_fix_request(ctx['body']):
+        await _comment(
+            base,
+            ctx['repo'],
+            ctx['number'],
+            '## 🤖 CodeTether\n\nI saw the mention. Ask me explicitly to fix, implement, handle, update, or otherwise change the code, for example: `@codetether handle this issue`.',
+        )
+        return {'accepted': False, 'reason': 'non-fix mention'}
+    result = await _dispatch(ctx, base)
+    await _comment(
+        base,
+        ctx['repo'],
+        ctx['number'],
+        "## 🛠️ CodeTether Fix\n\nPicked this up. I'm preparing the Forgejo workspace and will report progress here.",
+    )
+    return result

--- a/a2a_server/forgejo_webhooks.py
+++ b/a2a_server/forgejo_webhooks.py
@@ -252,6 +252,29 @@ Request:
 
 Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from `{default_branch}` for an issue; for a PR update its existing branch). Implement the requested changes, run focused validation, commit, and push. For an issue, open a Forgejo pull request against `{default_branch}`. Post concise progress and the final commit/PR URL back to Forgejo issue #{ctx['number']}. Do not use GitHub APIs."""
     routing = await resolve_task_target()
+    from a2a_server.forgejo_agent_client import create_task as create_agent_task
+
+    operation = 'fix' if is_fix_request(ctx['body']) else 'review'
+    forgejo_agent_task = await create_agent_task(
+        repo=repo,
+        operation=operation,
+        prompt=prompt,
+        idempotency_key=(
+            f'forgejo-comment:{ctx.get("comment_id") or 0}:'
+            f'{head_sha or work_branch}:{operation}'
+        ),
+        issue_index=ctx['number'],
+        pull_request_index=ctx['number'] if ctx['is_pr'] else 0,
+        head_sha=head_sha,
+        metadata={
+            'source': 'forgejo-agent',
+            'trigger_actor_login': ctx.get('actor_login'),
+            'comment_id': ctx.get('comment_id'),
+        },
+        base_url=base,
+    )
+    forgejo_agent_task_id = int(forgejo_agent_task['id'])
+    forgejo_agent_task_url = str(forgejo_agent_task['html_url'])
     followup = {
         'workspace_id': wid,
         'source': 'forgejo-webhook',
@@ -264,6 +287,8 @@ Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from 
         'default_branch': default_branch,
         'forgejo_api_url': base,
         'forgejo_issue_url': ctx['html_url'],
+        'forgejo_agent_task_id': forgejo_agent_task_id,
+        'forgejo_agent_task_url': forgejo_agent_task_url,
         'trigger_actor_login': ctx.get('actor_login'),
         'pr_head_sha': head_sha,
         'forgejo_work_key': (
@@ -284,6 +309,8 @@ Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from 
         'pr_head_sha': head_sha,
         'trigger_actor_login': ctx.get('actor_login'),
         'forgejo_api_url': base,
+        'forgejo_agent_task_id': forgejo_agent_task_id,
+        'forgejo_agent_task_url': forgejo_agent_task_url,
         'forgejo_work_key': (
             f'forgejo:{repo}:{ctx["number"]}:clone:{head_sha or branch}:'
             f'{ctx.get("comment_id") or 0}'
@@ -307,7 +334,24 @@ Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from 
         metadata=metadata,
         task_timeout_seconds=604800,
     )
-    return {'accepted': True, 'workspace_id': wid, 'clone_task_id': task_id}
+    from a2a_server.forgejo_agent_client import update_task as update_agent_task
+
+    await update_agent_task(
+        repo=repo,
+        task_id=forgejo_agent_task_id,
+        base_url=base,
+        status='accepted',
+        external_task_id=str(task_id),
+        head_sha=head_sha,
+        branch=work_branch,
+    )
+    return {
+        'accepted': True,
+        'workspace_id': wid,
+        'clone_task_id': task_id,
+        'forgejo_agent_task_id': forgejo_agent_task_id,
+        'forgejo_agent_task_url': forgejo_agent_task_url,
+    }
 
 
 async def _handle_status_event(

--- a/a2a_server/forgejo_webhooks.py
+++ b/a2a_server/forgejo_webhooks.py
@@ -155,14 +155,16 @@ async def _comment(base: str, repo: str, number: int, body: str) -> None:
 async def _active_task(repo: str, number: int) -> bool:
     from a2a_server import database as db
 
-    row = await db.fetchrow(
-        """SELECT id FROM tasks WHERE status IN ('pending','queued','running','in_progress')
-           AND COALESCE(metadata, '{}'::jsonb)->>'source' = 'forgejo-webhook'
-           AND COALESCE(metadata, '{}'::jsonb)->>'repo' = $1
-           AND COALESCE(metadata, '{}'::jsonb)->>'issue_number' = $2 LIMIT 1""",
-        repo,
-        str(number),
-    )
+    pool = await db.get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """SELECT id FROM tasks WHERE status IN ('pending','queued','running','in_progress')
+               AND COALESCE(metadata, '{}'::jsonb)->>'source' = 'forgejo-webhook'
+               AND COALESCE(metadata, '{}'::jsonb)->>'repo' = $1
+               AND COALESCE(metadata, '{}'::jsonb)->>'issue_number' = $2 LIMIT 1""",
+            repo,
+            str(number),
+        )
     return bool(row)
 
 

--- a/a2a_server/forgejo_webhooks.py
+++ b/a2a_server/forgejo_webhooks.py
@@ -308,6 +308,67 @@ Use the checked-out Forgejo repository. Work on `{work_branch}` (create it from 
     return {'accepted': True, 'workspace_id': wid, 'clone_task_id': task_id}
 
 
+async def _handle_status_event(
+    payload: dict[str, Any], base: str
+) -> dict[str, Any]:
+    """Create one remediation task for a failed status on an open PR head."""
+    from a2a_server.forgejo_automation import (
+        create_status_remediation_task,
+        is_failed_status,
+        is_self_status,
+    )
+
+    repo_data = payload.get('repository') or {}
+    repo = str(repo_data.get('full_name') or '')
+    sha = str(payload.get('sha') or '')
+    sender = payload.get('sender') or {}
+    status = {
+        'id': payload.get('id'),
+        'status': payload.get('state') or payload.get('status'),
+        'context': payload.get('context'),
+        'description': payload.get('description'),
+        'target_url': payload.get('target_url'),
+        'creator': sender,
+    }
+    if not (repo and sha) or '/' not in repo:
+        return {'accepted': False, 'reason': 'invalid-status-payload'}
+    if not is_failed_status(status) or is_self_status(status):
+        return {'accepted': False, 'reason': 'non-failed-or-self-status'}
+
+    owner, name = repo.split('/', 1)
+    repo_path = f'/repos/{quote(owner, safe="")}/{quote(name, safe="")}'
+    pr = None
+    for page in range(1, 21):
+        pulls = await forgejo_json(
+            'GET', base, f'{repo_path}/pulls?state=open&limit=50&page={page}'
+        )
+        pr = next(
+            (
+                candidate
+                for candidate in pulls or []
+                if str(((candidate or {}).get('head') or {}).get('sha') or '')
+                == sha
+            ),
+            None,
+        )
+        if pr or len(pulls or []) < 50:
+            break
+    if not pr:
+        return {'accepted': False, 'reason': 'no-open-pr-for-status-sha'}
+
+    task_id = await create_status_remediation_task(
+        base=base,
+        repo=repo,
+        pr=pr,
+        status=status,
+    )
+    return {
+        'accepted': bool(task_id),
+        'reason': 'queued' if task_id else 'duplicate-or-ignored',
+        'task_id': task_id,
+    }
+
+
 @forgejo_webhook_router.post('/forgejo')
 async def handle_forgejo_webhook(request: Request) -> dict[str, Any]:
     """Authenticate and process a Forgejo issue-comment delivery."""
@@ -317,6 +378,8 @@ async def handle_forgejo_webhook(request: Request) -> dict[str, Any]:
     event = _event_name(request)
     if event == 'ping':
         return {'ok': True}
+    if event == 'status':
+        return await _handle_status_event(payload, _api_base(payload))
     if _is_self_authored(payload):
         return {'accepted': False, 'reason': 'self-authored-event'}
     ctx = _context(event, payload)

--- a/a2a_server/git_service.py
+++ b/a2a_server/git_service.py
@@ -8,7 +8,6 @@ and auto-clone them on workers. Credentials are stored in Vault.
 import asyncio
 import logging
 import os
-import re
 import shutil
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
@@ -23,15 +22,28 @@ GIT_CLONE_BASE = os.environ.get('GIT_CLONE_BASE', '/var/lib/codetether/repos')
 # Maximum repo size (in bytes) — default 2GB
 MAX_REPO_SIZE = int(os.environ.get('GIT_MAX_REPO_SIZE', str(2 * 1024 * 1024 * 1024)))
 
-# Allowed Git URL patterns (HTTPS only — no arbitrary protocols)
-_ALLOWED_URL_PATTERN = re.compile(
-    r'^https://(github\.com|gitlab\.com|bitbucket\.org|dev\.azure\.com)/[^\s]+\.git$'
-)
+# Allowed Git hosts (HTTPS only — no arbitrary protocols or embedded credentials).
+_PUBLIC_GIT_HOSTS = {'github.com', 'gitlab.com', 'bitbucket.org', 'dev.azure.com'}
 
 
 def validate_git_url(url: str) -> bool:
-    """Validate that a Git URL is an allowed HTTPS repo URL."""
-    return bool(_ALLOWED_URL_PATTERN.match(url))
+    """Validate that a Git URL uses HTTPS and an explicitly allowed host."""
+    parsed = urlparse(url)
+    configured_forgejo_host = urlparse(
+        os.environ.get('FORGEJO_API_URL', '')
+    ).hostname
+    allowed_hosts = _PUBLIC_GIT_HOSTS | (
+        {configured_forgejo_host} if configured_forgejo_host else set()
+    )
+    return (
+        parsed.scheme == 'https'
+        and parsed.hostname in allowed_hosts
+        and parsed.path.endswith('.git')
+        and not parsed.username
+        and not parsed.password
+        and not parsed.query
+        and not parsed.fragment
+    )
 
 
 async def store_git_credentials(

--- a/a2a_server/github_app/active_work.py
+++ b/a2a_server/github_app/active_work.py
@@ -70,6 +70,7 @@ def _context_for_item(
         pr_number=number if is_pr else None,
         comment_id=int(item.get('id') or number),
         comment_body=body,
+        actor_login=str((item.get('user') or {}).get('login') or ''),
     )
 
 

--- a/a2a_server/github_app/build_task.py
+++ b/a2a_server/github_app/build_task.py
@@ -3,7 +3,7 @@
 from .context import MentionContext
 from .prompt import fix_prompt
 from .routing import resolve_task_target
-from .settings import MODEL_REF
+from .settings import MODEL_REF, TASK_PRIORITY
 
 DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
@@ -22,6 +22,7 @@ async def create_build_task(
         'workspace_id': wid,
         'source': 'github-app',
         'repo': context.repo_full_name,
+        'trigger_actor_login': context.actor_login,
         'pr_number': context.pr_number,
         'pr_head': pr['head']['ref'],
         'pr_base': pr['base']['ref'],
@@ -36,6 +37,7 @@ async def create_build_task(
         title=f'Apply PR fix #{context.pr_number}',
         prompt=fix_prompt(context, pr),
         agent_type='build',
+        priority=TASK_PRIORITY,
         model_ref=MODEL_REF,
         metadata=metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,

--- a/a2a_server/github_app/context.py
+++ b/a2a_server/github_app/context.py
@@ -16,3 +16,4 @@ class MentionContext:
     comment_body: str
     comment_path: str = ''
     comment_diff_hunk: str = ''
+    actor_login: str = ''

--- a/a2a_server/github_app/issue_build_task.py
+++ b/a2a_server/github_app/issue_build_task.py
@@ -3,7 +3,7 @@
 from .context import MentionContext
 from .issue_prompt import issue_fix_prompt
 from .routing import resolve_task_target
-from .settings import MODEL_REF
+from .settings import MODEL_REF, TASK_PRIORITY
 
 DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
@@ -28,6 +28,7 @@ async def create_issue_build_task(
         'source': 'github-app',
         'repo': context.repo_full_name,
         'issue_number': context.issue_number,
+        'trigger_actor_login': context.actor_login,
         'branch_name': branch,
         'default_branch': repo['default_branch'],
         'github_issue_url': f'https://github.com/{context.repo_full_name}/issues/{context.issue_number}',
@@ -39,6 +40,7 @@ async def create_issue_build_task(
         title=f'Work issue #{context.issue_number}',
         prompt=issue_fix_prompt(context, issue, repo, branch),
         agent_type='build',
+        priority=TASK_PRIORITY,
         model_ref=MODEL_REF,
         metadata=metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,

--- a/a2a_server/github_app/issue_clone_task.py
+++ b/a2a_server/github_app/issue_clone_task.py
@@ -3,7 +3,7 @@
 from .context import MentionContext
 from .issue_prompt import issue_fix_prompt
 from .routing import resolve_task_target
-from .settings import MODEL_REF
+from .settings import MODEL_REF, TASK_PRIORITY
 
 DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
@@ -34,6 +34,7 @@ async def create_issue_clone_task(
     followup_metadata = {
         'workspace_id': wid,
         'source': 'github-app',
+        'trigger_actor_login': context.actor_login,
         'workflow_stage': 'code',
         'repo': context.repo_full_name,
         'issue_number': context.issue_number,
@@ -67,6 +68,7 @@ async def create_issue_clone_task(
         'git_branch': base_branch,
         'source': 'github-app',
         'repo': context.repo_full_name,
+        'trigger_actor_login': context.actor_login,
         'issue_number': context.issue_number,
         'github_check_head_sha': github_check_head_sha,
         'github_issue_url': github_issue_url,
@@ -84,6 +86,7 @@ async def create_issue_clone_task(
         title=f'Prepare issue workspace #{context.issue_number}',
         prompt=f'Clone or refresh {context.repo_full_name} on branch {base_branch} for issue automation.',
         agent_type='clone_repo',
+        priority=TASK_PRIORITY,
         model_ref=MODEL_REF,
         metadata=metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,

--- a/a2a_server/github_app/issue_final_comment.py
+++ b/a2a_server/github_app/issue_final_comment.py
@@ -6,10 +6,10 @@ import os
 from urllib.parse import quote
 
 from a2a_server import database as db
-from a2a_server.github_app.auth import github_json
+from a2a_server.github_app import auth as github_app_auth
+from a2a_server.github_app import issue_review_task
 from a2a_server.github_app.issue_pr import open_issue_pr
 from a2a_server.github_app.issue_review_task import (
-    create_issue_review_task,
     issue_pr_provenance,
     provenance_footer,
 )
@@ -34,9 +34,7 @@ def _github_repo_migrated_to_forgejo(repo: str) -> bool:
         'rileyseaburg/spotlessbinco,spotlessbinco/spotlessbinco',
     )
     migrated = {
-        item.strip().lower()
-        for item in configured.split(',')
-        if item.strip()
+        item.strip().lower() for item in configured.split(',') if item.strip()
     }
     return str(repo or '').strip().lower() in migrated
 
@@ -60,7 +58,7 @@ async def _verify_branch_and_commits(
     """
     encoded_branch = quote(branch, safe='')
     try:
-        ref = await github_json(
+        ref = await github_app_auth.github_json(
             'GET',
             f'/repos/{repo}/git/ref/heads/{encoded_branch}',
             token,
@@ -114,8 +112,8 @@ async def normalize_issue_task_terminal_status(task: dict) -> dict:
         error = (
             'Branch verification failed after worker completion. '
             f'Expected branch `{branch}` for issue #{issue_number}; '
-            f"GET /repos/{repo}/git/ref/heads/{quote(branch, safe='')} "
-            f"failed: {branch_info.get('error', 'unknown reason')}. "
+            f'GET /repos/{repo}/git/ref/heads/{quote(branch, safe="")} '
+            f'failed: {branch_info.get("error", "unknown reason")}. '
             'Recovery: retry or investigate worker commit/push/auth before '
             'marking the check successful.'
         )
@@ -185,17 +183,23 @@ async def notify_issue_final_comment(task: dict) -> None:
             review_task_id = None
             review_status = ''
             try:
-                review_task_id = await create_issue_review_task(
-                    workspace_id=str(metadata.get('workspace_id') or ''),
-                    repo=repo,
-                    issue_number=issue_number,
-                    branch=branch,
-                    pr=pr,
-                    github_issue_url=metadata.get('github_issue_url'),
-                    github_installation_id=metadata.get(
-                        'github_installation_id',
-                    ),
-                    parent_task_id=str(task_id),
+                review_task_id = (
+                    await issue_review_task.create_issue_review_task(
+                        workspace_id=str(metadata.get('workspace_id') or ''),
+                        repo=repo,
+                        issue_number=issue_number,
+                        branch=branch,
+                        pr=pr,
+                        github_issue_url=metadata.get('github_issue_url'),
+                        github_installation_id=metadata.get(
+                            'github_installation_id',
+                        ),
+                        token=token,
+                        parent_task_id=str(task_id),
+                        trigger_actor_login=str(
+                            metadata.get('trigger_actor_login') or ''
+                        ),
+                    )
                 )
                 if review_task_id:
                     review_status = (
@@ -235,7 +239,7 @@ async def notify_issue_final_comment(task: dict) -> None:
 
             message = (
                 '## 🛠️ CodeTether Fix\n\n'
-                f"Opened PR #{pr['number']}: {pr['html_url']}"
+                f'Opened PR #{pr["number"]}: {pr["html_url"]}'
             )
             if body:
                 message += f'\n\n{body}'

--- a/a2a_server/github_app/issue_prepare_completion.py
+++ b/a2a_server/github_app/issue_prepare_completion.py
@@ -8,14 +8,16 @@ from .pr_prepare_completion import (
     _release_followup_lock,
     _release_pr_followup_claim,
 )
-from .settings import MODEL_REF
+from .settings import MODEL_REF, TASK_PRIORITY
 from .task_context import issue_task_context
 from .watch import post_issue_comment
 
 DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
 
-async def handle_issue_prepare_completion(task: dict, worker_id: str | None = None) -> None:
+async def handle_issue_prepare_completion(
+    task: dict, worker_id: str | None = None
+) -> None:
     """Create the issue build task or post a prepare failure."""
     from ..persistent_worker_pool import create_and_dispatch_task
 
@@ -25,19 +27,38 @@ async def handle_issue_prepare_completion(task: dict, worker_id: str | None = No
         return
     repo, issue_number, _, token = context
     if str(task.get('status')) != 'completed':
-        body = str(task.get('error') or task.get('result') or f"Task `{task.get('id')}` ended with status `{task.get('status')}`.").strip()
-        await post_issue_comment(repo, issue_number, token, f"## 🛠️ CodeTether Fix\n\nI couldn't prepare the issue workspace.\n\n{body}")
+        body = str(
+            task.get('error')
+            or task.get('result')
+            or f'Task `{task.get("id")}` ended with status `{task.get("status")}`.'
+        ).strip()
+        await post_issue_comment(
+            repo,
+            issue_number,
+            token,
+            f"## 🛠️ CodeTether Fix\n\nI couldn't prepare the issue workspace.\n\n{body}",
+        )
         return
     followup = metadata.get('post_clone_task') or {}
     workspace_id = str(metadata.get('workspace_id') or '').strip()
     prompt = str(followup.get('prompt') or '').strip()
     if not workspace_id or not prompt:
-        await post_issue_comment(repo, issue_number, token, "## 🛠️ CodeTether Fix\n\nI prepared the workspace, but the follow-up task metadata was incomplete.")
+        await post_issue_comment(
+            repo,
+            issue_number,
+            token,
+            '## 🛠️ CodeTether Fix\n\nI prepared the workspace, but the follow-up task metadata was incomplete.',
+        )
         return
     followup_metadata = dict(followup.get('metadata') or {})
 
     # Propagate GitHub metadata for progress reporting and Checks API updates.
-    for key in ('github_issue_url', 'github_installation_id', 'github_check_head_sha', 'github_check_run_id'):
+    for key in (
+        'github_issue_url',
+        'github_installation_id',
+        'github_check_head_sha',
+        'github_check_run_id',
+    ):
         if key in metadata and key not in followup_metadata:
             followup_metadata[key] = metadata[key]
 
@@ -45,7 +66,9 @@ async def handle_issue_prepare_completion(task: dict, worker_id: str | None = No
     if not await _claim_pr_followup_creation(source_task_id):
         return
 
-    github_issue_url = followup_metadata.get('github_issue_url') or metadata.get('github_issue_url')
+    github_issue_url = followup_metadata.get(
+        'github_issue_url'
+    ) or metadata.get('github_issue_url')
     lock = await _acquire_followup_lock(repo, issue_number, 'issue')
     try:
         existing_task_id = await _active_followup_task_id(
@@ -62,6 +85,7 @@ async def handle_issue_prepare_completion(task: dict, worker_id: str | None = No
             title=str(followup.get('title') or f'Work issue #{issue_number}'),
             prompt=prompt,
             agent_type=str(followup.get('agent_type') or 'build'),
+            priority=TASK_PRIORITY,
             model_ref=MODEL_REF,
             metadata=followup_metadata,
             task_timeout_seconds=DEFAULT_TASK_TIMEOUT,

--- a/a2a_server/github_app/issue_review_task.py
+++ b/a2a_server/github_app/issue_review_task.py
@@ -10,7 +10,12 @@ import uuid
 from typing import Any
 
 from ..provenance import verify_provenance
-from .settings import AUTO_MERGE_ENABLED, MERGE_METHOD, MODEL_REF
+from .settings import (
+    AUTO_MERGE_ENABLED,
+    MERGE_METHOD,
+    MODEL_REF,
+    TASK_PRIORITY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -629,6 +634,7 @@ async def create_fix_followup_task(
         title=f'Apply PR fix #{pr_number}',
         prompt=fix_prompt,
         agent_type='build',
+        priority=TASK_PRIORITY,
         model_ref=MODEL_REF,
         metadata=fix_metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
@@ -1032,11 +1038,14 @@ async def create_issue_review_task(
     pr: dict[str, Any],
     github_issue_url: str | None,
     github_installation_id: int | str | None,
+    token: str = '',
     parent_task_id: str | None = None,
     target_worker_id: str | None = None,
+    trigger_actor_login: str = '',
 ) -> str | None:
     """Queue a reviewer task for an issue PR if provenance policy allows it."""
     from ..persistent_worker_pool import create_and_dispatch_task
+    from .review_request import request_human_review
 
     provenance = issue_pr_provenance(
         repo=repo,
@@ -1056,6 +1065,7 @@ async def create_issue_review_task(
 
     metadata = {
         'workspace_id': workspace_id,
+        'trigger_actor_login': trigger_actor_login,
         'source': 'github-app',
         'workflow_stage': 'review',
         'repo': repo,
@@ -1080,11 +1090,16 @@ async def create_issue_review_task(
         title=f'Review issue PR #{pr.get("number")}',
         prompt=review_prompt(repo, issue_number, branch, pr, provenance),
         agent_type='review',
+        priority=TASK_PRIORITY,
         model_ref=MODEL_REF,
         metadata=metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,
         github_issue_url=github_issue_url,
     )
+    if token:
+        await request_human_review(
+            repo, int(pr.get('number') or 0), token, trigger_actor_login
+        )
     await record_automation_decision(
         provenance=provenance, decision=decision, task_id=task_id
     )
@@ -1331,6 +1346,7 @@ async def create_issue_merge_task(
         title=f'Merge issue PR #{pr_number}',
         prompt=merge_prompt(repo, issue_number, branch, pr, provenance),
         agent_type='merge',
+        priority=TASK_PRIORITY,
         model_ref=MODEL_REF,
         metadata=merge_metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,

--- a/a2a_server/github_app/payload.py
+++ b/a2a_server/github_app/payload.py
@@ -16,8 +16,12 @@ def _actor_for_event(
     if event_name == 'pull_request_review':
         return payload.get('review', {}).get('user', {}) or {}
     if event_name == 'issues':
+        if str(payload.get('action') or '').lower() == 'edited':
+            return payload.get('sender', {}) or {}
         return payload.get('issue', {}).get('user', {}) or {}
     if event_name == 'pull_request':
+        if str(payload.get('action') or '').lower() == 'edited':
+            return payload.get('sender', {}) or {}
         return payload.get('pull_request', {}).get('user', {}) or {}
     return payload.get('sender', {}) or {}
 
@@ -115,6 +119,7 @@ def extract_context(
     body = _body_for_event(event_name, payload)
     installation_id = payload.get('installation', {}).get('id')
     repo_full_name = payload.get('repository', {}).get('full_name', '')
+    actor_login = str(_actor_for_event(event_name, payload).get('login') or '')
     comment_id = payload.get('comment', {}).get('id')
     issue_number = None
     pr_number = None
@@ -171,4 +176,5 @@ def extract_context(
         comment_body=body,
         comment_path=comment_path,
         comment_diff_hunk=comment_diff_hunk,
+        actor_login=actor_login,
     )

--- a/a2a_server/github_app/pr_final_comment.py
+++ b/a2a_server/github_app/pr_final_comment.py
@@ -13,7 +13,9 @@ async def normalize_pr_fix_terminal_status(task: dict) -> dict:
     if str(task.get('status')) != 'completed':
         return task
     metadata = task.get('metadata') or {}
-    if metadata.get('workflow_stage') != 'fix' and not str(task.get('title') or '').startswith('Apply PR fix #'):
+    if metadata.get('workflow_stage') != 'fix' and not str(
+        task.get('title') or ''
+    ).startswith('Apply PR fix #'):
         return task
     context = await github_app_task_context(task)
     if context is None:
@@ -25,17 +27,27 @@ async def normalize_pr_fix_terminal_status(task: dict) -> dict:
 
         pr = await github_json('GET', f'/repos/{repo}/pulls/{pr_number}', token)
         current_sha = str((pr.get('head') or {}).get('sha') or '')
-        original_sha = str(metadata.get('pr_head_sha') or metadata.get('github_check_head_sha') or '')
+        original_sha = str(
+            metadata.get('pr_head_sha')
+            or metadata.get('github_check_head_sha')
+            or ''
+        )
         if original_sha and current_sha == original_sha:
             error = (
                 'GitHub fix task completed without moving '
                 f'PR #{pr_number} from head `{original_sha}`.'
             )
-            await db.db_update_task_status(str(task.get('id')), 'failed', error=error)
+            await db.db_update_task_status(
+                str(task.get('id')), 'failed', error=error
+            )
             refreshed = await db.db_get_task(str(task.get('id')))
             return refreshed or {**task, 'status': 'failed', 'error': error}
     except Exception as exc:
-        logger.warning('Could not verify PR fix task %s branch delta: %s', task.get('id'), exc)
+        logger.warning(
+            'Could not verify PR fix task %s branch delta: %s',
+            task.get('id'),
+            exc,
+        )
     return task
 
 
@@ -49,36 +61,52 @@ async def notify_pr_final_comment(task: dict) -> None:
     body = str(
         task.get('result')
         or task.get('error')
-        or f"Task `{task.get('id')}` ended with status `{task.get('status')}`."
+        or f'Task `{task.get("id")}` ended with status `{task.get("status")}`.'
     ).strip()
     if str(task.get('status')) == 'completed':
-        message = "## 🛠️ CodeTether Fix\n\nPushed changes to this PR branch."
+        message = '## 🛠️ CodeTether Fix\n\nPushed changes to this PR branch.'
         if body:
-            message += f"\n\n{body}"
+            message += f'\n\n{body}'
         metadata = task.get('metadata') or {}
         try:
             from .auth import github_json
-            from .issue_review_task import create_issue_review_task, issue_pr_provenance, provenance_footer
+            from .issue_review_task import (
+                create_issue_review_task,
+                issue_pr_provenance,
+                provenance_footer,
+            )
 
-            pr = await github_json('GET', f'/repos/{repo}/pulls/{pr_number}', token)
+            pr = await github_json(
+                'GET', f'/repos/{repo}/pulls/{pr_number}', token
+            )
+            branch_name = str(
+                (pr.get('head') or {}).get('ref')
+                or metadata.get('pr_head')
+                or ''
+            )
             review_task_id = await create_issue_review_task(
                 workspace_id=str(metadata.get('workspace_id') or ''),
                 repo=repo,
                 issue_number=int(metadata.get('issue_number') or pr_number),
-                branch=str((pr.get('head') or {}).get('ref') or metadata.get('pr_head') or branch),
+                branch=branch_name,
                 pr=pr,
-                github_issue_url=metadata.get('github_issue_url') or f'https://github.com/{repo}/pull/{pr_number}',
+                github_issue_url=metadata.get('github_issue_url')
+                or f'https://github.com/{repo}/pull/{pr_number}',
                 github_installation_id=metadata.get('github_installation_id'),
+                token=token,
                 parent_task_id=str(task.get('id') or ''),
+                trigger_actor_login=str(
+                    metadata.get('trigger_actor_login') or ''
+                ),
             )
             if review_task_id:
-                message += f"\n\nQueued CodeTether reviewer task `{review_task_id}`. If review passes and GitHub feedback is resolved, CodeTether will auto-merge the PR."
+                message += f'\n\nQueued CodeTether reviewer task `{review_task_id}`. If review passes and GitHub feedback is resolved, CodeTether will auto-merge the PR.'
             else:
-                message += "\n\nCodeTether review automation was not queued because the local provenance/policy gate denied it."
+                message += '\n\nCodeTether review automation was not queued because the local provenance/policy gate denied it.'
             provenance = issue_pr_provenance(
                 repo=repo,
                 issue_number=int(metadata.get('issue_number') or pr_number),
-                branch=str((pr.get('head') or {}).get('ref') or metadata.get('pr_head') or branch),
+                branch=branch_name,
                 pr=pr,
                 installation_id=metadata.get('github_installation_id'),
                 action='github:review_pr',
@@ -86,8 +114,16 @@ async def notify_pr_final_comment(task: dict) -> None:
             )
             message += provenance_footer(provenance, action='github:review_pr')
         except Exception as exc:
-            logger.exception('Failed to enqueue PR review for task %s: %s', task.get('id'), exc)
-            message += f"\n\n⚠️ CodeTether could not queue the reviewer task: `{exc}`"
+            logger.exception(
+                'Failed to enqueue PR review for task %s: %s',
+                task.get('id'),
+                exc,
+            )
+            message += (
+                f'\n\n⚠️ CodeTether could not queue the reviewer task: `{exc}`'
+            )
         await post_issue_comment(repo, pr_number, token, message)
         return
-    await post_issue_comment(repo, pr_number, token, f"## 🛠️ CodeTether Fix\n\n{body}")
+    await post_issue_comment(
+        repo, pr_number, token, f'## 🛠️ CodeTether Fix\n\n{body}'
+    )

--- a/a2a_server/github_app/pr_prepare_completion.py
+++ b/a2a_server/github_app/pr_prepare_completion.py
@@ -4,7 +4,7 @@ import json
 import logging
 from datetime import datetime
 
-from .settings import MODEL_REF
+from .settings import MODEL_REF, TASK_PRIORITY
 from .task_context import github_app_task_context
 from .watch import post_issue_comment
 
@@ -51,7 +51,9 @@ async def _claim_pr_followup_creation(task_id: str | None) -> bool:
     return row is not None
 
 
-async def _record_pr_followup_task(task_id: str | None, followup_task_id: str) -> None:
+async def _record_pr_followup_task(
+    task_id: str | None, followup_task_id: str
+) -> None:
     if not task_id:
         return
 
@@ -140,7 +142,9 @@ async def _active_followup_task_id(
     return str(row['id']) if row else None
 
 
-async def _release_pr_followup_claim(task_id: str | None, error: Exception) -> None:
+async def _release_pr_followup_claim(
+    task_id: str | None, error: Exception
+) -> None:
     if not task_id:
         return
 
@@ -171,7 +175,9 @@ async def _release_pr_followup_claim(task_id: str | None, error: Exception) -> N
         )
 
 
-async def handle_pr_prepare_completion(task: dict, worker_id: str | None = None) -> None:
+async def handle_pr_prepare_completion(
+    task: dict, worker_id: str | None = None
+) -> None:
     """Create the PR branch edit task or post a prepare failure."""
     from ..persistent_worker_pool import create_and_dispatch_task
 
@@ -184,7 +190,7 @@ async def handle_pr_prepare_completion(task: dict, worker_id: str | None = None)
         body = str(
             task.get('error')
             or task.get('result')
-            or f"Task `{task.get('id')}` ended with status `{task.get('status')}`."
+            or f'Task `{task.get("id")}` ended with status `{task.get("status")}`.'
         ).strip()
         await post_issue_comment(
             repo,
@@ -202,14 +208,19 @@ async def handle_pr_prepare_completion(task: dict, worker_id: str | None = None)
             repo,
             pr_number,
             token,
-            "## 🛠️ CodeTether Fix\n\nI prepared the PR workspace, but the follow-up task metadata was incomplete.",
+            '## 🛠️ CodeTether Fix\n\nI prepared the PR workspace, but the follow-up task metadata was incomplete.',
         )
         return
 
     followup_metadata = dict(followup.get('metadata') or {})
 
     # Propagate GitHub metadata for progress reporting and Checks API updates.
-    for key in ('github_issue_url', 'github_installation_id', 'github_check_head_sha', 'github_check_run_id'):
+    for key in (
+        'github_issue_url',
+        'github_installation_id',
+        'github_check_head_sha',
+        'github_check_run_id',
+    ):
         if key in metadata and key not in followup_metadata:
             followup_metadata[key] = metadata[key]
 
@@ -221,9 +232,9 @@ async def handle_pr_prepare_completion(task: dict, worker_id: str | None = None)
         )
         return
 
-    github_issue_url = followup_metadata.get('github_issue_url') or metadata.get(
+    github_issue_url = followup_metadata.get(
         'github_issue_url'
-    )
+    ) or metadata.get('github_issue_url')
     lock = await _acquire_followup_lock(repo, pr_number, 'pr')
     try:
         existing_task_id = await _active_followup_task_id(repo, pr_number, 'pr')
@@ -242,6 +253,7 @@ async def handle_pr_prepare_completion(task: dict, worker_id: str | None = None)
             title=str(followup.get('title') or f'Apply PR fix #{pr_number}'),
             prompt=prompt,
             agent_type=str(followup.get('agent_type') or 'build'),
+            priority=TASK_PRIORITY,
             model_ref=MODEL_REF,
             metadata=followup_metadata,
             task_timeout_seconds=DEFAULT_TASK_TIMEOUT,

--- a/a2a_server/github_app/review_publish.py
+++ b/a2a_server/github_app/review_publish.py
@@ -1,0 +1,119 @@
+"""Publish CodeTether reviewer-task results as GitHub pull request reviews."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from a2a_server.github_app.auth import github_json
+from a2a_server.github_app.issue_review_task import reviewer_verdict
+
+
+logger = logging.getLogger(__name__)
+
+_REVIEW_BODY_LIMIT = 60_000
+
+
+def review_marker(task_id: str) -> str:
+    """Return the stable marker used to suppress duplicate review publication."""
+    return f'<!-- codetether-review-task:{task_id} -->'
+
+
+def review_event(review_task: dict[str, Any]) -> str:
+    """Map a CodeTether reviewer verdict to a GitHub review event."""
+    verdict = reviewer_verdict(review_task)
+    if verdict == 'APPROVED':
+        return 'APPROVE'
+    if verdict in {'CHANGES_REQUESTED', 'BLOCKED'}:
+        return 'REQUEST_CHANGES'
+    return 'COMMENT'
+
+
+def review_body(review_task: dict[str, Any]) -> str:
+    """Build the first-class GitHub review body with idempotency evidence."""
+    task_id = str(review_task.get('id') or '').strip()
+    verdict = reviewer_verdict(review_task) or 'COMMENT'
+    result = str(
+        review_task.get('result')
+        or review_task.get('error')
+        or 'CodeTether reviewer task completed without a textual summary.'
+    ).strip()
+    marker = review_marker(task_id)
+    prefix = f'## CodeTether Review\n\n**Verdict:** `{verdict}`\n\n'
+    available = max(0, _REVIEW_BODY_LIMIT - len(prefix) - len(marker) - 2)
+    return f'{prefix}{result[:available]}\n\n{marker}'
+
+
+async def publish_github_review(
+    review_task: dict[str, Any],
+    token: str,
+) -> dict[str, Any]:
+    """Publish one idempotent GitHub PR review for a reviewer task.
+
+    GitHub does not allow an App to approve or request changes on a PR authored
+    by that same App. When the semantic event is rejected, publish the same
+    verdict and evidence as a first-class ``COMMENT`` review instead. Existing
+    reviews carrying this task's hidden marker are returned without reposting.
+    """
+    metadata = review_task.get('metadata') or {}
+    task_id = str(review_task.get('id') or '').strip()
+    repo = str(metadata.get('repo') or '').strip()
+    pr_number = int(metadata.get('pr_number') or 0)
+    head_sha = str(
+        metadata.get('pr_head_sha')
+        or metadata.get('github_check_head_sha')
+        or ''
+    ).strip()
+    if not (task_id and repo and pr_number and token):
+        raise ValueError('review task is missing GitHub publication context')
+
+    marker = review_marker(task_id)
+    reviews = await github_json(
+        'GET',
+        f'/repos/{repo}/pulls/{pr_number}/reviews?per_page=100',
+        token,
+    )
+    for review in reviews or []:
+        if marker in str((review or {}).get('body') or ''):
+            return {
+                'published': True,
+                'duplicate': True,
+                'event': str((review or {}).get('state') or 'COMMENT'),
+                'review_id': (review or {}).get('id'),
+            }
+
+    event = review_event(review_task)
+    payload: dict[str, Any] = {
+        'body': review_body(review_task),
+        'event': event,
+    }
+    if head_sha:
+        payload['commit_id'] = head_sha
+
+    path = f'/repos/{repo}/pulls/{pr_number}/reviews'
+    try:
+        published = await github_json('POST', path, token, payload)
+        return {
+            'published': True,
+            'duplicate': False,
+            'event': event,
+            'review_id': (published or {}).get('id'),
+        }
+    except Exception as exc:
+        if event == 'COMMENT':
+            raise
+        logger.info(
+            'GitHub rejected %s review for task %s; retrying as COMMENT: %s',
+            event,
+            task_id,
+            exc,
+        )
+        comment_payload = {**payload, 'event': 'COMMENT'}
+        published = await github_json('POST', path, token, comment_payload)
+        return {
+            'published': True,
+            'duplicate': False,
+            'event': 'COMMENT',
+            'requested_event': event,
+            'review_id': (published or {}).get('id'),
+        }

--- a/a2a_server/github_app/review_request.py
+++ b/a2a_server/github_app/review_request.py
@@ -1,0 +1,70 @@
+"""GitHub reviewer request helpers for CodeTether App workflows."""
+
+from __future__ import annotations
+
+import logging
+
+from .auth import github_json
+from .settings import APP_SLUG
+
+logger = logging.getLogger(__name__)
+
+
+def is_human_reviewer_login(login: str | None) -> bool:
+    """Return true when ``login`` is safe to request as a human reviewer.
+
+    GitHub App installation tokens author PRs/comments as ``<app-slug>[bot]`` and
+    GitHub does not let that bot approve its own PRs.  We therefore only request
+    review from the human who triggered the workflow, never from the App/bots.
+    """
+    normalized = str(login or '').strip()
+    if not normalized:
+        return False
+    lowered = normalized.lower()
+    app_slug = APP_SLUG.lower()
+    if lowered in {app_slug, f'{app_slug}[bot]', f'{app_slug}-bot'}:
+        return False
+    if lowered.endswith('[bot]'):
+        return False
+    return True
+
+
+async def request_human_review(
+    repo: str,
+    pr_number: int,
+    token: str,
+    reviewer_login: str | None,
+) -> bool:
+    """Request PR review from the triggering human, if one is known.
+
+    Returns ``True`` when GitHub accepted the reviewer request.  Failures are
+    logged and swallowed so review automation still continues when the user is
+    not a collaborator or the installation lacks reviewer-request permission.
+    """
+    if not is_human_reviewer_login(reviewer_login):
+        return False
+
+    reviewer = str(reviewer_login).strip()
+    try:
+        await github_json(
+            'POST',
+            f'/repos/{repo}/pulls/{pr_number}/requested_reviewers',
+            token,
+            {'reviewers': [reviewer]},
+        )
+        logger.info(
+            'Requested GitHub review from @%s on %s#%s',
+            reviewer,
+            repo,
+            pr_number,
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - network/API failure path
+        logger.warning(
+            'Could not request GitHub review from @%s on %s#%s: %s',
+            reviewer,
+            repo,
+            pr_number,
+            exc,
+        )
+        return False

--- a/a2a_server/github_app/routing.py
+++ b/a2a_server/github_app/routing.py
@@ -40,6 +40,26 @@ def _has_any_capability(worker: dict[str, Any], capabilities: tuple[str, ...]) -
     return any(cap in worker_caps for cap in capabilities)
 
 
+def _required_capabilities() -> list[str]:
+    """Canonicalize aliases before emitting AND-based claim requirements."""
+    persistent_aliases = {
+        'persistent-workspace',
+        'persistent_workspace',
+        'persistent',
+        'harvester',
+    }
+    required: list[str] = []
+    for capability in TARGET_CAPABILITIES:
+        canonical = (
+            'persistent-workspace'
+            if capability in persistent_aliases
+            else capability
+        )
+        if canonical not in required:
+            required.append(canonical)
+    return required
+
+
 def clone_task_routing_metadata() -> dict[str, Any]:
     """Return mandatory capability metadata for GitHub App durable tasks.
 
@@ -53,7 +73,7 @@ def clone_task_routing_metadata() -> dict[str, Any]:
     if TARGET_AGENT:
         metadata['target_agent_name'] = TARGET_AGENT
     if not TARGET_WORKER_ID and TARGET_CAPABILITIES:
-        metadata['required_capabilities'] = list(TARGET_CAPABILITIES)
+        metadata['required_capabilities'] = _required_capabilities()
     return metadata
 
 

--- a/a2a_server/github_app/settings.py
+++ b/a2a_server/github_app/settings.py
@@ -38,6 +38,9 @@ MODEL_REF = (
     os.environ.get('GITHUB_APP_MODEL_REF', 'zai:glm-5.1').strip()
     or 'zai:glm-5.1'
 )
+# GitHub webhook work is user-facing and must not starve behind an old generic
+# task backlog. Apply this to every stage of the automation chain.
+TASK_PRIORITY = int(os.environ.get('GITHUB_APP_TASK_PRIORITY', '100'))
 # Existing env name retained; default includes harvester first while still
 # allowing legacy knative-worker deployments to be selected if connected.
 # Leave GITHUB_APP_TARGET_AGENT unset to route by durable worker capability

--- a/a2a_server/github_app/task_completion.py
+++ b/a2a_server/github_app/task_completion.py
@@ -6,7 +6,9 @@ from .pr_final_comment import notify_pr_final_comment
 from .pr_prepare_completion import handle_pr_prepare_completion
 
 
-async def notify_issue_task_completion(task: dict, worker_id: str | None = None) -> None:
+async def notify_issue_task_completion(
+    task: dict, worker_id: str | None = None
+) -> None:
     """Advance or finish a GitHub App issue workflow."""
     metadata = task.get('metadata') or {}
     if metadata.get('source') != 'github-app':
@@ -15,6 +17,7 @@ async def notify_issue_task_completion(task: dict, worker_id: str | None = None)
     stage = metadata.get('workflow_stage')
     if stage == 'review' or title.startswith('Review issue PR #'):
         from .issue_review_task import create_issue_merge_task
+        from .review_publish import publish_github_review
         from .task_context import github_app_task_context
 
         if str(task.get('status')) != 'completed':
@@ -23,6 +26,7 @@ async def notify_issue_task_completion(task: dict, worker_id: str | None = None)
         if context is None:
             return
         _, _, _, token = context
+        await publish_github_review(task, token)
         await create_issue_merge_task(review_task=task, token=token)
         return
     if metadata.get('pr_number'):

--- a/a2a_server/github_app/task_status_hook.py
+++ b/a2a_server/github_app/task_status_hook.py
@@ -9,7 +9,9 @@ logger = logging.getLogger(__name__)
 _RECONCILER_TASK: asyncio.Task | None = None
 
 
-async def handle_github_app_terminal_task(task_id: str, worker_id: str | None = None) -> None:
+async def handle_github_app_terminal_task(
+    task_id: str, worker_id: str | None = None
+) -> None:
     """Load a terminal task and run any GitHub App follow-up logic."""
     from .. import database as db
     from .checks import ensure_task_check_run
@@ -28,23 +30,35 @@ async def handle_github_app_terminal_task(task_id: str, worker_id: str | None = 
                 from .pr_final_comment import normalize_pr_fix_terminal_status
 
                 task = await normalize_pr_fix_terminal_status(task)
-            elif metadata.get('workflow_stage') == 'code' and not metadata.get('pr_number'):
-                from .issue_final_comment import normalize_issue_task_terminal_status
+            elif metadata.get('workflow_stage') == 'code' and not metadata.get(
+                'pr_number'
+            ):
+                from .issue_final_comment import (
+                    normalize_issue_task_terminal_status,
+                )
 
                 task = await normalize_issue_task_terminal_status(task)
         except Exception as exc:
-            logger.warning('GitHub terminal protocol normalization failed for task %s: %s', task_id, exc)
+            logger.warning(
+                'GitHub terminal protocol normalization failed for task %s: %s',
+                task_id,
+                exc,
+            )
         try:
             await ensure_task_check_run(task, status='completed')
         except Exception as exc:
-            logger.warning('GitHub Checks terminal update failed for task %s: %s', task_id, exc)
+            logger.warning(
+                'GitHub Checks terminal update failed for task %s: %s',
+                task_id,
+                exc,
+            )
         await notify_issue_task_completion(task, worker_id)
 
 
 async def reconcile_github_app_terminal_tasks(limit: int = 20) -> int:
-    """Run missed GitHub App review completions that have no merge decision yet."""
+    """Run missed GitHub App review completions exactly once per outcome."""
     from .. import database as db
-    from .issue_review_task import reviewer_allows_merge
+    from .issue_review_task import reviewer_verdict
     from .task_completion import notify_issue_task_completion
 
     pool = await db.get_pool()
@@ -60,12 +74,29 @@ async def reconcile_github_app_terminal_tasks(limit: int = 20) -> int:
               AND t.completed_at >= NOW() - INTERVAL '2 days'
               AND t.metadata->>'source' = 'github-app'
               AND t.metadata->>'workflow_stage' = 'review'
-              AND t.result ILIKE '%APPROVED%'
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM github_automation_decisions d
-                  WHERE d.task_id = t.id
-                    AND d.action = 'github:merge_pr'
+              AND (
+                (
+                  t.result ILIKE '%APPROVED%'
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM github_automation_decisions d
+                    WHERE d.task_id = t.id
+                      AND d.action = 'github:merge_pr'
+                  )
+                )
+                OR
+                (
+                  (
+                    t.result ILIKE '%CHANGES_REQUESTED%'
+                    OR t.result ~* 'BLOCKED\\s*:'
+                  )
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM tasks fix
+                    WHERE fix.metadata->>'review_task_id' = t.id
+                      AND fix.metadata->>'fix_followup' = 'true'
+                  )
+                )
               )
             ORDER BY t.completed_at ASC
             LIMIT $1
@@ -76,23 +107,38 @@ async def reconcile_github_app_terminal_tasks(limit: int = 20) -> int:
     handled = 0
     for row in rows:
         task = await db.db_get_task(str(row['id']))
-        if not task or not reviewer_allows_merge(task):
+        if not task or reviewer_verdict(task) not in {
+            'APPROVED',
+            'CHANGES_REQUESTED',
+            'BLOCKED',
+        }:
             continue
         await notify_issue_task_completion(task)
         handled += 1
     if handled:
-        logger.info('Reconciled %s missed GitHub App terminal review task(s)', handled)
+        logger.info(
+            'Reconciled %s missed GitHub App terminal review task(s)', handled
+        )
     return handled
 
 
 def start_github_app_terminal_reconciler() -> None:
     """Start a lightweight reconciliation loop for missed terminal hooks."""
     global _RECONCILER_TASK
-    enabled = os.environ.get('GITHUB_APP_TERMINAL_RECONCILER_ENABLED', 'true').lower()
+    enabled = os.environ.get(
+        'GITHUB_APP_TERMINAL_RECONCILER_ENABLED', 'true'
+    ).lower()
     if enabled in {'0', 'false', 'no'} or _RECONCILER_TASK is not None:
         return
 
-    interval = max(30, int(os.environ.get('GITHUB_APP_TERMINAL_RECONCILER_INTERVAL_SECONDS', '60')))
+    interval = max(
+        30,
+        int(
+            os.environ.get(
+                'GITHUB_APP_TERMINAL_RECONCILER_INTERVAL_SECONDS', '60'
+            )
+        ),
+    )
 
     async def _loop() -> None:
         await asyncio.sleep(30)

--- a/a2a_server/github_app/task_status_hook.py
+++ b/a2a_server/github_app/task_status_hook.py
@@ -145,10 +145,20 @@ def start_github_app_terminal_reconciler() -> None:
         while True:
             try:
                 await reconcile_github_app_terminal_tasks()
+                if os.environ.get(
+                    'FORGEJO_AUTOMATION_RECONCILER_ENABLED', 'true'
+                ).lower() not in {'0', 'false', 'no'}:
+                    from ..forgejo_automation import (
+                        reconcile_forgejo_failures,
+                        reconcile_forgejo_terminal_reviews,
+                    )
+
+                    await reconcile_forgejo_terminal_reviews()
+                    await reconcile_forgejo_failures()
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                logger.warning('GitHub App terminal reconciler failed: %s', exc)
+                logger.warning('Automation terminal reconciler failed: %s', exc)
             await asyncio.sleep(interval)
 
     _RECONCILER_TASK = asyncio.create_task(_loop())

--- a/a2a_server/github_app/task_status_hook.py
+++ b/a2a_server/github_app/task_status_hook.py
@@ -17,6 +17,11 @@ async def handle_github_app_terminal_task(task_id: str, worker_id: str | None = 
 
     task = await db.db_get_task(task_id)
     metadata = (task or {}).get('metadata') or {}
+    if metadata.get('source') == 'forgejo-webhook':
+        from ..forgejo_task_completion import notify_forgejo_task_completion
+
+        await notify_forgejo_task_completion(task)
+        return
     if metadata.get('source') == 'github-app':
         try:
             if metadata.get('workflow_stage') == 'fix':

--- a/a2a_server/github_app/task_status_hook.py
+++ b/a2a_server/github_app/task_status_hook.py
@@ -148,15 +148,19 @@ def start_github_app_terminal_reconciler() -> None:
                 if os.environ.get(
                     'FORGEJO_AUTOMATION_RECONCILER_ENABLED', 'true'
                 ).lower() not in {'0', 'false', 'no'}:
-                    from ..forgejo_agent_controls import (
-                        reconcile_forgejo_agent_controls,
-                    )
                     from ..forgejo_automation import (
                         reconcile_forgejo_failures,
                         reconcile_forgejo_terminal_reviews,
                     )
 
-                    await reconcile_forgejo_agent_controls()
+                    if os.environ.get(
+                        'FORGEJO_TEMPORAL_ENABLED', 'false'
+                    ).lower() not in {'1', 'true', 'yes'}:
+                        from ..forgejo_agent_controls import (
+                            reconcile_forgejo_agent_controls,
+                        )
+
+                        await reconcile_forgejo_agent_controls()
                     await reconcile_forgejo_terminal_reviews()
                     await reconcile_forgejo_failures()
             except asyncio.CancelledError:

--- a/a2a_server/github_app/task_status_hook.py
+++ b/a2a_server/github_app/task_status_hook.py
@@ -148,11 +148,15 @@ def start_github_app_terminal_reconciler() -> None:
                 if os.environ.get(
                     'FORGEJO_AUTOMATION_RECONCILER_ENABLED', 'true'
                 ).lower() not in {'0', 'false', 'no'}:
+                    from ..forgejo_agent_controls import (
+                        reconcile_forgejo_agent_controls,
+                    )
                     from ..forgejo_automation import (
                         reconcile_forgejo_failures,
                         reconcile_forgejo_terminal_reviews,
                     )
 
+                    await reconcile_forgejo_agent_controls()
                     await reconcile_forgejo_terminal_reviews()
                     await reconcile_forgejo_failures()
             except asyncio.CancelledError:

--- a/a2a_server/github_app/watch.py
+++ b/a2a_server/github_app/watch.py
@@ -19,7 +19,6 @@ worker_sse.py / hosted_worker.py / monitor_api.py when tasks go terminal.
 """
 
 import logging
-from typing import Any
 
 from .auth import github_json
 
@@ -36,3 +35,80 @@ async def post_issue_comment(
         token,
         {'body': body[:65000]},
     )
+
+
+ACCEPTED_COMMENT_FINGERPRINTS = {
+    'Picked up this request for PR #',
+    'Picked up issue #',
+    'Picked up this issue (#',
+}
+
+
+def _looks_like_acceptance_comment(body: str) -> bool:
+    """Return True when ``body`` is one of our standard acceptance messages."""
+    if not body:
+        return False
+    return any(marker in body for marker in ACCEPTED_COMMENT_FINGERPRINTS)
+
+
+async def recent_app_acceptance_comment_exists(
+    repo_full_name: str,
+    issue_number: int,
+    token: str,
+    *,
+    app_slug: str,
+    within_seconds: int = 600,
+) -> bool:
+    """Return True when the App recently posted a duplicate acceptance comment.
+
+    The webhook ingress can be re-entered for the same PR/issue when
+    ``installation``/``installation_repositories`` backfill events fire or when
+    the same user comment triggers a retry. Posting a second acceptance
+    message confuses users, so this helper short-circuits the duplicate post
+    by scanning the recent comment timeline authored by the App.
+    """
+    try:
+        comments = await github_json(
+            'GET',
+            f'/repos/{repo_full_name}/issues/{issue_number}/comments?per_page=20',
+            token,
+        )
+    except Exception as exc:  # pragma: no cover - network/API failure path
+        logger.warning(
+            'Could not read recent comments for %s#%s: %s',
+            repo_full_name,
+            issue_number,
+            exc,
+        )
+        return False
+    if not isinstance(comments, list):
+        return False
+    bot_login = f'{app_slug.lower()}[bot]'
+    for entry in comments:
+        if not isinstance(entry, dict):
+            continue
+        author = (entry.get('user') or {}).get('login') or ''
+        if str(author).lower() != bot_login:
+            continue
+        if not _looks_like_acceptance_comment(str(entry.get('body') or '')):
+            continue
+        created_at = str(entry.get('created_at') or '')
+        if _within_window(created_at, within_seconds):
+            return True
+    return False
+
+
+def _within_window(iso_timestamp: str, within_seconds: int) -> bool:
+    """Return True when ``iso_timestamp`` is within the last ``within_seconds`` seconds."""
+    if not iso_timestamp:
+        return False
+    try:
+        from datetime import datetime, timedelta, timezone
+
+        parsed = datetime.fromisoformat(iso_timestamp.replace('Z', '+00:00'))
+    except ValueError:
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    return now - parsed <= timedelta(seconds=within_seconds)

--- a/a2a_server/github_app/workspace.py
+++ b/a2a_server/github_app/workspace.py
@@ -4,15 +4,18 @@ import hashlib
 from typing import Any
 
 from .context import MentionContext
-from .prompt import fix_prompt; from .routing import resolve_task_target
-from .settings import MODEL_REF, get_secret
+from .prompt import fix_prompt
+from .routing import resolve_task_target
+from .settings import MODEL_REF, TASK_PRIORITY, get_secret
 
 DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
 
 def workspace_id(git_url: str, git_branch: str) -> str:
     """Derive the deterministic branch-scoped workspace ID."""
-    return hashlib.sha256(f'{git_url}::{git_branch or "main"}'.encode()).hexdigest()[:16]
+    return hashlib.sha256(
+        f'{git_url}::{git_branch or "main"}'.encode()
+    ).hexdigest()[:16]
 
 
 def checkout_branch(context: MentionContext, pr: dict[str, Any]) -> str:
@@ -28,9 +31,40 @@ async def ensure_workspace(context: MentionContext, pr: dict[str, Any]) -> str:
     git_url = pr['head']['repo']['clone_url']
     branch_name = pr['head']['ref']
     git_branch = checkout_branch(context, pr)
-    app_id = await get_secret('app_id', 'GITHUB_APP_ID', 'app_id', 'github_app_id')
+    app_id = await get_secret(
+        'app_id', 'GITHUB_APP_ID', 'app_id', 'github_app_id'
+    )
     wid = workspace_id(git_url, git_branch)
-    workspace = {'id': wid, 'name': context.repo_full_name, 'path': f'/var/lib/codetether/repos/{wid}', 'description': f'GitHub App workspace for {context.repo_full_name}', 'git_url': git_url, 'git_branch': git_branch, 'status': 'active', 'agent_config': {'source': 'github-app', 'repo': {'full_name': context.repo_full_name}, 'github': {'repo_full_name': context.repo_full_name, 'pull_request_number': context.pr_number, 'branch_name': branch_name}, 'git_auth': {'github_app': {'app_id': app_id, 'installation_id': str(context.installation_id)}}}, 'git_auth': {'github_app': {'app_id': app_id, 'installation_id': str(context.installation_id)}}}
+    workspace = {
+        'id': wid,
+        'name': context.repo_full_name,
+        'path': f'/var/lib/codetether/repos/{wid}',
+        'description': f'GitHub App workspace for {context.repo_full_name}',
+        'git_url': git_url,
+        'git_branch': git_branch,
+        'status': 'active',
+        'agent_config': {
+            'source': 'github-app',
+            'repo': {'full_name': context.repo_full_name},
+            'github': {
+                'repo_full_name': context.repo_full_name,
+                'pull_request_number': context.pr_number,
+                'branch_name': branch_name,
+            },
+            'git_auth': {
+                'github_app': {
+                    'app_id': app_id,
+                    'installation_id': str(context.installation_id),
+                }
+            },
+        },
+        'git_auth': {
+            'github_app': {
+                'app_id': app_id,
+                'installation_id': str(context.installation_id),
+            }
+        },
+    }
     await db.db_upsert_workspace(workspace)
     await _redis_upsert_workspace_meta(workspace)
     return wid
@@ -59,6 +93,7 @@ async def create_clone_task(
         'workspace_id': wid,
         'source': 'github-app',
         'workflow_stage': 'code',
+        'trigger_actor_login': context.actor_login,
         'repo': context.repo_full_name,
         'pr_number': context.pr_number,
         'pr_head': pr['head']['ref'],
@@ -80,6 +115,7 @@ async def create_clone_task(
         'git_branch': pr['head']['ref'],
         'source': 'github-app',
         'repo': context.repo_full_name,
+        'trigger_actor_login': context.actor_login,
         'pr_number': context.pr_number,
         'pr_head_sha': (pr.get('head') or {}).get('sha'),
         'github_check_head_sha': (pr.get('head') or {}).get('sha'),
@@ -98,6 +134,7 @@ async def create_clone_task(
         title=f'Prepare PR workspace #{context.pr_number}',
         prompt=f'Clone or refresh {context.repo_full_name} on branch {pr["head"]["ref"]} for PR fix execution.',
         agent_type='clone_repo',
+        priority=TASK_PRIORITY,
         model_ref=MODEL_REF,
         metadata=metadata,
         task_timeout_seconds=DEFAULT_TASK_TIMEOUT,

--- a/a2a_server/monitor_api.py
+++ b/a2a_server/monitor_api.py
@@ -11,29 +11,28 @@ Supports multiple storage backends:
 """
 
 import asyncio
+import io
 import json
 import logging
 import os
 import sqlite3
 import threading
 import uuid
-from typing import List, Dict, Any, Optional, Literal
-from datetime import datetime, timezone, timedelta
 from collections import deque
-from dataclasses import dataclass, asdict
-from fastapi import APIRouter, HTTPException, Request, Depends, Security
-from fastapi.responses import (
-    StreamingResponse,
-    HTMLResponse,
-    FileResponse,
-    JSONResponse,
-)
-from pydantic import BaseModel
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-import os
-import io
-import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
+from typing import Any, Dict, List, Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Security
+from fastapi.responses import (
+    FileResponse,
+    HTMLResponse,
+    JSONResponse,
+    StreamingResponse,
+)
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
 
 # Import PostgreSQL persistence layer
 from . import database as db
@@ -45,6 +44,15 @@ from .git_service import (
 )
 from .task_routing import target_agent_mismatch
 from .task_orchestration import orchestrate_task_route
+from .vault_client import (
+    KNOWN_PROVIDERS,
+    check_vault_connection,
+    delete_user_api_key,
+    get_all_user_api_keys_with_diagnostics,
+    get_worker_sync_data,
+    set_user_api_key,
+    test_api_key as vault_test_api_key,
+)
 
 try:
     from .vm_workspace_provisioner import (
@@ -947,7 +955,7 @@ class MonitoringService:
         for queue in self.subscribers:
             try:
                 await queue.put(f'data: {message_json}\n\n')
-                logger.debug(f'Message queued successfully')
+                logger.debug('Message queued successfully')
             except Exception as e:
                 logger.error(f'Failed to send to subscriber: {e}')
                 pass
@@ -1149,7 +1157,7 @@ async def monitor_stream(request: Request):
                     yield message
                 except asyncio.TimeoutError:
                     # Send heartbeat on timeout
-                    yield f': heartbeat\n\n'
+                    yield ': heartbeat\n\n'
                 except asyncio.CancelledError:
                     logger.info('SSE stream cancelled')
                     break
@@ -1620,10 +1628,7 @@ def get_agent_bridge():
 
             # Set up SSE worker notification hook for task updates
             try:
-                from .worker_sse import (
-                    get_worker_registry,
-                    notify_workers_of_new_task,
-                )
+                from .worker_sse import notify_workers_of_new_task
 
                 async def _on_task_update(task):
                     """Notify SSE-connected workers when a task is created/updated."""
@@ -3222,7 +3227,7 @@ async def register_workspace(registration: WorkspaceRegistration):
             'success': True,
             'pending': True,
             'task_id': task.id,
-            'message': f'Registration task created. A worker will validate the path and confirm registration.',
+            'message': 'Registration task created. A worker will validate the path and confirm registration.',
         }
     else:
         raise HTTPException(
@@ -4500,8 +4505,6 @@ async def _validate_target_worker_is_available(
         )
 
 
-
-
 async def get_current_policy_user(request: Request) -> dict:
     """Return the OIDC/self-service/API-key user resolved by policy middleware."""
     user = getattr(request.state, 'policy_user', None)
@@ -4564,7 +4567,6 @@ async def list_all_tasks(
     return tasks
 
 
-
 @agent_router_alias.get('/workflows/github-app')
 async def get_github_app_workflows(
     request: Request,
@@ -4580,7 +4582,6 @@ async def get_github_app_workflows(
     dashboard users and authorized agents are handled consistently.
     """
     from .workflow_monitor import load_github_app_workflows
-    from .workflow_monitor import build_response as empty_workflow_response
 
     roles = set(user.get('roles') or [])
     tenant_id = (
@@ -4873,7 +4874,9 @@ def _is_github_app_worker_post_clone_followup(
         return False
     if metadata.get('source') != 'github-app':
         return False
-    if not metadata.get('github_issue_url') or not metadata.get('target_worker_id'):
+    if not metadata.get('github_issue_url') or not metadata.get(
+        'target_worker_id'
+    ):
         return False
     return title.startswith(('Apply PR fix #', 'Work issue #'))
 
@@ -5723,7 +5726,6 @@ async def get_session_messages_by_id(
     workspace_id: str, session_id: str, limit: int = 100
 ):
     """Get messages from a specific session."""
-    import aiohttp
     import traceback
 
     try:
@@ -6275,12 +6277,6 @@ async def get_watch_status(workspace_id: str):
     if not workspace:
         raise HTTPException(status_code=404, detail='Workspace not found')
 
-    pending_tasks = await bridge.list_tasks(
-        codebase_id=workspace_id,
-        status=bridge._tasks.__class__.PENDING
-        if hasattr(bridge._tasks, '__class__')
-        else None,
-    )
     from .agent_bridge import AgentTaskStatus
 
     pending_count = len(
@@ -7379,7 +7375,7 @@ async def stream_task_output_sse(task_id: str, request: Request):
 
 
 @agent_router_alias.post('/tasks/{task_id}/cancel')
-async def cancel_task(task_id: str):
+async def cancel_task_streaming_route(task_id: str):
     """Cancel a pending task."""
     bridge = get_agent_bridge()
     if bridge is None:
@@ -7699,7 +7695,7 @@ async def logout(
 
 
 @auth_router.get('/session')
-async def get_session(session_id: str):
+async def get_auth_session(session_id: str):
     """Get current session info."""
     auth = get_keycloak_auth()
     if auth is None:
@@ -7957,19 +7953,6 @@ async def nextauth_callback(code: str, state: str):
 # These endpoints allow users to manage their LLM provider API keys through the UI.
 # Keys are stored in HashiCorp Vault, scoped to the authenticated user.
 
-from .vault_client import (
-    KNOWN_PROVIDERS,
-    get_user_api_key,
-    set_user_api_key,
-    delete_user_api_key,
-    list_user_api_keys,
-    get_all_user_api_keys,
-    get_all_user_api_keys_with_diagnostics,
-    get_worker_sync_data,
-    check_vault_connection,
-    test_api_key as vault_test_api_key,
-)
-
 try:
     from .keycloak_auth import (
         get_current_user as get_keycloak_user,
@@ -7994,7 +7977,6 @@ except ImportError:
 
     async def get_self_service_user(*args, **kwargs):
         return None
-
 
 
 @dataclass
@@ -8052,7 +8034,7 @@ class APIKeyCreate(BaseModel):
 
 
 @agent_router_alias.get('/providers')
-async def list_providers():
+async def list_configured_providers():
     """List all known LLM providers with their configuration."""
     return {
         'providers': [
@@ -8333,9 +8315,6 @@ async def upload_workspace_tarball(
         )
 
     # Parse multipart form data
-    from fastapi import UploadFile, File
-    import aiofiles
-
     try:
         form = await request.form()
         file = form.get('file')
@@ -8586,7 +8565,6 @@ async def get_session_worker_status(
     if session:
         # Check if we have Knative service info stored
         knative_service_name = session.get('knative_service_name')
-        worker_status = session.get('worker_status', 'pending')
         last_activity = session.get('last_activity_at')
 
         if not knative_service_name:
@@ -8819,7 +8797,7 @@ async def create_voice_session(request: VoiceSessionRequest):
         logger.error(f'Failed to mint access token: {e}')
         try:
             await bridge.delete_room(room_name)
-        except:
+        except Exception:
             pass
         raise HTTPException(
             status_code=500, detail=f'Failed to generate access token: {str(e)}'
@@ -8865,7 +8843,7 @@ async def get_voice_session(room_name: str, user_id: Optional[str] = None):
                 if isinstance(metadata_str, str)
                 else metadata_str
             )
-        except:
+        except Exception:
             pass
 
     response = {
@@ -8950,7 +8928,7 @@ async def get_voice_session_state(room_name: str):
                     if isinstance(metadata_str, str)
                     else metadata_str
                 )
-            except:
+            except Exception:
                 pass
 
         session_id = metadata.get('session_id')

--- a/a2a_server/persistent_worker_pool.py
+++ b/a2a_server/persistent_worker_pool.py
@@ -16,7 +16,6 @@ Configuration:
     GITHUB_PROGRESS_INTERVAL_SECONDS: GitHub comment frequency (default: 300)
 """
 
-import asyncio
 import json
 import logging
 import os
@@ -26,9 +25,9 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-PERSISTENT_WORKER_ENABLED = os.environ.get(
-    'PERSISTENT_WORKER_ENABLED', 'false'
-).lower() == 'true'
+PERSISTENT_WORKER_ENABLED = (
+    os.environ.get('PERSISTENT_WORKER_ENABLED', 'false').lower() == 'true'
+)
 PERSISTENT_WORKER_LEASE_SECONDS = int(
     os.environ.get('PERSISTENT_WORKER_LEASE_SECONDS', '3600')
 )
@@ -43,19 +42,24 @@ DEFAULT_TASK_TIMEOUT = 604800  # 7 days
 
 
 def _github_work_key(metadata: Dict[str, Any]) -> Optional[str]:
-    """Return a stable idempotency key for active GitHub App work.
+    """Return a stable idempotency key for GitHub App or Forgejo work.
 
     The key is intentionally scoped to one workflow stage and head SHA so a PR can
     move from prepare -> code, and a new commit can trigger fresh work, while
     concurrent webhook/active-work scans cannot create duplicate workers for the
     same PR commit/stage.
     """
+    explicit_forgejo_key = str(metadata.get('forgejo_work_key') or '').strip()
+    if metadata.get('source') == 'forgejo-webhook':
+        return explicit_forgejo_key or None
     if metadata.get('source') != 'github-app':
         return None
 
     repo = str(metadata.get('repo') or '').strip()
     number = metadata.get('pr_number') or metadata.get('issue_number')
-    stage = str(metadata.get('workflow_stage') or metadata.get('agent_type') or '').strip()
+    stage = str(
+        metadata.get('workflow_stage') or metadata.get('agent_type') or ''
+    ).strip()
     head_sha = str(
         metadata.get('pr_head_sha')
         or metadata.get('github_check_head_sha')
@@ -85,17 +89,25 @@ async def _github_work_dedupe_lock(metadata: Dict[str, Any]):
 
     conn = await pool.acquire()
     try:
-        await conn.execute('SELECT pg_advisory_lock(hashtextextended($1, 0))', work_key)
+        await conn.execute(
+            'SELECT pg_advisory_lock(hashtextextended($1, 0))', work_key
+        )
         yield work_key
     finally:
         try:
-            await conn.execute('SELECT pg_advisory_unlock(hashtextextended($1, 0))', work_key)
+            await conn.execute(
+                'SELECT pg_advisory_unlock(hashtextextended($1, 0))', work_key
+            )
         finally:
             await pool.release(conn)
 
 
 async def _active_github_work_task_id(work_key: Optional[str]) -> Optional[str]:
-    """Return the oldest active task for a GitHub App idempotency key."""
+    """Return existing work for an idempotency key.
+
+    Forgejo keys describe immutable delivery/outcome work and remain deduped after
+    terminal completion. GitHub keys preserve the existing active-only behavior.
+    """
     if not work_key:
         return None
 
@@ -110,9 +122,18 @@ async def _active_github_work_task_id(work_key: Optional[str]) -> Optional[str]:
             """
             SELECT id
             FROM tasks
-            WHERE status IN ('pending', 'queued', 'running', 'working')
-              AND COALESCE(metadata, '{}'::jsonb)->>'source' = 'github-app'
-              AND COALESCE(metadata, '{}'::jsonb)->>'github_work_key' = $1
+            WHERE (
+                    (
+                      status IN ('pending', 'queued', 'running', 'working')
+                      AND COALESCE(metadata, '{}'::jsonb)->>'source' = 'github-app'
+                      AND COALESCE(metadata, '{}'::jsonb)->>'github_work_key' = $1
+                    )
+                    OR
+                    (
+                      COALESCE(metadata, '{}'::jsonb)->>'source' = 'forgejo-webhook'
+                      AND COALESCE(metadata, '{}'::jsonb)->>'forgejo_work_key' = $1
+                    )
+                  )
             ORDER BY created_at ASC
             LIMIT 1
             """,
@@ -155,6 +176,7 @@ async def create_and_dispatch_task(
     if not workspace:
         try:
             from .monitor_api import _rehydrate_workspace_into_bridge
+
             workspace = await _rehydrate_workspace_into_bridge(workspace_id)
         except Exception:
             workspace = None
@@ -165,7 +187,7 @@ async def create_and_dispatch_task(
         effective_metadata['model_ref'] = model_ref
 
     work_key = _github_work_key(effective_metadata)
-    if work_key:
+    if work_key and effective_metadata.get('source') == 'github-app':
         effective_metadata['github_work_key'] = work_key
 
     async with _github_work_dedupe_lock(effective_metadata) as locked_work_key:
@@ -237,7 +259,10 @@ async def dispatch_fire_and_forget(
     async with pool.acquire() as conn:
         run_id = await conn.fetchval(
             'SELECT create_fire_and_forget_run($1, $2, $3, $4, $5, $6)',
-            task_id, user_id, tenant_id, priority,
+            task_id,
+            user_id,
+            tenant_id,
+            priority,
             min(task_timeout_seconds, PERSISTENT_WORKER_MAX_TIMEOUT),
             github_issue_url,
         )
@@ -245,20 +270,31 @@ async def dispatch_fire_and_forget(
     async with pool.acquire() as conn:
         await conn.execute(
             "UPDATE tasks SET dispatch_mode = 'fire_and_forget', updated_at = NOW() "
-            "WHERE id = $1", task_id,
+            'WHERE id = $1',
+            task_id,
         )
 
     # Notify SSE workers
     try:
         from .worker_sse import notify_workers_of_new_task
+
         task_data = {
-            'id': task_id, 'title': title, 'prompt': description,
-            'agent_type': agent_type, 'model': model, 'priority': priority,
-            'metadata': metadata or {}, 'dispatch_mode': 'fire_and_forget',
+            'id': task_id,
+            'title': title,
+            'prompt': description,
+            'agent_type': agent_type,
+            'model': model,
+            'priority': priority,
+            'metadata': metadata or {},
+            'dispatch_mode': 'fire_and_forget',
             'task_timeout_seconds': task_timeout_seconds,
         }
         routed_metadata = metadata or {}
-        for key in ('target_agent_name', 'target_worker_id', 'required_capabilities'):
+        for key in (
+            'target_agent_name',
+            'target_worker_id',
+            'required_capabilities',
+        ):
             if routed_metadata.get(key):
                 task_data[key] = routed_metadata[key]
         notified = await notify_workers_of_new_task(task_data)
@@ -270,7 +306,9 @@ async def dispatch_fire_and_forget(
         logger.warning(f'SSE notify failed for {task_id}: {e}')
 
     return {
-        'task_id': task_id, 'run_id': run_id, 'status': 'queued',
+        'task_id': task_id,
+        'run_id': run_id,
+        'status': 'queued',
         'dispatch_mode': 'fire_and_forget',
         'task_timeout_seconds': task_timeout_seconds,
         'message': 'Task dispatched. Monitor via heartbeat API or GitHub comments.',
@@ -287,9 +325,7 @@ async def claim_extended_task(
     from . import database as db
 
     worker_capabilities = [
-        str(cap).strip()
-        for cap in (capabilities or [])
-        if str(cap).strip()
+        str(cap).strip() for cap in (capabilities or []) if str(cap).strip()
     ]
 
     # Extended polling is load-balanced independently of the SSE connection.
@@ -311,7 +347,10 @@ async def claim_extended_task(
                 f'Failed to load registered capabilities for worker {worker_id}: {e}'
             )
 
-    if 'knative' in worker_capabilities and 'persistent' not in worker_capabilities:
+    if (
+        'knative' in worker_capabilities
+        and 'persistent' not in worker_capabilities
+    ):
         logger.debug(
             f'Worker {worker_id} is knative-only; skipping extended persistent claim'
         )
@@ -324,9 +363,12 @@ async def claim_extended_task(
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             'SELECT * FROM claim_next_task_run_extended($1, $2, $3, $4, $5, $6)',
-            worker_id, PERSISTENT_WORKER_LEASE_SECONDS,
-            agent_name, json.dumps(worker_capabilities),
-            models_supported or None, PERSISTENT_WORKER_MAX_TIMEOUT,
+            worker_id,
+            PERSISTENT_WORKER_LEASE_SECONDS,
+            agent_name,
+            json.dumps(worker_capabilities),
+            models_supported or None,
+            PERSISTENT_WORKER_MAX_TIMEOUT,
         )
 
     if not row or not row.get('run_id'):
@@ -361,12 +403,14 @@ async def post_extended_heartbeat(
 
     progress_json = None
     if progress_pct is not None or status_message is not None:
-        progress_json = json.dumps({
-            'progress_pct': progress_pct,
-            'status_message': status_message,
-            'worker_id': worker_id,
-            'heartbeat_at': datetime.now(timezone.utc).isoformat(),
-        })
+        progress_json = json.dumps(
+            {
+                'progress_pct': progress_pct,
+                'status_message': status_message,
+                'worker_id': worker_id,
+                'heartbeat_at': datetime.now(timezone.utc).isoformat(),
+            }
+        )
 
     checkpoint_json = json.dumps(checkpoint) if checkpoint else None
     lease_seconds = lease_extension_seconds or PERSISTENT_WORKER_LEASE_SECONDS
@@ -374,8 +418,13 @@ async def post_extended_heartbeat(
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             'SELECT * FROM extended_heartbeat($1, $2, $3, $4, $5, $6, $7)',
-            task_id, worker_id, progress_json, checkpoint_json,
-            checkpoint_seq, lease_seconds, log_tail,
+            task_id,
+            worker_id,
+            progress_json,
+            checkpoint_json,
+            checkpoint_seq,
+            lease_seconds,
+            log_tail,
         )
 
     if not row or not row['success']:
@@ -387,7 +436,8 @@ async def post_extended_heartbeat(
     return {
         'success': True,
         'lease_expires_at': row['lease_expires_at'].isoformat()
-            if row['lease_expires_at'] else None,
+        if row['lease_expires_at']
+        else None,
         'within_timeout': row['within_timeout'],
         'elapsed_seconds': row['elapsed_seconds'],
         'resume_attempt': row['resume_attempt'],

--- a/a2a_server/policy_middleware.py
+++ b/a2a_server/policy_middleware.py
@@ -75,6 +75,8 @@ _RULES: List[Tuple[str, Optional[set], str]] = [
     # Billing webhooks — Stripe signature verified
     (r'^/v1/webhooks/stripe$', {'POST'}, ''),
     (r'^/v1/webhooks/github$', {'POST'}, ''),
+    # Forgejo webhooks and native agent controls verify HMAC signatures.
+    (r'^/v1/webhooks/forgejo(?:/agent-control)?$', {'POST'}, ''),
     # ── Already-protected routes (skip to avoid double auth) ─────
     # Billing, admin, tenant (non-signup), user auth (non-public),
     # cronjobs, queue — all have existing Depends(require_*).

--- a/a2a_server/policy_middleware.py
+++ b/a2a_server/policy_middleware.py
@@ -49,6 +49,8 @@ _RULES: List[Tuple[str, Optional[set], str]] = [
     (r'^/docs', None, ''),
     (r'^/openapi\.json$', None, ''),
     (r'^/redoc', None, ''),
+    # Expiring HMAC-signed task transcript links validate in the route handler.
+    (r'^/sessions/tasks/[^/]+$', {'GET'}, ''),
     # Auth endpoints — intentionally public
     (r'^/v1/auth/login$', None, ''),
     (r'^/v1/auth/refresh$', None, ''),

--- a/a2a_server/post_clone_followup.py
+++ b/a2a_server/post_clone_followup.py
@@ -22,12 +22,32 @@ async def enqueue_post_clone_followup(bridge, task_id: str) -> Optional[str]:
     followup = metadata.get('post_clone_task')
     if not isinstance(followup, dict):
         return None
+    if metadata.get('source') == 'forgejo-webhook':
+        from .persistent_worker_pool import create_and_dispatch_task
+
+        queued_id = await create_and_dispatch_task(
+            workspace_id=task.codebase_id,
+            title=followup.get('title') or 'Continue after clone',
+            prompt=followup.get('prompt') or '',
+            agent_type=followup.get('agent_type') or 'build',
+            priority=int(followup.get('priority') or 0),
+            metadata=followup.get('metadata'),
+            model_ref=followup.get('model_ref'),
+            task_timeout_seconds=604800,
+            github_issue_url=(followup.get('metadata') or {}).get(
+                'forgejo_issue_url'
+            ),
+        )
+        return queued_id
+
     queued = await bridge.create_task(
         codebase_id=task.codebase_id,
         title=followup.get('title') or 'Continue after clone',
         prompt=followup.get('prompt') or '',
         agent_type=followup.get('agent_type') or 'build',
+        priority=int(followup.get('priority') or metadata.get('priority') or 0),
         metadata=followup.get('metadata'),
+        model_ref=followup.get('model_ref'),
     )
     if queued is None:
         logger.warning(

--- a/a2a_server/post_clone_followup.py
+++ b/a2a_server/post_clone_followup.py
@@ -25,19 +25,31 @@ async def enqueue_post_clone_followup(bridge, task_id: str) -> Optional[str]:
     if metadata.get('source') == 'forgejo-webhook':
         from .persistent_worker_pool import create_and_dispatch_task
 
+        followup_metadata = followup.get('metadata') or {}
         queued_id = await create_and_dispatch_task(
             workspace_id=task.codebase_id,
             title=followup.get('title') or 'Continue after clone',
             prompt=followup.get('prompt') or '',
             agent_type=followup.get('agent_type') or 'build',
             priority=int(followup.get('priority') or 0),
-            metadata=followup.get('metadata'),
+            metadata=followup_metadata,
             model_ref=followup.get('model_ref'),
             task_timeout_seconds=604800,
-            github_issue_url=(followup.get('metadata') or {}).get(
-                'forgejo_issue_url'
-            ),
+            github_issue_url=followup_metadata.get('forgejo_issue_url'),
         )
+        forgejo_task_id = int(
+            followup_metadata.get('forgejo_agent_task_id') or 0
+        )
+        if forgejo_task_id:
+            from .forgejo_agent_client import update_task
+
+            await update_task(
+                repo=str(followup_metadata.get('repo') or ''),
+                task_id=forgejo_task_id,
+                base_url=str(followup_metadata.get('forgejo_api_url') or ''),
+                status='running',
+                external_task_id=str(queued_id),
+            )
         return queued_id
 
     queued = await bridge.create_task(

--- a/a2a_server/server.py
+++ b/a2a_server/server.py
@@ -59,6 +59,7 @@ from .monitor_api import (
     log_agent_message,
 )
 from .worker_sse import worker_sse_router
+from .forgejo_webhooks import forgejo_webhook_router
 from .email_inbound import email_router
 from .email_api import email_api_router
 from .tenant_middleware import TenantContextMiddleware
@@ -684,6 +685,9 @@ class A2AServer:
             logger.info(
                 'GitHub App routes mounted at /v1/webhooks/github, /v1/agent/workspaces/*/git/credentials, and /v1/integrations/rudder/log-incidents'
             )
+
+        self.app.include_router(forgejo_webhook_router)
+        logger.info('Forgejo webhook route mounted at /v1/webhooks/forgejo')
 
         # Include token billing API routes for per-token usage tracking
         self.app.include_router(token_billing_router)

--- a/a2a_server/session_view.py
+++ b/a2a_server/session_view.py
@@ -1,0 +1,247 @@
+"""Signed, read-only CodeTether Agent session transcripts."""
+
+# Recursive worker message/tool payloads are untyped JSON by contract.
+# ruff: noqa: ANN401, E501
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import html
+import json
+import os
+import time
+
+from typing import Any
+from urllib.parse import quote, urlencode
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import HTMLResponse
+
+from a2a_server import database as db
+from a2a_server.monitor_api import _get_session_messages_impl
+
+
+session_view_router = APIRouter(tags=['sessions'])
+
+_DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60
+_SECRET_KEYS = {
+    'authorization',
+    'cookie',
+    'password',
+    'passwd',
+    'secret',
+    'token',
+    'api_key',
+    'apikey',
+    'private_key',
+    'access_token',
+    'refresh_token',
+}
+
+
+def _signing_secret() -> bytes:
+    value = (
+        os.getenv('CODETETHER_SESSION_VIEW_SECRET')
+        or os.getenv('FORGEJO_WEBHOOK_SECRET')
+        or ''
+    )
+    if not value:
+        raise RuntimeError('session view signing secret is not configured')
+    return value.encode()
+
+
+def _signature(task_id: str, expires: int) -> str:
+    message = f'{task_id}:{expires}'.encode()
+    return hmac.new(_signing_secret(), message, hashlib.sha256).hexdigest()
+
+
+def build_task_session_url(
+    task_id: str,
+    *,
+    base_url: str | None = None,
+    expires: int | None = None,
+) -> str | None:
+    """Build an expiring task-scoped session URL for Forgejo comments."""
+    if not task_id:
+        return None
+    origin = (base_url or os.getenv('CODETETHER_PUBLIC_URL') or '').rstrip('/')
+    if not origin:
+        return None
+    try:
+        deadline = expires or int(time.time()) + int(
+            os.getenv(
+                'CODETETHER_SESSION_VIEW_TTL_SECONDS', _DEFAULT_TTL_SECONDS
+            )
+        )
+        query = urlencode(
+            {'expires': deadline, 'signature': _signature(task_id, deadline)}
+        )
+    except (RuntimeError, TypeError, ValueError):
+        return None
+    return f'{origin}/sessions/tasks/{quote(task_id, safe="")}?{query}'
+
+
+def verify_task_session_signature(
+    task_id: str, expires: int, signature: str
+) -> None:
+    """Reject expired or forged task-scoped session links."""
+    if expires < int(time.time()):
+        raise HTTPException(status_code=410, detail='Session link expired')
+    try:
+        expected = _signature(task_id, expires)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if not signature or not hmac.compare_digest(expected, signature):
+        raise HTTPException(status_code=403, detail='Invalid session link')
+
+
+def _redact(value: Any, key: str = '') -> Any:
+    """Recursively redact common credential fields before rendering."""
+    if key.lower() in _SECRET_KEYS:
+        return '[REDACTED]'
+    if isinstance(value, dict):
+        return {str(k): _redact(v, str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact(item) for item in value]
+    return value
+
+
+def _task_session_id(task: dict[str, Any]) -> str | None:
+    metadata = task.get('metadata') or {}
+    return (
+        str(
+            task.get('session_id')
+            or metadata.get('session_id')
+            or metadata.get('resume_session_id')
+            or ''
+        )
+        or None
+    )
+
+
+async def _task_messages(
+    task: dict[str, Any], limit: int
+) -> tuple[str | None, list[dict[str, Any]]]:
+    session_id = _task_session_id(task)
+    if not session_id:
+        return None, []
+    workspace_id = str(
+        task.get('workspace_id') or task.get('codebase_id') or ''
+    )
+    messages: list[dict[str, Any]] = []
+    if workspace_id:
+        try:
+            merged = await _get_session_messages_impl(
+                workspace_id, session_id, limit
+            )
+            messages = list(merged.get('messages') or [])
+        except Exception:
+            messages = []
+    if not messages:
+        messages = await db.db_list_messages(session_id=session_id, limit=limit)
+    return session_id, [_redact(message) for message in messages]
+
+
+def _json_block(value: Any) -> str:
+    return html.escape(
+        json.dumps(value, indent=2, ensure_ascii=False, default=str)
+    )
+
+
+def _tool_card(tool: Any) -> str:
+    data = _redact(tool)
+    name = 'Tool call'
+    status = ''
+    if isinstance(data, dict):
+        name = str(
+            data.get('name') or data.get('tool') or data.get('function') or name
+        )
+        status = str(data.get('status') or data.get('state') or '')
+    title = html.escape(name + (f' · {status}' if status else ''))
+    return f'<details class="tool"><summary>{title}</summary><pre>{_json_block(data)}</pre></details>'
+
+
+def render_session_html(
+    task: dict[str, Any], session_id: str | None, messages: list[dict[str, Any]]
+) -> str:
+    """Render a standalone, read-only CodeTether Agent transcript."""
+    metadata = _redact(task.get('metadata') or {})
+    repo = str(metadata.get('repo') or metadata.get('forgejo_repo') or '')
+    number = metadata.get('pr_number') or metadata.get('issue_number')
+    header_bits = [f'Task {html.escape(str(task.get("id") or ""))}']
+    if repo:
+        header_bits.append(html.escape(repo))
+    if number:
+        header_bits.append(f'#{html.escape(str(number))}')
+
+    cards: list[str] = []
+    for message in messages:
+        role = html.escape(str(message.get('role') or 'event'))
+        created = html.escape(str(message.get('created_at') or ''))
+        content = html.escape(str(message.get('content') or ''))
+        model = html.escape(str(message.get('model') or ''))
+        tools = ''.join(
+            _tool_card(call) for call in (message.get('tool_calls') or [])
+        )
+        cards.append(
+            '<article class="message">'
+            f'<header><strong>{role}</strong><span>{created}</span></header>'
+            f'<div class="content">{content}</div>'
+            f'{tools}'
+            f'<footer>{("Model: " + model) if model else ""}</footer>'
+            '</article>'
+        )
+    if not cards:
+        cards.append(
+            '<p class="empty">No persisted messages are available yet. Refresh while the agent is running.</p>'
+        )
+
+    status = html.escape(str(task.get('status') or 'unknown'))
+    session_label = html.escape(session_id or 'pending')
+    title = ' · '.join(header_bits)
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>CodeTether Agent session</title>
+<style>
+:root{{--bg:#0d1117;--panel:#161b22;--border:#30363d;--text:#e6edf3;--muted:#8b949e;--accent:#58a6ff}}
+*{{box-sizing:border-box}} body{{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 ui-sans-serif,system-ui,sans-serif}}
+main{{max-width:1000px;margin:auto;padding:32px 20px}} h1{{font-size:24px;margin:0 0 8px}} .meta{{color:var(--muted);margin-bottom:24px}}
+.message{{background:var(--panel);border:1px solid var(--border);border-radius:8px;margin:12px 0;padding:16px}}
+.message header{{display:flex;justify-content:space-between;color:var(--accent)}} .message header span,.message footer{{color:var(--muted)}}
+.content{{white-space:pre-wrap;overflow-wrap:anywhere;margin:14px 0}} details.tool{{border-top:1px solid var(--border);padding:10px 0}}
+summary{{cursor:pointer;color:#d2a8ff}} pre{{overflow:auto;background:#010409;border-radius:6px;padding:12px;white-space:pre-wrap}}
+.empty{{color:var(--muted)}}
+</style></head><body><main>
+<h1>CodeTether Agent · View session</h1>
+<div class="meta">{title} · Status {status} · Session {session_label} · Read-only transcript</div>
+{''.join(cards)}
+</main></body></html>"""
+
+
+@session_view_router.get(
+    '/sessions/tasks/{task_id}', response_class=HTMLResponse
+)
+async def view_task_session(
+    task_id: str,
+    expires: int = Query(...),
+    signature: str = Query(...),
+    limit: int = Query(1000, ge=1, le=5000),
+):
+    """Render an expiring, task-scoped CodeTether Agent transcript."""
+    verify_task_session_signature(task_id, expires, signature)
+    task = await db.db_get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail='Task not found')
+    session_id, messages = await _task_messages(task, limit)
+    return HTMLResponse(
+        render_session_html(task, session_id, messages),
+        headers={
+            'Cache-Control': 'private, no-store',
+            'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'",
+            'Referrer-Policy': 'no-referrer',
+            'X-Content-Type-Options': 'nosniff',
+        },
+    )

--- a/a2a_server/temporal/__init__.py
+++ b/a2a_server/temporal/__init__.py
@@ -1,0 +1,22 @@
+"""Durable Temporal orchestration for CodeTether workflows."""
+
+from .config import TemporalSettings, temporal_settings
+from .models import (
+    ForgejoAgentWorkflowInput,
+    ForgejoAgentWorkflowResult,
+    ForgejoControlSignal,
+    ForgejoStageRequest,
+    ForgejoStageResult,
+    ForgejoTaskTerminalSignal,
+)
+
+__all__ = [
+    'ForgejoAgentWorkflowInput',
+    'ForgejoAgentWorkflowResult',
+    'ForgejoControlSignal',
+    'ForgejoStageRequest',
+    'ForgejoStageResult',
+    'ForgejoTaskTerminalSignal',
+    'TemporalSettings',
+    'temporal_settings',
+]

--- a/a2a_server/temporal/activities.py
+++ b/a2a_server/temporal/activities.py
@@ -1,0 +1,327 @@
+"""Temporal activities for Forgejo agent orchestration.
+
+Activity inputs and results deliberately exclude prompts, transcripts, tool
+payloads, credentials, and repository clone URLs. Those values are loaded and
+used inside activity execution only, so they are not persisted in workflow
+history.
+"""
+
+from __future__ import annotations
+
+import os
+
+from functools import wraps
+from typing import Any, Callable
+from urllib.parse import quote
+
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+
+from .models import ForgejoStageRequest, ForgejoStageResult
+
+
+def safe_activity(error_type: str) -> Callable:
+    """Prevent upstream exception text from entering Temporal history."""
+
+    def decorate(function: Callable) -> Callable:
+        @wraps(function)
+        async def wrapped(*args, **kwargs):
+            try:
+                return await function(*args, **kwargs)
+            except ApplicationError:
+                raise
+            except Exception:
+                raise ApplicationError(
+                    error_type,
+                    type=error_type,
+                ) from None
+
+        return wrapped
+
+    return decorate
+
+
+async def _codetether_task(task_id: str) -> dict[str, Any]:
+    from a2a_server import database as db
+
+    task = await db.db_get_task(task_id)
+    if not task:
+        raise RuntimeError(f'CodeTether task {task_id} was not found')
+    return task
+
+
+def _issue_url(repository: str, number: int) -> str:
+    api = os.environ.get('FORGEJO_API_URL', '').rstrip('/')
+    origin = api.removesuffix('/api/v1')
+    owner, name = repository.split('/', 1)
+    return (
+        f'{origin}/{quote(owner, safe="")}/{quote(name, safe="")}/issues/{number}'
+        if origin and number
+        else ''
+    )
+
+
+def _temporal_metadata(
+    request: ForgejoStageRequest,
+    *,
+    branch: str,
+    head_sha: str,
+    pull_request_number: int,
+) -> dict[str, Any]:
+    workflow = request.workflow
+    return {
+        'workspace_id': workflow.workspace_id,
+        'source': 'forgejo-webhook',
+        'platform': 'forgejo',
+        'workflow_stage': request.stage,
+        'repo': workflow.repository,
+        'issue_number': workflow.issue_number,
+        'pr_number': pull_request_number or None,
+        'branch_name': branch,
+        'pr_head_sha': head_sha,
+        'forgejo_api_url': os.environ.get('FORGEJO_API_URL', '').rstrip('/'),
+        'forgejo_issue_url': _issue_url(
+            workflow.repository,
+            pull_request_number or workflow.issue_number,
+        ),
+        'forgejo_agent_task_id': workflow.forgejo_task_id,
+        'temporal_orchestrated': True,
+        'temporal_workflow_id': request.workflow_id,
+        'temporal_attempt': workflow.attempt,
+        'parent_task_id': request.parent_task_id or None,
+        'review_task_id': request.review_task_id or None,
+        'fix_attempt': request.fix_attempt or None,
+        'forgejo_work_key': (
+            f'forgejo-temporal:{workflow.forgejo_task_id}:'
+            f'{workflow.attempt}:{request.stage}:{head_sha or branch}'
+        ),
+    }
+
+
+async def _forgejo_context(
+    request: ForgejoStageRequest,
+) -> tuple[dict[str, Any], str, str, int, str, str]:
+    from a2a_server.forgejo_agent_client import get_task
+    from a2a_server.forgejo_webhooks import forgejo_json
+
+    workflow = request.workflow
+    forgejo_task = await get_task(
+        repo=workflow.repository,
+        task_id=workflow.forgejo_task_id,
+    )
+    owner, name = workflow.repository.split('/', 1)
+    repo_path = f'/repos/{quote(owner, safe="")}/{quote(name, safe="")}'
+    repository = await forgejo_json(
+        'GET', os.environ.get('FORGEJO_API_URL', '').rstrip('/'), repo_path
+    )
+    default_branch = str(repository.get('default_branch') or 'main')
+    branch = workflow.branch or default_branch
+    clone_branch = default_branch
+    clone_url = str(repository.get('clone_url') or '')
+    head_sha = workflow.head_sha
+    pull_number = workflow.pull_request_number
+    if pull_number:
+        pull = await forgejo_json(
+            'GET',
+            os.environ.get('FORGEJO_API_URL', '').rstrip('/'),
+            f'{repo_path}/pulls/{pull_number}',
+        )
+        head = (pull or {}).get('head') or {}
+        branch = str(head.get('ref') or branch)
+        clone_branch = branch
+        head_sha = str(head.get('sha') or head_sha)
+        clone_url = str(
+            ((head.get('repo') or {}).get('clone_url')) or clone_url
+        )
+    if not clone_url:
+        raise RuntimeError('Forgejo repository has no clone URL')
+    return (
+        forgejo_task,
+        branch,
+        head_sha,
+        pull_number,
+        clone_url,
+        clone_branch,
+    )
+
+
+@activity.defn(name='forgejo_dispatch_stage')
+@safe_activity('forgejo_dispatch_stage_failed')
+async def dispatch_stage(request: ForgejoStageRequest) -> ForgejoStageResult:
+    """Dispatch one existing CodeTether execution stage."""
+    from a2a_server.forgejo_agent_client import update_task
+    from a2a_server.github_app.routing import resolve_task_target
+    from a2a_server.persistent_worker_pool import create_and_dispatch_task
+
+    (
+        forgejo_task,
+        branch,
+        head_sha,
+        pull_number,
+        clone_url,
+        clone_branch,
+    ) = await _forgejo_context(request)
+    routing = await resolve_task_target()
+    metadata = _temporal_metadata(
+        request,
+        branch=branch,
+        head_sha=head_sha,
+        pull_request_number=pull_number,
+    )
+    metadata.update(routing)
+
+    if request.stage == 'prepare':
+        metadata['git_url'] = clone_url
+        metadata['git_branch'] = clone_branch
+        title = f'Prepare Forgejo task #{request.workflow.issue_number}'
+        prompt = (
+            f'Clone or refresh {request.workflow.repository} on branch {branch} '
+            'for Forgejo automation.'
+        )
+        agent_type = 'clone_repo'
+    elif request.stage == 'code':
+        title = f'Work Forgejo task #{request.workflow.issue_number}'
+        prompt = str(forgejo_task.get('prompt') or '')
+        agent_type = 'build'
+    else:
+        raise ValueError(f'unsupported direct stage: {request.stage}')
+
+    task_id = await create_and_dispatch_task(
+        workspace_id=request.workflow.workspace_id,
+        title=title,
+        prompt=prompt,
+        agent_type=agent_type,
+        priority=100,
+        model_ref='zai:glm-5.1',
+        metadata=metadata,
+        task_timeout_seconds=604800,
+        github_issue_url=metadata.get('forgejo_issue_url') or None,
+    )
+    await update_task(
+        repo=request.workflow.repository,
+        task_id=request.workflow.forgejo_task_id,
+        status='running',
+        external_task_id=str(task_id),
+        head_sha=head_sha,
+        branch=branch,
+    )
+    return ForgejoStageResult(
+        task_id=str(task_id),
+        stage=request.stage,
+        pull_request_number=pull_number,
+        branch=branch,
+        head_sha=head_sha,
+    )
+
+
+@activity.defn(name='forgejo_dispatch_review')
+@safe_activity('forgejo_dispatch_review_failed')
+async def dispatch_review(request: ForgejoStageRequest) -> ForgejoStageResult:
+    """Create a head-bound review task using the existing safety checks."""
+    from a2a_server.forgejo_automation import create_forgejo_review_task
+
+    parent = await _codetether_task(request.parent_task_id)
+    task_id = await create_forgejo_review_task(parent)
+    if not task_id:
+        raise RuntimeError('Forgejo review task was not created')
+    task = await _codetether_task(str(task_id))
+    metadata = task.get('metadata') or {}
+    return ForgejoStageResult(
+        task_id=str(task_id),
+        stage='review',
+        pull_request_number=int(metadata.get('pr_number') or 0),
+        branch=str(metadata.get('branch_name') or ''),
+        head_sha=str(metadata.get('pr_head_sha') or ''),
+    )
+
+
+@activity.defn(name='forgejo_publish_review')
+@safe_activity('forgejo_publish_review_failed')
+async def publish_review(review_task_id: str) -> str:
+    """Publish a formal Forgejo review and return only its verdict enum."""
+    from a2a_server.forgejo_automation import (
+        publish_forgejo_review,
+        reviewer_verdict,
+    )
+
+    task = await _codetether_task(review_task_id)
+    await publish_forgejo_review(task)
+    return reviewer_verdict(task)
+
+
+@activity.defn(name='forgejo_dispatch_fix')
+@safe_activity('forgejo_dispatch_fix_failed')
+async def dispatch_fix(request: ForgejoStageRequest) -> ForgejoStageResult:
+    """Create one bounded fix task after a blocking review."""
+    from a2a_server.forgejo_automation import create_forgejo_fix_followup
+
+    review_task = await _codetether_task(request.review_task_id)
+    task_id = await create_forgejo_fix_followup(review_task)
+    if not task_id:
+        raise RuntimeError('Forgejo fix task was not created')
+    task = await _codetether_task(str(task_id))
+    metadata = task.get('metadata') or {}
+    return ForgejoStageResult(
+        task_id=str(task_id),
+        stage='fix',
+        pull_request_number=int(metadata.get('pr_number') or 0),
+        branch=str(metadata.get('branch_name') or ''),
+        head_sha=str(metadata.get('pr_head_sha') or ''),
+    )
+
+
+@activity.defn(name='forgejo_cancel_task')
+@safe_activity('forgejo_cancel_task_failed')
+async def cancel_task(task_id: str) -> bool:
+    """Cancel the active CodeTether task and revoke its run lease."""
+    from a2a_server.forgejo_agent_controls import _cancel_codetether_task
+
+    return await _cancel_codetether_task(task_id)
+
+
+@activity.defn(name='forgejo_finalize_workflow')
+@safe_activity('forgejo_finalize_workflow_failed')
+async def finalize_workflow(payload: dict[str, Any]) -> None:
+    """Project a terminal workflow status into Forgejo and post one comment."""
+    from a2a_server.forgejo_agent_client import update_task
+    from a2a_server.forgejo_webhooks import _comment
+
+    repository = str(payload['repository'])
+    forgejo_task_id = int(payload['forgejo_task_id'])
+    status = str(payload['status'])
+    active_task_id = str(payload.get('active_task_id') or '')
+    await update_task(
+        repo=repository,
+        task_id=forgejo_task_id,
+        status=status,
+        external_task_id=active_task_id,
+    )
+    issue_number = int(payload.get('issue_number') or 0)
+    if issue_number:
+        base = os.environ.get('FORGEJO_API_URL', '').rstrip('/')
+        task_url = str(payload.get('task_url') or '')
+        marker = (
+            f'<!-- codetether-temporal:{forgejo_task_id}:'
+            f'{payload.get("attempt", 1)} -->'
+        )
+        body = (
+            f'## CodeTether Agent\n\nTemporal workflow finished with '
+            f'status `{status}`.'
+        )
+        if task_url:
+            body += f'\n\n[View native session]({task_url})'
+        from a2a_server.forgejo_webhooks import forgejo_json
+
+        owner, name = repository.split('/', 1)
+        comments = await forgejo_json(
+            'GET',
+            base,
+            f'/repos/{quote(owner, safe="")}/{quote(name, safe="")}'
+            f'/issues/{issue_number}/comments',
+        )
+        if not any(
+            marker in str((comment or {}).get('body') or '')
+            for comment in comments or []
+        ):
+            body += f'\n\n{marker}'
+            await _comment(base, repository, issue_number, body)

--- a/a2a_server/temporal/client.py
+++ b/a2a_server/temporal/client.py
@@ -1,0 +1,61 @@
+"""Temporal client helpers for Forgejo workflow start and signals."""
+
+from __future__ import annotations
+
+import logging
+
+from temporalio.client import WorkflowHandle
+from temporalio.common import WorkflowIDConflictPolicy
+
+from .config import get_temporal_client, temporal_settings
+from .models import (
+    ForgejoAgentWorkflowInput,
+    ForgejoControlSignal,
+    ForgejoTaskTerminalSignal,
+)
+from .workflows import ForgejoAgentWorkflow
+
+logger = logging.getLogger(__name__)
+
+
+def forgejo_workflow_id(forgejo_task_id: int) -> str:
+    """Return the stable workflow ID for one Forgejo-owned task."""
+    return f'forgejo-agent-task-{forgejo_task_id}'
+
+
+async def start_forgejo_workflow(
+    workflow_input: ForgejoAgentWorkflowInput,
+) -> str:
+    """Start or attach to the idempotent workflow for a Forgejo task."""
+    client = await get_temporal_client()
+    workflow_id = forgejo_workflow_id(workflow_input.forgejo_task_id)
+    await client.start_workflow(
+        ForgejoAgentWorkflow.run,
+        workflow_input,
+        id=workflow_id,
+        task_queue=temporal_settings().task_queue,
+        id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+    )
+    return workflow_id
+
+
+async def workflow_handle(forgejo_task_id: int) -> WorkflowHandle:
+    client = await get_temporal_client()
+    return client.get_workflow_handle(forgejo_workflow_id(forgejo_task_id))
+
+
+async def signal_task_terminal(
+    forgejo_task_id: int,
+    signal: ForgejoTaskTerminalSignal,
+) -> None:
+    """Signal one terminal CodeTether task projection into its workflow."""
+    handle = await workflow_handle(forgejo_task_id)
+    await handle.signal(ForgejoAgentWorkflow.task_terminal, signal)
+
+
+async def signal_control(
+    signal: ForgejoControlSignal,
+) -> None:
+    """Signal a signed native Forgejo cancel/retry request."""
+    handle = await workflow_handle(signal.forgejo_task_id)
+    await handle.signal(ForgejoAgentWorkflow.control, signal)

--- a/a2a_server/temporal/config.py
+++ b/a2a_server/temporal/config.py
@@ -1,0 +1,92 @@
+"""Temporal configuration and lazy client lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from temporalio.client import Client, TLSConfig
+
+
+@dataclass(frozen=True)
+class TemporalSettings:
+    enabled: bool
+    address: str
+    namespace: str
+    task_queue: str
+    tls_cert_path: str
+    tls_key_path: str
+    server_name: str
+
+    @classmethod
+    def from_env(cls) -> 'TemporalSettings':
+        return cls(
+            enabled=os.environ.get('FORGEJO_TEMPORAL_ENABLED', 'false').lower()
+            in {'1', 'true', 'yes'},
+            address=os.environ.get('TEMPORAL_ADDRESS', 'temporal:7233').strip(),
+            namespace=os.environ.get('TEMPORAL_NAMESPACE', 'default').strip(),
+            task_queue=os.environ.get(
+                'TEMPORAL_FORGEJO_TASK_QUEUE', 'codetether-forgejo-agent'
+            ).strip(),
+            tls_cert_path=os.environ.get('TEMPORAL_TLS_CERT', '').strip(),
+            tls_key_path=os.environ.get('TEMPORAL_TLS_KEY', '').strip(),
+            server_name=os.environ.get('TEMPORAL_TLS_SERVER_NAME', '').strip(),
+        )
+
+
+def temporal_settings() -> TemporalSettings:
+    """Read current settings so tests and runtime flags remain dynamic."""
+    return TemporalSettings.from_env()
+
+
+def _tls_config(settings: TemporalSettings) -> TLSConfig | bool:
+    if not settings.tls_cert_path and not settings.tls_key_path:
+        return False
+    if not settings.tls_cert_path or not settings.tls_key_path:
+        raise RuntimeError(
+            'TEMPORAL_TLS_CERT and TEMPORAL_TLS_KEY must be configured together'
+        )
+    return TLSConfig(
+        client_cert=Path(settings.tls_cert_path).read_bytes(),
+        client_private_key=Path(settings.tls_key_path).read_bytes(),
+        domain=settings.server_name or None,
+    )
+
+
+_CLIENT: Client | None = None
+_CLIENT_KEY: tuple[str, str, str, str, str] | None = None
+_CLIENT_LOCK = asyncio.Lock()
+
+
+async def get_temporal_client() -> Client:
+    """Return one process-local Temporal client for the active configuration."""
+    global _CLIENT, _CLIENT_KEY
+    settings = temporal_settings()
+    if not settings.enabled:
+        raise RuntimeError('Forgejo Temporal orchestration is disabled')
+    key = (
+        settings.address,
+        settings.namespace,
+        settings.tls_cert_path,
+        settings.tls_key_path,
+        settings.server_name,
+    )
+    async with _CLIENT_LOCK:
+        if _CLIENT is None or _CLIENT_KEY != key:
+            _CLIENT = await Client.connect(
+                settings.address,
+                namespace=settings.namespace,
+                tls=_tls_config(settings),
+            )
+            _CLIENT_KEY = key
+        return _CLIENT
+
+
+def reset_temporal_client() -> None:
+    """Forget the cached client; intended for tests and controlled shutdown."""
+    global _CLIENT, _CLIENT_KEY
+    _CLIENT = None
+    _CLIENT_KEY = None

--- a/a2a_server/temporal/models.py
+++ b/a2a_server/temporal/models.py
@@ -1,0 +1,80 @@
+"""Deterministic, non-sensitive Temporal workflow data contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ForgejoAgentWorkflowInput:
+    """Identifiers needed to orchestrate one Forgejo task attempt.
+
+    Prompts, credentials, transcripts, tool payloads, and repository clone URLs
+    are deliberately excluded from Temporal workflow history. Activities load
+    those values from CodeTether/Forgejo using these identifiers.
+    """
+
+    forgejo_task_id: int
+    repository: str
+    issue_number: int
+    pull_request_number: int
+    workspace_id: str
+    branch: str
+    head_sha: str
+    operation: str
+    attempt: int = 1
+
+
+@dataclass(frozen=True)
+class ForgejoStageRequest:
+    workflow: ForgejoAgentWorkflowInput
+    workflow_id: str
+    stage: str
+    parent_task_id: str = ''
+    review_task_id: str = ''
+    fix_attempt: int = 0
+
+
+@dataclass(frozen=True)
+class ForgejoStageResult:
+    task_id: str
+    stage: str
+    pull_request_number: int = 0
+    branch: str = ''
+    head_sha: str = ''
+
+
+@dataclass(frozen=True)
+class ForgejoTaskTerminalSignal:
+    """Small terminal projection sent from CodeTether's task-status hook."""
+
+    task_id: str
+    stage: str
+    status: str
+    session_id: str = ''
+    verdict: str = ''
+    head_sha: str = ''
+    pull_request_number: int = 0
+
+
+@dataclass(frozen=True)
+class ForgejoControlSignal:
+    """Authenticated Forgejo control delivered to a running workflow."""
+
+    action: str
+    forgejo_task_id: int
+    requested_by: str = ''
+    request_id: str = ''
+
+
+@dataclass
+class ForgejoAgentWorkflowResult:
+    """Terminal non-sensitive workflow result."""
+
+    forgejo_task_id: int
+    attempt: int
+    status: str
+    active_task_id: str = ''
+    completed_stages: list[str] = field(default_factory=list)
+    review_verdict: str = ''
+    error_type: str = ''

--- a/a2a_server/temporal/worker.py
+++ b/a2a_server/temporal/worker.py
@@ -1,0 +1,58 @@
+"""Dedicated Temporal worker process for Forgejo agent workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from temporalio.worker import Worker
+
+from .activities import (
+    cancel_task,
+    dispatch_fix,
+    dispatch_review,
+    dispatch_stage,
+    finalize_workflow,
+    publish_review,
+)
+from .config import get_temporal_client, temporal_settings
+from .workflows import ForgejoAgentWorkflow
+
+logger = logging.getLogger(__name__)
+
+
+async def run_worker() -> None:
+    settings = temporal_settings()
+    if not settings.enabled:
+        raise RuntimeError(
+            'FORGEJO_TEMPORAL_ENABLED must be true for the worker'
+        )
+    client = await get_temporal_client()
+    worker = Worker(
+        client,
+        task_queue=settings.task_queue,
+        workflows=[ForgejoAgentWorkflow],
+        activities=[
+            dispatch_stage,
+            dispatch_review,
+            publish_review,
+            dispatch_fix,
+            cancel_task,
+            finalize_workflow,
+        ],
+    )
+    logger.info(
+        'Starting Forgejo Temporal worker namespace=%s queue=%s',
+        settings.namespace,
+        settings.task_queue,
+    )
+    await worker.run()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(run_worker())
+
+
+if __name__ == '__main__':
+    main()

--- a/a2a_server/temporal/workflows.py
+++ b/a2a_server/temporal/workflows.py
@@ -1,0 +1,300 @@
+"""Deterministic Temporal workflows for Forgejo coding-agent tasks."""
+
+from __future__ import annotations
+
+import asyncio
+
+from datetime import timedelta
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+from temporalio.exceptions import ActivityError, ApplicationError
+
+with workflow.unsafe.imports_passed_through():
+    from .activities import (
+        cancel_task,
+        dispatch_fix,
+        dispatch_review,
+        dispatch_stage,
+        finalize_workflow,
+        publish_review,
+    )
+    from .models import (
+        ForgejoAgentWorkflowInput,
+        ForgejoAgentWorkflowResult,
+        ForgejoControlSignal,
+        ForgejoStageRequest,
+        ForgejoStageResult,
+        ForgejoTaskTerminalSignal,
+    )
+
+_ACTIVITY_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=2),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(minutes=1),
+    maximum_attempts=5,
+)
+_TERMINAL_STATUSES = {'completed', 'failed', 'cancelled'}
+_BLOCKING_VERDICTS = {'CHANGES_REQUESTED', 'BLOCKED'}
+
+
+@workflow.defn(name='ForgejoAgentWorkflow')
+class ForgejoAgentWorkflow:
+    """Durably orchestrate one Forgejo task without sensitive history data."""
+
+    def __init__(self) -> None:
+        self._terminal: dict[str, ForgejoTaskTerminalSignal] = {}
+        self._cancel_requested = False
+        self._retry_requested = False
+        self._active_task_id = ''
+        self._completed_stages: list[str] = []
+        self._review_verdict = ''
+
+    @workflow.signal(name='task_terminal')
+    async def task_terminal(self, signal: ForgejoTaskTerminalSignal) -> None:
+        if signal.status in _TERMINAL_STATUSES:
+            self._terminal[signal.task_id] = signal
+
+    @workflow.signal(name='control')
+    async def control(self, signal: ForgejoControlSignal) -> None:
+        if signal.action == 'cancel':
+            self._cancel_requested = True
+        elif signal.action == 'retry':
+            self._retry_requested = True
+            self._cancel_requested = True
+
+    @workflow.query(name='state')
+    def state(self) -> dict[str, Any]:
+        return {
+            'active_task_id': self._active_task_id,
+            'completed_stages': list(self._completed_stages),
+            'review_verdict': self._review_verdict,
+            'cancel_requested': self._cancel_requested,
+            'retry_requested': self._retry_requested,
+        }
+
+    async def _activity(
+        self, fn, arg, *, timeout: timedelta = timedelta(minutes=5)
+    ):
+        return await workflow.execute_activity(
+            fn,
+            arg,
+            start_to_close_timeout=timeout,
+            retry_policy=_ACTIVITY_RETRY,
+        )
+
+    async def _wait_terminal(
+        self, stage: ForgejoStageResult
+    ) -> ForgejoTaskTerminalSignal:
+        self._active_task_id = stage.task_id
+        try:
+            await workflow.wait_condition(
+                lambda: (
+                    stage.task_id in self._terminal or self._cancel_requested
+                ),
+                timeout=timedelta(days=7),
+            )
+        except asyncio.TimeoutError:
+            await self._activity(
+                cancel_task, stage.task_id, timeout=timedelta(minutes=2)
+            )
+            return ForgejoTaskTerminalSignal(
+                task_id=stage.task_id,
+                stage=stage.stage,
+                status='failed',
+            )
+        if self._cancel_requested:
+            await self._activity(
+                cancel_task, stage.task_id, timeout=timedelta(minutes=2)
+            )
+            return ForgejoTaskTerminalSignal(
+                task_id=stage.task_id,
+                stage=stage.stage,
+                status='cancelled',
+            )
+        terminal = self._terminal.pop(stage.task_id)
+        if terminal.status == 'completed':
+            self._completed_stages.append(stage.stage)
+        return terminal
+
+    async def _finalize(
+        self,
+        workflow_input: ForgejoAgentWorkflowInput,
+        status: str,
+        *,
+        error_type: str = '',
+    ) -> ForgejoAgentWorkflowResult:
+        await self._activity(
+            finalize_workflow,
+            {
+                'repository': workflow_input.repository,
+                'forgejo_task_id': workflow_input.forgejo_task_id,
+                'issue_number': workflow_input.issue_number,
+                'attempt': workflow_input.attempt,
+                'status': status,
+                'active_task_id': self._active_task_id,
+            },
+        )
+        return ForgejoAgentWorkflowResult(
+            forgejo_task_id=workflow_input.forgejo_task_id,
+            attempt=workflow_input.attempt,
+            status=status,
+            active_task_id=self._active_task_id,
+            completed_stages=list(self._completed_stages),
+            review_verdict=self._review_verdict,
+            error_type=error_type,
+        )
+
+    def _next_attempt(
+        self, workflow_input: ForgejoAgentWorkflowInput
+    ) -> ForgejoAgentWorkflowInput:
+        return ForgejoAgentWorkflowInput(
+            forgejo_task_id=workflow_input.forgejo_task_id,
+            repository=workflow_input.repository,
+            issue_number=workflow_input.issue_number,
+            pull_request_number=workflow_input.pull_request_number,
+            workspace_id=workflow_input.workspace_id,
+            branch=workflow_input.branch,
+            head_sha=workflow_input.head_sha,
+            operation=workflow_input.operation,
+            attempt=workflow_input.attempt + 1,
+        )
+
+    async def _finish_attempt(
+        self,
+        workflow_input: ForgejoAgentWorkflowInput,
+        status: str,
+        *,
+        error_type: str,
+    ) -> ForgejoAgentWorkflowResult:
+        result = await self._finalize(
+            workflow_input, status, error_type=error_type
+        )
+        if status not in {'failed', 'cancelled'}:
+            return result
+        if not self._retry_requested:
+            try:
+                await workflow.wait_condition(
+                    lambda: self._retry_requested,
+                    timeout=timedelta(days=7),
+                )
+            except asyncio.TimeoutError:
+                return result
+        workflow.continue_as_new(self._next_attempt(workflow_input))
+        return result
+
+    async def _stage(
+        self,
+        workflow_input: ForgejoAgentWorkflowInput,
+        stage: str,
+        *,
+        parent_task_id: str = '',
+        review_task_id: str = '',
+        fix_attempt: int = 0,
+    ) -> tuple[ForgejoStageResult, ForgejoTaskTerminalSignal]:
+        request = ForgejoStageRequest(
+            workflow=workflow_input,
+            workflow_id=workflow.info().workflow_id,
+            stage=stage,
+            parent_task_id=parent_task_id,
+            review_task_id=review_task_id,
+            fix_attempt=fix_attempt,
+        )
+        if stage in {'prepare', 'code'}:
+            result = await self._activity(dispatch_stage, request)
+        elif stage == 'review':
+            result = await self._activity(dispatch_review, request)
+        elif stage == 'fix':
+            result = await self._activity(dispatch_fix, request)
+        else:
+            raise ValueError(f'unsupported Forgejo stage: {stage}')
+        return result, await self._wait_terminal(result)
+
+    async def _run_attempt(
+        self, workflow_input: ForgejoAgentWorkflowInput
+    ) -> ForgejoAgentWorkflowResult:
+        prepare, terminal = await self._stage(workflow_input, 'prepare')
+        if terminal.status != 'completed':
+            return await self._finish_attempt(
+                workflow_input,
+                terminal.status,
+                error_type='prepare_failed',
+            )
+
+        code, terminal = await self._stage(
+            workflow_input, 'code', parent_task_id=prepare.task_id
+        )
+        if terminal.status != 'completed':
+            return await self._finish_attempt(
+                workflow_input, terminal.status, error_type='code_failed'
+            )
+
+        parent_task_id = code.task_id
+        for fix_attempt in range(0, 3):
+            review, terminal = await self._stage(
+                workflow_input,
+                'review',
+                parent_task_id=parent_task_id,
+                fix_attempt=fix_attempt,
+            )
+            if terminal.status != 'completed':
+                return await self._finish_attempt(
+                    workflow_input,
+                    terminal.status,
+                    error_type='review_failed',
+                )
+            self._review_verdict = await self._activity(
+                publish_review, review.task_id
+            )
+            if self._review_verdict == 'APPROVED':
+                return await self._finalize(workflow_input, 'completed')
+            if self._review_verdict not in _BLOCKING_VERDICTS:
+                return await self._finish_attempt(
+                    workflow_input,
+                    'failed',
+                    error_type='review_unresolved',
+                )
+            if fix_attempt >= 2:
+                return await self._finish_attempt(
+                    workflow_input,
+                    'failed',
+                    error_type='fix_attempts_exhausted',
+                )
+            fix, terminal = await self._stage(
+                workflow_input,
+                'fix',
+                parent_task_id=parent_task_id,
+                review_task_id=review.task_id,
+                fix_attempt=fix_attempt + 1,
+            )
+            if terminal.status != 'completed':
+                return await self._finish_attempt(
+                    workflow_input,
+                    terminal.status,
+                    error_type='fix_failed',
+                )
+            parent_task_id = fix.task_id
+
+        return await self._finish_attempt(
+            workflow_input, 'failed', error_type='workflow_exhausted'
+        )
+
+    @workflow.run
+    async def run(
+        self, workflow_input: ForgejoAgentWorkflowInput
+    ) -> ForgejoAgentWorkflowResult:
+        try:
+            return await self._run_attempt(workflow_input)
+        except ActivityError as error:
+            cause = error.cause
+            error_type = (
+                cause.type
+                if isinstance(cause, ApplicationError) and cause.type
+                else 'activity_failed'
+            )
+            return await self._finish_attempt(
+                workflow_input,
+                'failed',
+                error_type=error_type,
+            )

--- a/chart/a2a-server/charts/docs/values.yaml
+++ b/chart/a2a-server/charts/docs/values.yaml
@@ -9,12 +9,12 @@ rolloutId: ""
 podAnnotations: {}
 
 image:
-  repository: us-central1-docker.pkg.dev/spotlessbinco/codetether/codetether-docs
+  repository: registry.quantum-forge.net/cluster-ci-cache/codetether-docs
   pullPolicy: Always
   tag: "latest"
 
 imagePullSecrets:
-  - name: gcp-artifact-registry
+  - name: registry-credentials
 
 service:
   type: ClusterIP

--- a/chart/a2a-server/charts/marketing/values.yaml
+++ b/chart/a2a-server/charts/marketing/values.yaml
@@ -9,12 +9,12 @@ rolloutId: ""
 podAnnotations: {}
 
 image:
-  repository: us-central1-docker.pkg.dev/spotlessbinco/codetether/codetether-marketing
+  repository: registry.quantum-forge.net/cluster-ci-cache/codetether-marketing
   pullPolicy: Always
   tag: "latest"
 
 imagePullSecrets:
-  - name: gcp-artifact-registry
+  - name: registry-credentials
 
 service:
   type: ClusterIP

--- a/chart/a2a-server/examples/values-argocd-prod.yaml
+++ b/chart/a2a-server/examples/values-argocd-prod.yaml
@@ -103,6 +103,9 @@ auth:
 secret:
   create: false
 
+existingEnvFromSecrets:
+  - harvester-api-keys
+
 envFromSecret:
   A2A_AUTH_TOKENS: a2a-server-auth-tokens
 

--- a/chart/a2a-server/examples/values-argocd-prod.yaml
+++ b/chart/a2a-server/examples/values-argocd-prod.yaml
@@ -10,12 +10,12 @@ app:
   enhanced: true
 
 image:
-  repository: us-central1-docker.pkg.dev/spotlessbinco/codetether/a2a-server-mcp
+  repository: registry.quantum-forge.net/cluster-ci-cache/a2a-server-mcp
   tag: "main-d518d97"
   pullPolicy: Always
 
 imagePullSecrets:
-  - name: gcp-artifact-registry
+  - name: registry-credentials
 
 # Use the deterministic blue/green chart path for GitOps. The legacy
 # non-blue/green deployment path uses a random Helm annotation, which causes
@@ -32,6 +32,11 @@ blueGreen:
     legacy: ""
     blue: ""
     green: "claimfix-20260506-152900"
+
+forgejo:
+  existingSecret: codetether-a2a-server-forgejo
+  apiUrl: https://forgejo.quantum-forge.io/api/v1
+  botUsername: codetether
 
 service:
   type: ClusterIP

--- a/chart/a2a-server/templates/configmap.yaml
+++ b/chart/a2a-server/templates/configmap.yaml
@@ -58,6 +58,14 @@ data:
   # RLS is enabled by default for multi-tenant isolation
   RLS_ENABLED: "true"
 
+  # Durable Forgejo Temporal orchestration (non-secret client settings)
+  FORGEJO_TEMPORAL_ENABLED: {{ .Values.temporal.enabled | quote }}
+  {{- if .Values.temporal.enabled }}
+  TEMPORAL_ADDRESS: {{ required "temporal.address is required when temporal.enabled=true" .Values.temporal.address | quote }}
+  TEMPORAL_NAMESPACE: {{ .Values.temporal.namespace | quote }}
+  TEMPORAL_FORGEJO_TASK_QUEUE: {{ .Values.temporal.taskQueue | quote }}
+  {{- end }}
+
   # Database persistence paths (use mounted volume for persistence across restarts)
   {{- if .Values.persistence.enabled }}
   MONITOR_DB_PATH: "{{ .Values.persistence.mountPath }}/monitor.db"

--- a/chart/a2a-server/templates/deployment.yaml
+++ b/chart/a2a-server/templates/deployment.yaml
@@ -95,6 +95,10 @@ spec:
             - secretRef:
                 name: {{ include "a2a-server.githubAppSecretName" . }}
             {{- end }}
+            {{- if .Values.forgejo.existingSecret }}
+            - secretRef:
+                name: {{ .Values.forgejo.existingSecret }}
+            {{- end }}
           env:
             {{- if .Values.opa.enabled }}
             - name: OPA_URL
@@ -120,6 +124,12 @@ spec:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.forgejo.apiUrl }}
+            - name: FORGEJO_API_URL
+              value: {{ .Values.forgejo.apiUrl | quote }}
+            - name: FORGEJO_BOT_USERNAME
+              value: {{ .Values.forgejo.botUsername | default "codetether" | quote }}
             {{- end }}
             {{- if .Values.minio.enabled }}
             - name: MINIO_ENDPOINT
@@ -393,6 +403,14 @@ spec:
             - secretRef:
                 name: {{ include "a2a-server.fullname" . }}-stripe
             {{- end }}
+            {{- if or .Values.githubApp.existingSecret .Values.githubApp.appId .Values.githubApp.privateKey .Values.githubApp.webhookSecret }}
+            - secretRef:
+                name: {{ include "a2a-server.githubAppSecretName" . }}
+            {{- end }}
+            {{- if .Values.forgejo.existingSecret }}
+            - secretRef:
+                name: {{ .Values.forgejo.existingSecret }}
+            {{- end }}
           env:
             {{- if .Values.opa.enabled }}
             - name: OPA_URL
@@ -418,6 +436,12 @@ spec:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.forgejo.apiUrl }}
+            - name: FORGEJO_API_URL
+              value: {{ .Values.forgejo.apiUrl | quote }}
+            - name: FORGEJO_BOT_USERNAME
+              value: {{ .Values.forgejo.botUsername | default "codetether" | quote }}
             {{- end }}
             {{- if .Values.minio.enabled }}
             - name: MINIO_ENDPOINT
@@ -635,6 +659,14 @@ spec:
             - secretRef:
                 name: {{ include "a2a-server.fullname" $ }}-stripe
             {{- end }}
+            {{- if or $.Values.githubApp.existingSecret $.Values.githubApp.appId $.Values.githubApp.privateKey $.Values.githubApp.webhookSecret }}
+            - secretRef:
+                name: {{ include "a2a-server.githubAppSecretName" $ }}
+            {{- end }}
+            {{- if $.Values.forgejo.existingSecret }}
+            - secretRef:
+                name: {{ $.Values.forgejo.existingSecret }}
+            {{- end }}
           env:
             {{- if $.Values.opa.enabled }}
             - name: OPA_URL
@@ -660,6 +692,12 @@ spec:
             {{- range $key, $value := $.Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
+            {{- if $.Values.forgejo.apiUrl }}
+            - name: FORGEJO_API_URL
+              value: {{ $.Values.forgejo.apiUrl | quote }}
+            - name: FORGEJO_BOT_USERNAME
+              value: {{ $.Values.forgejo.botUsername | default "codetether" | quote }}
             {{- end }}
             {{- if $.Values.minio.enabled }}
             - name: MINIO_ENDPOINT

--- a/chart/a2a-server/templates/deployment.yaml
+++ b/chart/a2a-server/templates/deployment.yaml
@@ -75,6 +75,10 @@ spec:
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           envFrom:
+            {{- range .Values.existingEnvFromSecrets }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
             {{- if .Values.configMap.create }}
             - configMapRef:
                 name: {{ include "a2a-server.fullname" . }}-config
@@ -387,6 +391,10 @@ spec:
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           envFrom:
+            {{- range .Values.existingEnvFromSecrets }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
             {{- if .Values.configMap.create }}
             - configMapRef:
                 name: {{ include "a2a-server.fullname" . }}-config
@@ -643,6 +651,10 @@ spec:
           startupProbe:
             {{- toYaml $.Values.startupProbe | nindent 12 }}
           envFrom:
+            {{- range $.Values.existingEnvFromSecrets }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
             {{- if $.Values.configMap.create }}
             - configMapRef:
                 name: {{ include "a2a-server.fullname" $ }}-config

--- a/chart/a2a-server/templates/temporal-worker.yaml
+++ b/chart/a2a-server/templates/temporal-worker.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.temporal.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "a2a-server.fullname" . }}-temporal-worker
+  labels:
+    {{- include "a2a-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: temporal-worker
+spec:
+  replicas: {{ .Values.temporal.replicas }}
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "a2a-server.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: temporal-worker
+  template:
+    metadata:
+      labels:
+        {{- include "a2a-server.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: temporal-worker
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "a2a-server.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: temporal-worker
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "a2a-server.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-m", "a2a_server.temporal.worker"]
+          envFrom:
+            {{- range .Values.existingEnvFromSecrets }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- if .Values.configMap.create }}
+            - configMapRef:
+                name: {{ include "a2a-server.fullname" . }}-config
+            {{- end }}
+            {{- if .Values.forgejo.existingSecret }}
+            - secretRef:
+                name: {{ .Values.forgejo.existingSecret }}
+            {{- end }}
+          env:
+            - name: FORGEJO_TEMPORAL_ENABLED
+              value: "true"
+            - name: TEMPORAL_ADDRESS
+              value: {{ required "temporal.address is required when temporal.enabled=true" .Values.temporal.address | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ .Values.temporal.namespace | quote }}
+            - name: TEMPORAL_FORGEJO_TASK_QUEUE
+              value: {{ .Values.temporal.taskQueue | quote }}
+            {{- if .Values.forgejo.apiUrl }}
+            - name: FORGEJO_API_URL
+              value: {{ .Values.forgejo.apiUrl | quote }}
+            - name: FORGEJO_BOT_USERNAME
+              value: {{ .Values.forgejo.botUsername | default "codetether" | quote }}
+            {{- end }}
+            {{- if .Values.externalPostgresql.url }}
+            - name: DATABASE_URL
+              value: {{ .Values.externalPostgresql.url | quote }}
+            {{- else if .Values.externalPostgresql.existingSecret }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalPostgresql.existingSecret }}
+                  key: {{ .Values.externalPostgresql.secretKey }}
+            {{- end }}
+            {{- range $key, $value := .Values.envFromSecret }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $value }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.temporal.tls.enabled }}
+            - name: TEMPORAL_TLS_CERT
+              value: /var/run/temporal-tls/{{ .Values.temporal.tls.certKey }}
+            - name: TEMPORAL_TLS_KEY
+              value: /var/run/temporal-tls/{{ .Values.temporal.tls.privateKeyKey }}
+            - name: TEMPORAL_TLS_SERVER_NAME
+              value: {{ .Values.temporal.tls.serverName | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.temporal.resources | nindent 12 }}
+          {{- if .Values.temporal.tls.enabled }}
+          volumeMounts:
+            - name: temporal-tls
+              mountPath: /var/run/temporal-tls
+              readOnly: true
+          {{- end }}
+      {{- if .Values.temporal.tls.enabled }}
+      volumes:
+        - name: temporal-tls
+          secret:
+            secretName: {{ required "temporal.existingSecret is required when temporal.tls.enabled=true" .Values.temporal.existingSecret }}
+      {{- end }}
+{{- end }}

--- a/chart/a2a-server/values.yaml
+++ b/chart/a2a-server/values.yaml
@@ -268,6 +268,27 @@ forgejo:
   apiUrl: ""
   botUsername: "codetether"
 
+# Durable Forgejo orchestration. Disabled by default for safe rollout.
+temporal:
+  enabled: false
+  address: "temporal-frontend.temporal.svc.cluster.local:7233"
+  namespace: "default"
+  taskQueue: "codetether-forgejo-agent"
+  replicas: 1
+  existingSecret: ""
+  tls:
+    enabled: false
+    certKey: "tls.crt"
+    privateKeyKey: "tls.key"
+    serverName: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
 # PostgreSQL configuration for durable persistence
 # This provides durable storage for workers, codebases, tasks, and sessions
 # that survives pod restarts and works across multiple replicas.

--- a/chart/a2a-server/values.yaml
+++ b/chart/a2a-server/values.yaml
@@ -236,7 +236,10 @@ env:
   WORKER_INFRA_CACHE_TTL_SECONDS: "30"
   WORKER_INFRA_NODE_MAP: ""
 
-# Environment variables from secrets
+# Import every key from existing Kubernetes secrets into server containers.
+existingEnvFromSecrets: []
+
+# Environment variables from individual secret keys
 envFromSecret: {}
 # Example:
 # envFromSecret:

--- a/chart/a2a-server/values.yaml
+++ b/chart/a2a-server/values.yaml
@@ -17,12 +17,12 @@ app:
 
 # Image configuration
 image:
-  repository: us-central1-docker.pkg.dev/spotlessbinco/codetether/a2a-server-mcp
+  repository: registry.quantum-forge.net/cluster-ci-cache/a2a-server-mcp
   pullPolicy: Always
   tag: "latest"
 
 imagePullSecrets:
-  - name: gcp-artifact-registry
+  - name: registry-credentials
 nameOverride: ""
 fullnameOverride: ""
 
@@ -259,6 +259,12 @@ githubApp:
   webhookSecret: ""
   apiBaseUrl: "https://api.github.com"
 
+# Native Forgejo @codetether integration. Credentials belong in existingSecret.
+forgejo:
+  existingSecret: ""
+  apiUrl: ""
+  botUsername: "codetether"
+
 # PostgreSQL configuration for durable persistence
 # This provides durable storage for workers, codebases, tasks, and sessions
 # that survives pod restarts and works across multiple replicas.
@@ -453,7 +459,7 @@ knative:
   worker:
     # Default uses Google Artifact Registry with versioned tag.
     # Override with --set-string knative.worker.image=<registry>/<image>:<tag>
-    image: "us-central1-docker.pkg.dev/spotlessbinco/codetether/codetether-worker:latest"
+    image: "registry.quantum-forge.net/cluster-ci-cache/codetether-worker:latest"
     # ServiceAccount used by Knative session workers.
     # This ServiceAccount must be bound to the Vault Kubernetes auth role below.
     serviceAccountName: "codetether-worker"
@@ -567,9 +573,9 @@ vmWorkspaces:
 marketing:
   enabled: false
   imagePullSecrets:
-    - name: gcp-artifact-registry
+    - name: registry-credentials
   image:
-    repository: us-central1-docker.pkg.dev/spotlessbinco/codetether/codetether-marketing
+    repository: registry.quantum-forge.net/cluster-ci-cache/codetether-marketing
     pullPolicy: Always
     tag: "latest"
   replicaCount: 1
@@ -608,9 +614,9 @@ marketing:
 docs:
   enabled: false
   imagePullSecrets:
-    - name: gcp-artifact-registry
+    - name: registry-credentials
   image:
-    repository: us-central1-docker.pkg.dev/spotlessbinco/codetether/codetether-docs
+    repository: registry.quantum-forge.net/cluster-ci-cache/codetether-docs
     pullPolicy: Always
     tag: "latest"
   replicaCount: 1
@@ -748,7 +754,7 @@ harvester:
   # If empty, falls back to .Values.image.repository (the Python server image, which
   # does NOT contain the codetether binary).
   image:
-    repository: "us-central1-docker.pkg.dev/spotlessbinco/codetether/codetether-worker"
+    repository: "registry.quantum-forge.net/cluster-ci-cache/codetether-worker"
     tag: "latest"
     pullPolicy: ""   # defaults to .Values.image.pullPolicy
   storage:

--- a/deploy/argocd/application.yaml
+++ b/deploy/argocd/application.yaml
@@ -106,6 +106,8 @@ spec:
         githubApp:
           existingSecret: codetether-a2a-server-github-app
           apiBaseUrl: https://api.github.com
+        existingEnvFromSecrets:
+          - harvester-api-keys
         envFromSecret:
           A2A_AUTH_TOKENS: a2a-server-auth-tokens
           GITHUB_APP_API_BASE_URL: codetether-a2a-server-github-app

--- a/docs/forgejo-codetether-webhook.md
+++ b/docs/forgejo-codetether-webhook.md
@@ -1,0 +1,65 @@
+# Forgejo `@codetether` webhook
+
+CodeTether exposes a native Forgejo-compatible webhook at:
+
+```text
+POST /v1/webhooks/forgejo
+```
+
+It accepts both Forgejo (`X-Forgejo-*`) and Gitea-compatible (`X-Gitea-*`) event headers. Issue comments and pull-request conversation comments containing an actionable request such as `@codetether handle this issue` create a durable clone/build task and receive an acknowledgement comment.
+
+## CodeTether configuration
+
+Configure these variables on the A2A server deployment:
+
+| Variable | Required | Description |
+|---|---:|---|
+| `FORGEJO_API_URL` | yes | Forgejo API root, e.g. `https://forge.example/api/v1`. Its HTTPS host is also added to the git clone allowlist. |
+| `FORGEJO_TOKEN` | yes | Token for the CodeTether bot account. Store it in a Kubernetes Secret or Vault-backed environment source. |
+| `FORGEJO_WEBHOOK_SECRET` | yes | Shared HMAC-SHA256 webhook secret. |
+| `FORGEJO_BOT_USERNAME` | no | Bot login used for loop prevention; defaults to `codetether`. |
+
+The bot token needs repository read/write access, issue read/write access, and pull-request read/write access. It must be able to clone, push branches, create pull requests, and post issue/PR comments.
+
+## Forgejo repository webhook
+
+In **Repository settings → Webhooks → Add webhook → Forgejo**, configure:
+
+- **Target URL:** `https://<codetether-host>/v1/webhooks/forgejo`
+- **HTTP method:** `POST`
+- **Content type:** `application/json`
+- **Secret:** the same value as `FORGEJO_WEBHOOK_SECRET`
+- **Events:** Issue comment events (Forgejo PR conversation comments use the issue-comment payload)
+- **Active:** enabled
+
+Use Forgejo's webhook test delivery and confirm an HTTP 200 response. A bad signature returns 401; missing server configuration returns 503.
+
+## Supported behavior
+
+- New actionable mentions dispatch work.
+- Editing a comment to add the first mention dispatches work.
+- Editing an already-mentioned comment does not dispatch duplicate work.
+- Bot-authored comments are ignored to prevent loops.
+- Non-actionable mentions receive guidance.
+- Active work for the same repository issue/PR is deduplicated.
+- Issue requests create a `codetether/issue-<number>` branch and instruct the worker to open a Forgejo PR.
+- PR requests target the current PR head branch.
+- Forgejo metadata remains tagged as `source=forgejo-webhook` and `platform=forgejo`; it is not represented as GitHub work.
+
+## Smoke test
+
+Post this in a Forgejo issue or PR conversation:
+
+```text
+@codetether handle this issue
+```
+
+Expected immediate reply:
+
+```text
+## 🛠️ CodeTether Fix
+
+Picked this up. I'm preparing the Forgejo workspace and will report progress here.
+```
+
+Then confirm a task with metadata `source=forgejo-webhook`, the expected repository and issue number, and a connected worker with the `persistent-workspace` capability.

--- a/docs/operations/forgejo-temporal-orchestration.md
+++ b/docs/operations/forgejo-temporal-orchestration.md
@@ -1,0 +1,124 @@
+# Forgejo agent orchestration with Temporal
+
+Temporal is the durable source of truth for Forgejo coding-agent stage
+transitions. Forgejo remains the authenticated repository-scoped read model for
+tasks, events, controls, issue/PR links, and session pages. CodeTether remains
+the execution backend.
+
+## Security boundary
+
+Workflow history may contain only:
+
+- Forgejo task/repository/issue/PR identifiers;
+- CodeTether task/session identifiers;
+- branch and commit SHA;
+- stage/status/verdict enums; and
+- bounded attempt counters.
+
+Prompts, credentials, clone URLs, transcripts, tool inputs/results, environment
+maps, and provider payloads are loaded inside activities and must never be
+returned to workflow history. Full transcripts remain in CodeTether storage;
+redacted events are projected into Forgejo.
+
+## CodeTether configuration
+
+The API and dedicated Temporal worker require:
+
+```text
+FORGEJO_TEMPORAL_ENABLED=true
+TEMPORAL_ADDRESS=temporal-frontend.temporal.svc.cluster.local:7233
+TEMPORAL_NAMESPACE=default
+TEMPORAL_FORGEJO_TASK_QUEUE=codetether-forgejo-agent
+FORGEJO_API_URL=https://forgejo.example/api/v1
+FORGEJO_TOKEN=<secret>
+FORGEJO_WEBHOOK_SECRET=<shared control HMAC secret>
+DATABASE_URL=<secret>
+```
+
+For mTLS, also set `TEMPORAL_TLS_CERT`, `TEMPORAL_TLS_KEY`, and optionally
+`TEMPORAL_TLS_SERVER_NAME`. Mount certificate/key files read-only.
+
+The Helm chart values are:
+
+```yaml
+temporal:
+  enabled: true
+  address: temporal-frontend.temporal.svc.cluster.local:7233
+  namespace: default
+  taskQueue: codetether-forgejo-agent
+  replicas: 1
+```
+
+`temporal.enabled=false` is the default. Enabling it creates the dedicated
+`<release>-temporal-worker` Deployment and configures all API deployment modes
+to start/signal workflows.
+
+## Forgejo configuration
+
+Forgejo sends native Cancel/Retry controls to CodeTether with HMAC-SHA256 over
+the exact JSON request body:
+
+```ini
+[codetether]
+CONTROL_URL = https://api.codetether.run/v1/webhooks/forgejo/agent-control
+CONTROL_SECRET = <same value as CodeTether FORGEJO_WEBHOOK_SECRET>
+```
+
+The URL must use HTTPS (loopback HTTP is accepted for tests only). When
+`CONTROL_URL` is configured, delivery is fail-closed: Forgejo changes no task
+state unless CodeTether returns a 2xx response. Requests expire after five
+minutes. Repeated cancel/retry signals are idempotent at workflow state level.
+
+## Rollout order
+
+1. Create the Temporal namespace and retention policy.
+2. Store Temporal TLS material, Forgejo token, database URL, and control HMAC in
+   Kubernetes Secrets. Never place them in Helm values or workflow arguments.
+3. Deploy the CodeTether image with `temporalio` installed while
+   `temporal.enabled=false`.
+4. Enable the worker only and verify one poller is attached to
+   `codetether-forgejo-agent`.
+5. Configure Forgejo `[codetether]` control delivery.
+6. Enable `FORGEJO_TEMPORAL_ENABLED` on one canary CodeTether API deployment.
+7. Run one private-repository task through prepare, code, review, and terminal
+   projection. Verify the native Forgejo session page and Temporal history.
+8. Exercise Cancel during an active stage and Retry after a failed attempt.
+9. Expand API traffic only after the canary succeeds.
+
+Do not enable both the legacy Forgejo control poller and Temporal control path.
+The application disables the legacy control poller when
+`FORGEJO_TEMPORAL_ENABLED=true`, and legacy terminal review reconciliation
+explicitly excludes Temporal-managed tasks.
+
+## Canary acceptance evidence
+
+Capture:
+
+- Temporal namespace, workflow ID, run ID, task queue, and terminal status;
+- CodeTether API/worker image digest and pod names;
+- Forgejo repository/task ID and native session URL;
+- prepare/code/review/fix task IDs as applicable;
+- redacted event count and proof that sensitive sentinel strings are absent;
+- Cancel activity observation and Retry `continue_as_new` attempt number;
+- worker/API restart counts and post-canary health.
+
+Never publish raw Temporal history if it contains unexpected sensitive data.
+Treat such a finding as a release blocker and purge the canary namespace/history
+according to the Temporal environment's retention/deletion policy.
+
+## Rollback
+
+Immediate rollback is non-destructive:
+
+1. Set `temporal.enabled=false` / `FORGEJO_TEMPORAL_ENABLED=false` on CodeTether.
+2. Scale `<release>-temporal-worker` to zero.
+3. Remove or comment Forgejo `CONTROL_URL` so native cancel/retry reverts to its
+   local state transition behavior.
+4. Restore the previous CodeTether image if application rollback is required.
+5. Leave Temporal history intact for diagnosis; it contains only the bounded
+   non-sensitive contracts above.
+6. Legacy control polling resumes when the feature flag is false.
+
+Do not terminate running workflows until their active CodeTether task IDs and
+Forgejo task IDs have been captured. Cancellation is preferred to termination
+because activities heartbeat and can revoke active run leases cleanly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,6 @@ a2a-sdk[http-server,postgresql]>=0.3.22
 # Cron scheduling support
 croniter>=2.0.0
 pytz>=2024.1
+
+# Durable Forgejo agent orchestration
+temporalio>=1.30.0,<2.0.0

--- a/tests/test_agent_bridge_task_reads.py
+++ b/tests/test_agent_bridge_task_reads.py
@@ -1,0 +1,43 @@
+"""Regression coverage for PostgreSQL-primary task detail reads."""
+
+import pytest
+
+from a2a_server.agent_bridge import AgentBridge, AgentTask, AgentTaskStatus
+
+
+@pytest.mark.asyncio
+async def test_get_task_refreshes_stale_replica_cache_from_database(monkeypatch):
+    bridge = AgentBridge(auto_start=False)
+    cached = AgentTask(
+        id='task-review',
+        codebase_id='global',
+        title='review',
+        prompt='review prompt',
+    )
+    bridge._tasks[cached.id] = cached
+    bridge._codebase_tasks['global'] = [cached.id]
+    assert cached.status == AgentTaskStatus.PENDING
+
+    database_row = cached.to_dict()
+    database_row.update(
+        {
+            'workspace_id': 'global',
+            'status': 'completed',
+            'result': 'review complete',
+        }
+    )
+
+    async def completed_task(task_id):
+        assert task_id == cached.id
+        return database_row
+
+    monkeypatch.setattr(
+        'a2a_server.agent_bridge.db.db_get_task', completed_task
+    )
+
+    refreshed = await bridge.get_task(cached.id)
+
+    assert refreshed is not None
+    assert refreshed.status == AgentTaskStatus.COMPLETED
+    assert refreshed.result == 'review complete'
+    assert bridge._tasks[cached.id] is refreshed

--- a/tests/test_forgejo_agent_client.py
+++ b/tests/test_forgejo_agent_client.py
@@ -75,6 +75,49 @@ async def test_create_update_and_append_event_use_repository_api(monkeypatch):
     assert event_payload['payload']['token'] == '[REDACTED]'
 
 
+@pytest.mark.asyncio
+async def test_publish_session_events_appends_after_existing_stage(monkeypatch):
+    appended: list[dict] = []
+
+    async def fake_list(**kwargs):
+        return {
+            'events': [
+                {'sequence': 4, 'external_id': 'older-stage-event'},
+                {
+                    'sequence': 5,
+                    'external_id': client._event_id(
+                        'task-2',
+                        1,
+                        'agent.message',
+                        {'role': 'assistant', 'content': 'Already published'},
+                    ),
+                },
+            ]
+        }
+
+    async def fake_append(**kwargs):
+        appended.append(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(client, 'list_events', fake_list)
+    monkeypatch.setattr(client, 'append_event', fake_append)
+
+    count = await client.publish_session_events(
+        repo='acme/widgets',
+        forgejo_task_id=42,
+        codetether_task_id='task-2',
+        messages=[
+            {'role': 'assistant', 'content': 'Already published'},
+            {'role': 'assistant', 'content': 'New event'},
+        ],
+    )
+
+    assert count == 1
+    assert len(appended) == 1
+    assert appended[0]['sequence'] == 7
+    assert appended[0]['payload']['content'] == 'New event'
+
+
 def test_normalize_session_events_is_ordered_deterministic_and_redacted():
     messages = [
         {

--- a/tests/test_forgejo_agent_client.py
+++ b/tests/test_forgejo_agent_client.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from a2a_server import forgejo_agent_client as client
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch):
+    monkeypatch.setenv('FORGEJO_API_URL', 'https://forgejo.example/api/v1')
+    monkeypatch.setenv('FORGEJO_TOKEN', 'top-secret-token')
+
+
+@pytest.mark.asyncio
+async def test_create_update_and_append_event_use_repository_api(monkeypatch):
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        path = request.url.path
+        if request.method == 'POST' and path.endswith('/agent/tasks'):
+            return httpx.Response(
+                201,
+                json={
+                    'id': 42,
+                    'html_url': 'https://forgejo.example/acme/widgets/agent/tasks/42',
+                },
+            )
+        if request.method == 'PATCH':
+            return httpx.Response(200, json={'id': 42, 'status': 'running'})
+        return httpx.Response(201, json={'id': 99, 'sequence': 1})
+
+    transport = httpx.MockTransport(handler)
+    original = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        'AsyncClient',
+        lambda **kwargs: original(transport=transport, **kwargs),
+    )
+
+    task = await client.create_task(
+        repo='acme/widgets',
+        operation='fix',
+        prompt='Fix issue 7',
+        idempotency_key='issue-7-comment-9',
+        issue_index=7,
+        metadata={'authorization': 'must-not-leak'},
+    )
+    assert task['id'] == 42
+    await client.update_task(repo='acme/widgets', task_id=42, status='running')
+    await client.append_event(
+        repo='acme/widgets',
+        task_id=42,
+        sequence=1,
+        external_id='task:1',
+        event_type='tool.call',
+        payload={'token': 'must-not-leak', 'tool': 'grep'},
+    )
+
+    assert [request.url.path for request in requests] == [
+        '/api/v1/repos/acme/widgets/agent/tasks',
+        '/api/v1/repos/acme/widgets/agent/tasks/42',
+        '/api/v1/repos/acme/widgets/agent/tasks/42/events',
+    ]
+    assert all(
+        request.headers['authorization'] == 'token top-secret-token'
+        for request in requests
+    )
+    create_payload = json.loads(requests[0].content)
+    assert create_payload['metadata']['authorization'] == '[REDACTED]'
+    event_payload = json.loads(requests[2].content)
+    assert event_payload['payload']['token'] == '[REDACTED]'
+
+
+def test_normalize_session_events_is_ordered_deterministic_and_redacted():
+    messages = [
+        {
+            'role': 'assistant',
+            'content': 'Inspecting',
+            'authorization': 'secret',
+            'tool_calls': [
+                {'name': 'grep', 'arguments': {'api_key': 'secret'}},
+                {'name': 'bash', 'output': 'ok', 'status': 'completed'},
+            ],
+        },
+        {'role': 'user', 'content': 'Continue'},
+    ]
+    first = client.normalize_session_events('task-1', messages)
+    second = client.normalize_session_events('task-1', messages)
+
+    assert first == second
+    assert [event['sequence'] for event in first] == [1, 2, 3, 4]
+    assert [event['type'] for event in first] == [
+        'agent.message',
+        'tool.call',
+        'tool.result',
+        'user.message',
+    ]
+    assert first[0]['payload']['authorization'] == '[REDACTED]'
+    assert first[1]['payload']['arguments']['api_key'] == '[REDACTED]'
+    assert len({event['external_id'] for event in first}) == 4

--- a/tests/test_forgejo_agent_controls.py
+++ b/tests/test_forgejo_agent_controls.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import pytest
+
+from a2a_server import forgejo_agent_client
+from a2a_server import forgejo_agent_controls as controls
+from a2a_server import persistent_worker_pool
+
+
+def _task(status: str = 'running') -> dict:
+    return {
+        'id': 'codetether-1',
+        'status': status,
+        'workspace_id': 'workspace-1',
+        'title': 'Fix issue 7',
+        'prompt': 'Implement the fix',
+        'agent_type': 'build',
+        'priority': 100,
+        'model_ref': 'zai:glm-5.1',
+        'task_timeout_seconds': 604800,
+        'metadata': {
+            'source': 'forgejo-webhook',
+            'repo': 'acme/widgets',
+            'forgejo_api_url': 'https://forgejo.example/api/v1',
+            'forgejo_agent_task_id': 42,
+            'forgejo_work_key': 'forgejo:acme/widgets:7:code:abc',
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_reconcile_cancelled_forgejo_task_cancels_codetether(
+    monkeypatch,
+):
+    cancelled: list[str] = []
+
+    async def fake_linked(limit):
+        assert limit == 50
+        return [_task('running')]
+
+    async def fake_get(**kwargs):
+        return {'id': 42, 'status': 'cancelled'}
+
+    async def fake_cancel(task_id):
+        cancelled.append(task_id)
+        return True
+
+    monkeypatch.setattr(controls, '_linked_tasks', fake_linked)
+    monkeypatch.setattr(forgejo_agent_client, 'get_task', fake_get)
+    monkeypatch.setattr(controls, '_cancel_codetether_task', fake_cancel)
+
+    assert await controls.reconcile_forgejo_agent_controls() == 1
+    assert cancelled == ['codetether-1']
+
+
+@pytest.mark.asyncio
+async def test_reconcile_pending_forgejo_task_retries_cancelled_codetether(
+    monkeypatch,
+):
+    dispatched: list[dict] = []
+    updates: list[dict] = []
+
+    async def fake_linked(limit):
+        return [_task('cancelled')]
+
+    async def fake_get(**kwargs):
+        return {'id': 42, 'status': 'pending'}
+
+    async def fake_dispatch(**kwargs):
+        dispatched.append(kwargs)
+        return 'codetether-2'
+
+    async def fake_update(**kwargs):
+        updates.append(kwargs)
+        return {'id': 42, 'status': 'accepted'}
+
+    monkeypatch.setattr(controls, '_linked_tasks', fake_linked)
+    monkeypatch.setattr(forgejo_agent_client, 'get_task', fake_get)
+    monkeypatch.setattr(
+        persistent_worker_pool, 'create_and_dispatch_task', fake_dispatch
+    )
+    monkeypatch.setattr(forgejo_agent_client, 'update_task', fake_update)
+
+    assert await controls.reconcile_forgejo_agent_controls() == 1
+    assert len(dispatched) == 1
+    assert dispatched[0]['workspace_id'] == 'workspace-1'
+    assert dispatched[0]['metadata']['forgejo_retry_generation'] == 1
+    assert dispatched[0]['metadata']['forgejo_retry_of'] == 'codetether-1'
+    assert dispatched[0]['metadata']['forgejo_work_key'].endswith(':retry:1')
+    assert updates == [
+        {
+            'repo': 'acme/widgets',
+            'task_id': 42,
+            'base_url': 'https://forgejo.example/api/v1',
+            'status': 'accepted',
+            'external_task_id': 'codetether-2',
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_matching_states_is_noop(monkeypatch):
+    async def fake_linked(limit):
+        return [_task('running')]
+
+    async def fake_get(**kwargs):
+        return {'id': 42, 'status': 'running'}
+
+    monkeypatch.setattr(controls, '_linked_tasks', fake_linked)
+    monkeypatch.setattr(forgejo_agent_client, 'get_task', fake_get)
+
+    assert await controls.reconcile_forgejo_agent_controls() == 0

--- a/tests/test_forgejo_agent_controls.py
+++ b/tests/test_forgejo_agent_controls.py
@@ -99,6 +99,32 @@ async def test_reconcile_pending_forgejo_task_retries_cancelled_codetether(
 
 
 @pytest.mark.asyncio
+async def test_reconcile_ignores_stale_codetether_stage(monkeypatch):
+    cancelled: list[str] = []
+
+    async def fake_linked(limit):
+        return [_task('running')]
+
+    async def fake_get(**kwargs):
+        return {
+            'id': 42,
+            'status': 'cancelled',
+            'external_task_id': 'newer-codetether-task',
+        }
+
+    async def fake_cancel(task_id):
+        cancelled.append(task_id)
+        return True
+
+    monkeypatch.setattr(controls, '_linked_tasks', fake_linked)
+    monkeypatch.setattr(forgejo_agent_client, 'get_task', fake_get)
+    monkeypatch.setattr(controls, '_cancel_codetether_task', fake_cancel)
+
+    assert await controls.reconcile_forgejo_agent_controls() == 0
+    assert cancelled == []
+
+
+@pytest.mark.asyncio
 async def test_reconcile_matching_states_is_noop(monkeypatch):
     async def fake_linked(limit):
         return [_task('running')]

--- a/tests/test_forgejo_agent_sync.py
+++ b/tests/test_forgejo_agent_sync.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import pytest
+
+from a2a_server import forgejo_agent_client
+from a2a_server import forgejo_task_completion as completion
+from a2a_server import session_view
+
+
+@pytest.mark.asyncio
+async def test_sync_terminal_task_updates_forgejo_and_publishes_transcript(
+    monkeypatch,
+):
+    updates: list[dict] = []
+    publishes: list[dict] = []
+
+    async def fake_messages(task, limit):
+        assert limit == 10_000
+        return 'session-9', [
+            {
+                'role': 'assistant',
+                'content': 'Done',
+                'tool_calls': [{'name': 'pytest', 'output': '2 passed'}],
+            }
+        ]
+
+    async def fake_update(**kwargs):
+        updates.append(kwargs)
+        return {'id': kwargs['task_id']}
+
+    async def fake_publish(**kwargs):
+        publishes.append(kwargs)
+        return 2
+
+    monkeypatch.setattr(session_view, '_task_messages', fake_messages)
+    monkeypatch.setattr(forgejo_agent_client, 'update_task', fake_update)
+    monkeypatch.setattr(
+        forgejo_agent_client, 'publish_session_events', fake_publish
+    )
+
+    task = {
+        'id': 'codetether-77',
+        'status': 'completed',
+        'result': 'Implemented and tested',
+        'error': '',
+        'metadata': {
+            'source': 'forgejo-webhook',
+            'repo': 'acme/widgets',
+            'forgejo_api_url': 'https://forgejo.example/api/v1',
+            'forgejo_agent_task_id': 42,
+            'forgejo_agent_task_url': (
+                'https://forgejo.example/acme/widgets/agent/tasks/42'
+            ),
+            'pr_head_sha': 'abc123',
+            'branch_name': 'codetether/issue-7',
+        },
+    }
+    await completion.sync_forgejo_agent_task(task)
+
+    assert updates == [
+        {
+            'repo': 'acme/widgets',
+            'task_id': 42,
+            'base_url': 'https://forgejo.example/api/v1',
+            'status': 'completed',
+            'external_task_id': 'codetether-77',
+            'external_session_id': 'session-9',
+            'head_sha': 'abc123',
+            'branch': 'codetether/issue-7',
+            'result': 'Implemented and tested',
+            'error': '',
+        }
+    ]
+    assert publishes == [
+        {
+            'repo': 'acme/widgets',
+            'forgejo_task_id': 42,
+            'codetether_task_id': 'codetether-77',
+            'messages': [
+                {
+                    'role': 'assistant',
+                    'content': 'Done',
+                    'tool_calls': [{'name': 'pytest', 'output': '2 passed'}],
+                }
+            ],
+            'base_url': 'https://forgejo.example/api/v1',
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_creates_forgejo_task_before_codetether_and_links_it(
+    monkeypatch,
+):
+    from a2a_server import forgejo_webhooks
+    from a2a_server import persistent_worker_pool
+
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_json(method, base, path, payload=None):
+        assert method == 'GET'
+        return {
+            'default_branch': 'main',
+            'clone_url': 'https://forgejo.example/acme/widgets.git',
+        }
+
+    async def fake_workspace(ctx, clone_url, branch, token):
+        return 'workspace-1'
+
+    async def fake_routing():
+        return {'required_capabilities': ['persistent-workspace']}
+
+    async def fake_create(**kwargs):
+        calls.append(('forgejo-create', kwargs))
+        return {
+            'id': 42,
+            'html_url': 'https://forgejo.example/acme/widgets/agent/tasks/42',
+        }
+
+    async def fake_dispatch(**kwargs):
+        calls.append(('codetether-dispatch', kwargs))
+        return 'codetether-77'
+
+    async def fake_update(**kwargs):
+        calls.append(('forgejo-update', kwargs))
+        return {'id': 42}
+
+    monkeypatch.setenv('FORGEJO_TOKEN', 'secret')
+    monkeypatch.setattr(forgejo_webhooks, 'forgejo_json', fake_json)
+    monkeypatch.setattr(forgejo_webhooks, '_ensure_workspace', fake_workspace)
+    monkeypatch.setattr(forgejo_webhooks, 'resolve_task_target', fake_routing)
+    monkeypatch.setattr(forgejo_agent_client, 'create_task', fake_create)
+    monkeypatch.setattr(forgejo_agent_client, 'update_task', fake_update)
+    monkeypatch.setattr(
+        persistent_worker_pool, 'create_and_dispatch_task', fake_dispatch
+    )
+
+    result = await forgejo_webhooks._dispatch(
+        {
+            'repo': 'acme/widgets',
+            'number': 7,
+            'is_pr': False,
+            'body': '@codetether fix this issue',
+            'repo_data': {},
+            'comment_id': 9,
+            'html_url': 'https://forgejo.example/acme/widgets/issues/7',
+            'actor_login': 'alice',
+        },
+        'https://forgejo.example/api/v1',
+    )
+
+    assert [name for name, _ in calls] == [
+        'forgejo-create',
+        'codetether-dispatch',
+        'forgejo-update',
+    ]
+    dispatch_metadata = calls[1][1]['metadata']
+    assert dispatch_metadata['forgejo_agent_task_id'] == 42
+    assert (
+        dispatch_metadata['post_clone_task']['metadata'][
+            'forgejo_agent_task_id'
+        ]
+        == 42
+    )
+    assert calls[2][1]['external_task_id'] == 'codetether-77'
+    assert result['forgejo_agent_task_id'] == 42
+    assert result['forgejo_agent_task_url'].endswith('/agent/tasks/42')
+
+
+def test_footer_prefers_native_forgejo_task_url(monkeypatch):
+    monkeypatch.setattr(
+        completion,
+        'build_task_session_url',
+        lambda task_id: f'https://codetether.example/session/{task_id}',
+    )
+    native = 'https://forgejo.example/acme/widgets/agent/tasks/42'
+    footer = completion._task_footer(
+        'codetether-77', {'forgejo_agent_task_url': native}
+    )
+    assert f'[View session]({native})' in footer
+    assert 'codetether.example' not in footer

--- a/tests/test_forgejo_automation.py
+++ b/tests/test_forgejo_automation.py
@@ -434,7 +434,10 @@ async def test_forgejo_post_clone_uses_durable_dispatch(monkeypatch):
                 'model_ref': 'zai:glm-5.1',
                 'metadata': {
                     'source': 'forgejo-webhook',
+                    'repo': 'owner/repo',
+                    'forgejo_api_url': 'https://forgejo.example/api/v1',
                     'forgejo_issue_url': PR['html_url'],
+                    'forgejo_agent_task_id': 42,
                     'forgejo_work_key': 'forgejo:owner/repo:5:code:abc123:9',
                 },
             },
@@ -445,14 +448,23 @@ async def test_forgejo_post_clone_uses_durable_dispatch(monkeypatch):
         assert task_id == 'clone-1'
         return task
 
+    updates = []
+
     async def fake_dispatch(**kwargs):
         dispatched.append(kwargs)
         return 'code-1'
+
+    async def fake_update(**kwargs):
+        updates.append(kwargs)
+        return {'id': 42}
 
     bridge.get_task = get_task
     monkeypatch.setattr(
         'a2a_server.persistent_worker_pool.create_and_dispatch_task',
         fake_dispatch,
+    )
+    monkeypatch.setattr(
+        'a2a_server.forgejo_agent_client.update_task', fake_update
     )
     queued = await post_clone_followup.enqueue_post_clone_followup(
         bridge, 'clone-1'
@@ -460,6 +472,15 @@ async def test_forgejo_post_clone_uses_durable_dispatch(monkeypatch):
     assert queued == 'code-1'
     assert dispatched[0]['priority'] == TASK_PRIORITY
     assert dispatched[0]['metadata']['forgejo_work_key'].endswith(':9')
+    assert updates == [
+        {
+            'repo': 'owner/repo',
+            'task_id': 42,
+            'base_url': 'https://forgejo.example/api/v1',
+            'status': 'running',
+            'external_task_id': 'code-1',
+        }
+    ]
 
 
 def test_forgejo_work_key_is_first_class():

--- a/tests/test_forgejo_automation.py
+++ b/tests/test_forgejo_automation.py
@@ -1,0 +1,472 @@
+from types import SimpleNamespace
+
+import pytest
+
+from a2a_server import forgejo_automation as automation
+from a2a_server import forgejo_task_completion
+from a2a_server import forgejo_webhooks
+from a2a_server.github_app.settings import TASK_PRIORITY
+
+
+PR = {
+    'number': 5,
+    'state': 'open',
+    'html_url': 'https://forge.example/owner/repo/pulls/5',
+    'head': {
+        'sha': 'abc123',
+        'ref': 'feature',
+        'repo': {
+            'full_name': 'owner/repo',
+            'clone_url': 'https://forge.example/owner/repo.git',
+        },
+    },
+}
+
+
+def review_task(verdict='CHANGES_REQUESTED: tests fail'):
+    return {
+        'id': 'review-1',
+        'status': 'completed',
+        'result': verdict,
+        'metadata': {
+            'source': 'forgejo-webhook',
+            'workflow_stage': 'review',
+            'workspace_id': 'ws1',
+            'repo': 'owner/repo',
+            'issue_number': 5,
+            'pr_number': 5,
+            'branch_name': 'feature',
+            'pr_head_sha': 'abc123',
+            'forgejo_api_url': 'https://forge.example/api/v1',
+            'forgejo_issue_url': PR['html_url'],
+            'target_agent_name': 'harvester',
+            'required_capabilities': ['persistent-workspace'],
+        },
+    }
+
+
+class Acquire:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class Pool:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def acquire(self):
+        return Acquire(self.connection)
+
+
+def install_database(monkeypatch, connection, *, task=None):
+    async def get_pool():
+        return Pool(connection)
+
+    async def db_get_task(task_id):
+        assert task_id == 'review-1'
+        return task
+
+    monkeypatch.setattr('a2a_server.database.get_pool', get_pool, raising=False)
+    monkeypatch.setattr(
+        'a2a_server.database.db_get_task', db_get_task, raising=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_review_is_semantic_and_idempotent(monkeypatch):
+    calls = []
+
+    async def fake_json(method, base, path, payload=None):
+        calls.append((method, base, path, payload))
+        if method == 'GET':
+            return []
+        return {'id': 44}
+
+    monkeypatch.setattr(automation, 'forgejo_json', fake_json)
+    result = await automation.publish_forgejo_review(review_task())
+    assert result == {
+        'published': True,
+        'duplicate': False,
+        'event': 'REQUEST_CHANGES',
+        'review_id': 44,
+    }
+    assert calls[1][3]['event'] == 'REQUEST_CHANGES'
+    assert calls[1][3]['commit_id'] == 'abc123'
+    assert automation.review_marker('review-1') in calls[1][3]['body']
+
+    calls.clear()
+
+    async def existing(method, base, path, payload=None):
+        calls.append(method)
+        return [
+            {
+                'id': 44,
+                'state': 'REQUEST_CHANGES',
+                'body': automation.review_marker('review-1'),
+            }
+        ]
+
+    monkeypatch.setattr(automation, 'forgejo_json', existing)
+    duplicate = await automation.publish_forgejo_review(review_task())
+    assert duplicate['duplicate'] is True
+    assert calls == ['GET']
+
+
+@pytest.mark.asyncio
+async def test_review_request_rejects_bots_and_requests_human(monkeypatch):
+    calls = []
+
+    async def fake_json(*args):
+        calls.append(args)
+        return []
+
+    monkeypatch.setattr(automation, 'forgejo_json', fake_json)
+    assert not await automation.request_forgejo_review(
+        base='https://forge.example/api/v1',
+        repo='owner/repo',
+        pr_number=5,
+        reviewer='codetether-bot',
+    )
+    assert await automation.request_forgejo_review(
+        base='https://forge.example/api/v1',
+        repo='owner/repo',
+        pr_number=5,
+        reviewer='alice',
+    )
+    assert calls[0][3] == {'reviewers': ['alice']}
+
+
+@pytest.mark.asyncio
+async def test_changes_requested_creates_exactly_one_fix(monkeypatch):
+    dispatched = []
+
+    class Connection:
+        async def fetchrow(self, query, *params):
+            assert "workflow_stage' = 'fix'" in query
+            return {
+                'attempts': 0,
+                'active': False,
+                'review_already_handled': False,
+            }
+
+    install_database(monkeypatch, Connection())
+
+    async def fake_json(method, base, path, payload=None):
+        assert method == 'GET'
+        return PR
+
+    async def fake_dispatch(**kwargs):
+        dispatched.append(kwargs)
+        return 'fix-1'
+
+    monkeypatch.setattr(automation, 'forgejo_json', fake_json)
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    task_id = await automation.create_forgejo_fix_followup(review_task())
+    assert task_id == 'fix-1'
+    assert dispatched[0]['priority'] == TASK_PRIORITY
+    assert dispatched[0]['metadata']['fix_followup'] == 'true'
+    assert dispatched[0]['metadata']['review_task_id'] == 'review-1'
+
+    class ActiveConnection:
+        async def fetchrow(self, query, *params):
+            return {
+                'attempts': 1,
+                'active': True,
+                'review_already_handled': False,
+            }
+
+    install_database(monkeypatch, ActiveConnection())
+    assert await automation.create_forgejo_fix_followup(review_task()) is None
+    assert len(dispatched) == 1
+
+    class CompletedSameReviewConnection:
+        async def fetchrow(self, query, *params):
+            assert params[-1] == 'review-1'
+            return {
+                'attempts': 1,
+                'active': False,
+                'review_already_handled': True,
+            }
+
+    install_database(monkeypatch, CompletedSameReviewConnection())
+    assert await automation.create_forgejo_fix_followup(review_task()) is None
+    assert len(dispatched) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_third_party_status_creates_deduped_fix(monkeypatch):
+    dispatched = []
+
+    class Connection:
+        async def fetchrow(self, query, *params):
+            assert "forgejo_work_key'" in query
+            return None
+
+    install_database(monkeypatch, Connection())
+
+    async def fake_ensure(ctx, clone_url, branch, token):
+        assert (ctx['repo'], branch, token) == (
+            'owner/repo',
+            'feature',
+            'token',
+        )
+        return 'ws-status'
+
+    async def fake_target():
+        return {
+            'target_agent_name': 'harvester',
+            'required_capabilities': ['persistent-workspace'],
+        }
+
+    async def fake_dispatch(**kwargs):
+        dispatched.append(kwargs)
+        return 'status-fix-1'
+
+    monkeypatch.setattr(forgejo_webhooks, '_ensure_workspace', fake_ensure)
+    monkeypatch.setattr(forgejo_webhooks, '_token', lambda: 'token')
+    monkeypatch.setattr(
+        'a2a_server.github_app.routing.resolve_task_target', fake_target
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    status = {
+        'status': 'failure',
+        'context': 'tests',
+        'description': 'unit tests failed',
+        'target_url': 'https://forge.example/actions/1',
+        'creator': {'login': 'forgejo-actions'},
+    }
+    task_id = await automation.create_status_remediation_task(
+        base='https://forge.example/api/v1',
+        repo='owner/repo',
+        pr=PR,
+        status=status,
+    )
+    assert task_id == 'status-fix-1'
+    assert dispatched[0]['workspace_id'] == 'ws-status'
+    assert dispatched[0]['priority'] == TASK_PRIORITY
+    assert dispatched[0]['metadata']['forgejo_status_context'] == 'tests'
+
+    self_status = {**status, 'creator': {'login': 'codetether-bot'}}
+    assert (
+        await automation.create_status_remediation_task(
+            base='https://forge.example/api/v1',
+            repo='owner/repo',
+            pr=PR,
+            status=self_status,
+        )
+        is None
+    )
+    assert len(dispatched) == 1
+
+
+@pytest.mark.asyncio
+async def test_code_completion_creates_review_and_terminal_comment(monkeypatch):
+    calls = []
+
+    async def fake_review(task):
+        assert task['id'] == 'code-1'
+        return 'review-1'
+
+    async def fake_json(method, base, path, payload=None):
+        calls.append((method, path, payload))
+        return [] if method == 'GET' else {'id': 1}
+
+    monkeypatch.setattr(
+        forgejo_task_completion, 'create_forgejo_review_task', fake_review
+    )
+    monkeypatch.setattr(forgejo_task_completion, 'forgejo_json', fake_json)
+    task = {
+        'id': 'code-1',
+        'status': 'completed',
+        'result': 'Pushed abc123.',
+        'metadata': {
+            'source': 'forgejo-webhook',
+            'workflow_stage': 'code',
+            'workspace_id': 'ws1',
+            'repo': 'owner/repo',
+            'issue_number': 5,
+            'pr_number': 5,
+            'forgejo_api_url': 'https://forge.example/api/v1',
+        },
+    }
+    await forgejo_task_completion.notify_forgejo_task_completion(task)
+    assert [call[0] for call in calls] == ['GET', 'POST']
+    assert 'Queued review task `review-1`' in calls[1][2]['body']
+
+
+@pytest.mark.asyncio
+async def test_review_completion_publishes_and_queues_fix_once(monkeypatch):
+    calls = []
+    reconciled = []
+
+    async def fake_publish(task):
+        return {'event': 'REQUEST_CHANGES', 'review_id': 44}
+
+    async def fake_fix(task):
+        return 'fix-1'
+
+    async def fake_mark(task_id):
+        reconciled.append(task_id)
+
+    async def fake_json(method, base, path, payload=None):
+        calls.append((method, path, payload))
+        return [] if method == 'GET' else {'id': 1}
+
+    monkeypatch.setattr(
+        forgejo_task_completion, 'publish_forgejo_review', fake_publish
+    )
+    monkeypatch.setattr(
+        forgejo_task_completion, 'create_forgejo_fix_followup', fake_fix
+    )
+    monkeypatch.setattr(
+        forgejo_task_completion, '_mark_review_reconciled', fake_mark
+    )
+    monkeypatch.setattr(forgejo_task_completion, 'forgejo_json', fake_json)
+    await forgejo_task_completion.notify_forgejo_task_completion(review_task())
+    assert reconciled == ['review-1']
+    assert (
+        'Published Forgejo review event `REQUEST_CHANGES`'
+        in calls[1][2]['body']
+    )
+    assert 'Queued fix follow-up task `fix-1`' in calls[1][2]['body']
+
+
+@pytest.mark.asyncio
+async def test_issue_code_completion_discovers_created_pr_by_branch(
+    monkeypatch,
+):
+    dispatched = []
+
+    class Connection:
+        async def fetchrow(self, query, *params):
+            return None
+
+    install_database(monkeypatch, Connection())
+
+    async def fake_json(method, base, path, payload=None):
+        assert method == 'GET'
+        assert 'state=open' in path
+        return [PR]
+
+    async def fake_dispatch(**kwargs):
+        dispatched.append(kwargs)
+        return 'review-issue-pr'
+
+    async def fake_request(**kwargs):
+        return True
+
+    monkeypatch.setattr(automation, 'forgejo_json', fake_json)
+    monkeypatch.setattr(automation, 'request_forgejo_review', fake_request)
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    code_task = {
+        'id': 'code-issue-1',
+        'status': 'completed',
+        'metadata': {
+            'source': 'forgejo-webhook',
+            'workflow_stage': 'code',
+            'workspace_id': 'ws1',
+            'repo': 'owner/repo',
+            'issue_number': 12,
+            'pr_number': None,
+            'branch_name': 'feature',
+            'forgejo_api_url': 'https://forge.example/api/v1',
+            'trigger_actor_login': 'alice',
+        },
+    }
+    task_id = await automation.create_forgejo_review_task(code_task)
+    assert task_id == 'review-issue-pr'
+    assert dispatched[0]['metadata']['pr_number'] == 5
+    assert dispatched[0]['metadata']['pr_head_sha'] == 'abc123'
+    assert dispatched[0]['priority'] == TASK_PRIORITY
+
+    created = []
+
+    async def fake_create_review(task):
+        created.append(task['id'])
+        return 'review-issue-pr'
+
+    async def fake_comment_json(method, base, path, payload=None):
+        return [] if method == 'GET' else {'id': 1}
+
+    monkeypatch.setattr(
+        forgejo_task_completion,
+        'create_forgejo_review_task',
+        fake_create_review,
+    )
+    monkeypatch.setattr(
+        forgejo_task_completion, 'forgejo_json', fake_comment_json
+    )
+    await forgejo_task_completion.notify_forgejo_task_completion(code_task)
+    assert created == ['code-issue-1']
+
+
+@pytest.mark.asyncio
+async def test_forgejo_post_clone_uses_durable_dispatch(monkeypatch):
+    from a2a_server import post_clone_followup
+
+    dispatched = []
+    bridge = SimpleNamespace()
+    task = SimpleNamespace(
+        agent_type='clone_repo',
+        codebase_id='ws1',
+        metadata={
+            'source': 'forgejo-webhook',
+            'post_clone_task': {
+                'title': 'Work Forgejo PR #5',
+                'prompt': 'fix it',
+                'agent_type': 'build',
+                'priority': TASK_PRIORITY,
+                'model_ref': 'zai:glm-5.1',
+                'metadata': {
+                    'source': 'forgejo-webhook',
+                    'forgejo_issue_url': PR['html_url'],
+                    'forgejo_work_key': 'forgejo:owner/repo:5:code:abc123:9',
+                },
+            },
+        },
+    )
+
+    async def get_task(task_id):
+        assert task_id == 'clone-1'
+        return task
+
+    async def fake_dispatch(**kwargs):
+        dispatched.append(kwargs)
+        return 'code-1'
+
+    bridge.get_task = get_task
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    queued = await post_clone_followup.enqueue_post_clone_followup(
+        bridge, 'clone-1'
+    )
+    assert queued == 'code-1'
+    assert dispatched[0]['priority'] == TASK_PRIORITY
+    assert dispatched[0]['metadata']['forgejo_work_key'].endswith(':9')
+
+
+def test_forgejo_work_key_is_first_class():
+    from a2a_server.persistent_worker_pool import _github_work_key
+
+    metadata = {
+        'source': 'forgejo-webhook',
+        'forgejo_work_key': 'forgejo:owner/repo:5:review:abc123',
+    }
+    assert _github_work_key(metadata) == metadata['forgejo_work_key']

--- a/tests/test_forgejo_task_completion.py
+++ b/tests/test_forgejo_task_completion.py
@@ -31,6 +31,8 @@ def task(status='completed'):
 
 @pytest.mark.asyncio
 async def test_posts_completed_forgejo_terminal_comment(monkeypatch):
+    monkeypatch.setenv('CODETETHER_PUBLIC_URL', 'https://api.codetether.run')
+    monkeypatch.setenv('CODETETHER_SESSION_VIEW_SECRET', 'test-session-secret')
     calls = []
 
     async def fake_json(method, base, path, payload=None):
@@ -44,6 +46,11 @@ async def test_posts_completed_forgejo_terminal_comment(monkeypatch):
     body = calls[1][3]['body']
     assert 'Completed and pushed' in body
     assert 'Pushed commit abc123.' in body
+    assert (
+        '[View session](https://api.codetether.run/sessions/tasks/task-1?'
+        in body
+    )
+    assert 'signature=' in body
     assert '<!-- codetether-forgejo-terminal:task-1 -->' in body
 
 

--- a/tests/test_forgejo_task_completion.py
+++ b/tests/test_forgejo_task_completion.py
@@ -1,0 +1,82 @@
+# ruff: noqa: I001
+
+import os
+
+import a2a_server
+import pytest
+
+os.environ.setdefault(
+    'DATABASE_URL', 'postgresql://test:test@localhost:5432/test'
+)
+
+from a2a_server import forgejo_task_completion
+from a2a_server.github_app import task_status_hook
+
+
+def task(status='completed'):
+    return {
+        'id': 'task-1',
+        'status': status,
+        'result': 'Pushed commit abc123.',
+        'metadata': {
+            'source': 'forgejo-webhook',
+            'workflow_stage': 'code',
+            'repo': 'riley/example',
+            'issue_number': 42,
+            'pr_number': 42,
+            'forgejo_api_url': 'https://forgejo.example/api/v1',
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_posts_completed_forgejo_terminal_comment(monkeypatch):
+    calls = []
+
+    async def fake_json(method, base, path, payload=None):
+        calls.append((method, base, path, payload))
+        return [] if method == 'GET' else {'id': 7}
+
+    monkeypatch.setattr(forgejo_task_completion, 'forgejo_json', fake_json)
+    await forgejo_task_completion.notify_forgejo_task_completion(task())
+
+    assert [call[0] for call in calls] == ['GET', 'POST']
+    body = calls[1][3]['body']
+    assert 'Completed and pushed' in body
+    assert 'Pushed commit abc123.' in body
+    assert '<!-- codetether-forgejo-terminal:task-1 -->' in body
+
+
+@pytest.mark.asyncio
+async def test_skips_duplicate_forgejo_terminal_comment(monkeypatch):
+    calls = []
+
+    async def fake_json(method, base, path, payload=None):
+        calls.append(method)
+        return [{'body': '<!-- codetether-forgejo-terminal:task-1 -->'}]
+
+    monkeypatch.setattr(forgejo_task_completion, 'forgejo_json', fake_json)
+    await forgejo_task_completion.notify_forgejo_task_completion(task())
+    assert calls == ['GET']
+
+
+@pytest.mark.asyncio
+async def test_terminal_hook_routes_forgejo_task(monkeypatch):
+    seen = []
+
+    async def fake_get(task_id):
+        assert task_id == 'task-1'
+        return task()
+
+    async def fake_notify(value):
+        seen.append(value)
+
+    from a2a_server import database  # noqa: PLC0415
+
+    monkeypatch.setattr(database, 'db_get_task', fake_get)
+    monkeypatch.setattr(
+        forgejo_task_completion, 'notify_forgejo_task_completion', fake_notify
+    )
+    await task_status_hook.handle_github_app_terminal_task('task-1')
+    assert seen == [task()]
+    delattr(a2a_server, 'database')

--- a/tests/test_forgejo_temporal_integration.py
+++ b/tests/test_forgejo_temporal_integration.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from a2a_server import forgejo_task_completion
+from a2a_server import forgejo_webhooks
+from a2a_server.temporal.activities import safe_activity
+from a2a_server.temporal.models import ForgejoAgentWorkflowInput
+
+
+@pytest.mark.asyncio
+async def test_activity_failure_does_not_persist_sensitive_exception_text():
+    @safe_activity('safe_failure_code')
+    async def fail():
+        raise RuntimeError('authorization=must-not-leak')
+
+    with pytest.raises(ApplicationError) as error:
+        await fail()
+    assert error.value.type == 'safe_failure_code'
+    assert error.value.message == 'safe_failure_code'
+    assert 'must-not-leak' not in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_temporal_dispatch_starts_workflow_without_legacy_clone(
+    monkeypatch,
+):
+    started: list[ForgejoAgentWorkflowInput] = []
+    updates: list[dict] = []
+
+    async def fake_json(method, base, path, payload=None):
+        if path.endswith('/pulls/12'):
+            return {'head': {'ref': 'feature', 'sha': 'abc123'}}
+        return {
+            'default_branch': 'main',
+            'clone_url': 'https://forge.example/owner/repo.git',
+        }
+
+    async def fake_workspace(ctx, clone_url, branch, token):
+        assert 'token' not in ctx
+        return 'workspace-1'
+
+    async def fake_create_agent_task(**kwargs):
+        assert 'must-not-leak' not in str(kwargs.get('metadata'))
+        return {
+            'id': 42,
+            'html_url': 'https://forge.example/owner/repo/agent/tasks/42',
+        }
+
+    async def fake_start(workflow_input):
+        started.append(workflow_input)
+        return 'forgejo-agent-task-42'
+
+    async def fake_update(**kwargs):
+        updates.append(kwargs)
+        return {'id': 42}
+
+    async def fail_legacy_dispatch(**kwargs):
+        raise AssertionError(
+            'legacy clone dispatch must not run in Temporal mode'
+        )
+
+    monkeypatch.setattr(forgejo_webhooks, 'forgejo_json', fake_json)
+    monkeypatch.setattr(forgejo_webhooks, '_ensure_workspace', fake_workspace)
+    monkeypatch.setattr(forgejo_webhooks, '_token', lambda: 'secret-token')
+    monkeypatch.setattr(
+        forgejo_webhooks, 'resolve_task_target', lambda: _async_value({})
+    )
+    monkeypatch.setattr(
+        'a2a_server.forgejo_agent_client.create_task', fake_create_agent_task
+    )
+    monkeypatch.setattr(
+        'a2a_server.forgejo_agent_client.update_task', fake_update
+    )
+    monkeypatch.setattr(
+        'a2a_server.temporal.config.temporal_settings',
+        lambda: SimpleNamespace(enabled=True),
+    )
+    monkeypatch.setattr(
+        'a2a_server.temporal.client.start_forgejo_workflow', fake_start
+    )
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fail_legacy_dispatch,
+    )
+
+    result = await forgejo_webhooks._dispatch(
+        {
+            'repo': 'owner/repo',
+            'number': 12,
+            'is_pr': True,
+            'body': '@codetether fix this',
+            'html_url': 'https://forge.example/owner/repo/pulls/12',
+            'actor_login': 'alice',
+            'comment_id': 9,
+        },
+        'https://forge.example/api/v1',
+    )
+
+    assert result['temporal_workflow_id'] == 'forgejo-agent-task-42'
+    assert len(started) == 1
+    assert started[0] == ForgejoAgentWorkflowInput(
+        forgejo_task_id=42,
+        repository='owner/repo',
+        issue_number=12,
+        pull_request_number=12,
+        workspace_id='workspace-1',
+        branch='feature',
+        head_sha='abc123',
+        operation='fix',
+    )
+    assert updates[-1]['status'] == 'accepted'
+
+
+async def _async_value(value):
+    return value
+
+
+@pytest.mark.asyncio
+async def test_temporal_terminal_sync_signals_without_legacy_followup(
+    monkeypatch,
+):
+    sync_calls = []
+    signals = []
+
+    async def fake_sync(task, *, workflow_terminal=True):
+        sync_calls.append((task, workflow_terminal))
+
+    async def fake_signal(forgejo_task_id, signal):
+        signals.append((forgejo_task_id, signal))
+
+    async def fail_legacy(*args, **kwargs):
+        raise AssertionError('legacy stage advancement must not run')
+
+    monkeypatch.setattr(
+        forgejo_task_completion, 'sync_forgejo_agent_task', fake_sync
+    )
+    monkeypatch.setattr(
+        'a2a_server.temporal.client.signal_task_terminal', fake_signal
+    )
+    monkeypatch.setattr(
+        forgejo_task_completion, 'create_forgejo_review_task', fail_legacy
+    )
+    monkeypatch.setattr(
+        forgejo_task_completion, 'create_forgejo_fix_followup', fail_legacy
+    )
+
+    task = {
+        'id': 'review-1',
+        'status': 'completed',
+        'session_id': 'session-1',
+        'result': 'APPROVED: focused tests pass',
+        'metadata': {
+            'source': 'forgejo-webhook',
+            'workflow_stage': 'review',
+            'temporal_orchestrated': True,
+            'forgejo_agent_task_id': 42,
+            'repo': 'owner/repo',
+            'pr_number': 12,
+            'pr_head_sha': 'abc123',
+        },
+    }
+    await forgejo_task_completion.notify_forgejo_task_completion(task)
+
+    assert sync_calls == [(task, False)]
+    assert len(signals) == 1
+    forgejo_task_id, signal = signals[0]
+    assert forgejo_task_id == 42
+    assert signal.task_id == 'review-1'
+    assert signal.stage == 'review'
+    assert signal.status == 'completed'
+    assert signal.verdict == 'APPROVED'

--- a/tests/test_forgejo_temporal_workflow.py
+++ b/tests/test_forgejo_temporal_workflow.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import asyncio
+
+from dataclasses import asdict
+from datetime import timedelta
+
+import pytest
+
+from temporalio import activity
+from temporalio.client import WorkflowHistoryEventFilterType
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from a2a_server.temporal.models import (
+    ForgejoAgentWorkflowInput,
+    ForgejoControlSignal,
+    ForgejoStageRequest,
+    ForgejoStageResult,
+    ForgejoTaskTerminalSignal,
+)
+from a2a_server.temporal.workflows import ForgejoAgentWorkflow
+
+
+class FakeActivities:
+    def __init__(self, verdicts: list[str] | None = None, fail_stage: str = ''):
+        self.dispatched: list[ForgejoStageRequest] = []
+        self.results: list[ForgejoStageResult] = []
+        self.cancelled: list[str] = []
+        self.finalized: list[dict] = []
+        self.verdicts = list(verdicts or ['APPROVED'])
+        self.fail_stage = fail_stage
+        self.counter = 0
+
+    def _result(self, request: ForgejoStageRequest) -> ForgejoStageResult:
+        self.counter += 1
+        self.dispatched.append(request)
+        result = ForgejoStageResult(
+            task_id=f'{request.stage}-{self.counter}',
+            stage=request.stage,
+            pull_request_number=request.workflow.pull_request_number or 7,
+            branch='feature',
+            head_sha='abc123',
+        )
+        self.results.append(result)
+        return result
+
+    @activity.defn(name='forgejo_dispatch_stage')
+    async def dispatch_stage(
+        self, request: ForgejoStageRequest
+    ) -> ForgejoStageResult:
+        if request.stage == self.fail_stage:
+            raise ApplicationError(
+                'forgejo_dispatch_stage_failed',
+                type='forgejo_dispatch_stage_failed',
+            )
+        return self._result(request)
+
+    @activity.defn(name='forgejo_dispatch_review')
+    async def dispatch_review(
+        self, request: ForgejoStageRequest
+    ) -> ForgejoStageResult:
+        return self._result(request)
+
+    @activity.defn(name='forgejo_dispatch_fix')
+    async def dispatch_fix(
+        self, request: ForgejoStageRequest
+    ) -> ForgejoStageResult:
+        return self._result(request)
+
+    @activity.defn(name='forgejo_publish_review')
+    async def publish_review(self, review_task_id: str) -> str:
+        assert review_task_id.startswith('review-')
+        return self.verdicts.pop(0)
+
+    @activity.defn(name='forgejo_cancel_task')
+    async def cancel_task(self, task_id: str) -> bool:
+        self.cancelled.append(task_id)
+        return True
+
+    @activity.defn(name='forgejo_finalize_workflow')
+    async def finalize_workflow(self, payload: dict) -> None:
+        self.finalized.append(payload)
+
+    @property
+    def registered(self):
+        return [
+            self.dispatch_stage,
+            self.dispatch_review,
+            self.publish_review,
+            self.dispatch_fix,
+            self.cancel_task,
+            self.finalize_workflow,
+        ]
+
+
+INPUT = ForgejoAgentWorkflowInput(
+    forgejo_task_id=42,
+    repository='acme/widgets',
+    issue_number=7,
+    pull_request_number=7,
+    workspace_id='workspace-1',
+    branch='feature',
+    head_sha='abc123',
+    operation='fix',
+)
+
+
+async def wait_for_stage(handle, stage: str) -> str:
+    for _ in range(100):
+        state = await handle.query(ForgejoAgentWorkflow.state)
+        active = str(state['active_task_id'])
+        if active.startswith(f'{stage}-'):
+            return active
+        await asyncio.sleep(0.01)
+    raise AssertionError(f'workflow never reached {stage}')
+
+
+async def wait_for_dispatched(
+    activities: FakeActivities, stage: str, occurrence: int
+) -> str:
+    for _ in range(200):
+        results = [
+            result for result in activities.results if result.stage == stage
+        ]
+        if len(results) >= occurrence:
+            return results[occurrence - 1].task_id
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        f'workflow never dispatched {stage} occurrence {occurrence}'
+    )
+
+
+async def complete(handle, task_id: str, stage: str, status='completed'):
+    await handle.signal(
+        ForgejoAgentWorkflow.task_terminal,
+        ForgejoTaskTerminalSignal(
+            task_id=task_id,
+            stage=stage,
+            status=status,
+            head_sha='abc123',
+            pull_request_number=7,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_temporal_forgejo_workflow_approval_and_safe_history():
+    activities = FakeActivities(['APPROVED'])
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue='forgejo-test',
+            workflows=[ForgejoAgentWorkflow],
+            activities=activities.registered,
+        ):
+            handle = await env.client.start_workflow(
+                ForgejoAgentWorkflow.run,
+                INPUT,
+                id='forgejo-agent-task-42-success',
+                task_queue='forgejo-test',
+            )
+            prepare = await wait_for_stage(handle, 'prepare')
+            await complete(handle, prepare, 'prepare')
+            code = await wait_for_stage(handle, 'code')
+            await complete(handle, code, 'code')
+            review = await wait_for_stage(handle, 'review')
+            await complete(handle, review, 'review')
+            result = await handle.result()
+
+            assert result.status == 'completed'
+            assert result.completed_stages == ['prepare', 'code', 'review']
+            assert result.review_verdict == 'APPROVED'
+            assert activities.finalized[-1]['status'] == 'completed'
+
+            history = await handle.fetch_history(
+                event_filter_type=WorkflowHistoryEventFilterType.ALL_EVENT
+            )
+            encoded = str(history).lower()
+            for forbidden in (
+                'must-not-leak',
+                'authorization:',
+                'private key',
+                'tool_calls',
+                'clone_url',
+                'prompt',
+                'transcript',
+            ):
+                assert forbidden not in encoded
+            assert 'acme/widgets' in encoded
+
+
+@pytest.mark.asyncio
+async def test_temporal_blocking_review_runs_fix_and_rereview():
+    activities = FakeActivities(['CHANGES_REQUESTED', 'APPROVED'])
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue='forgejo-test-fix',
+            workflows=[ForgejoAgentWorkflow],
+            activities=activities.registered,
+        ):
+            handle = await env.client.start_workflow(
+                ForgejoAgentWorkflow.run,
+                INPUT,
+                id='forgejo-agent-task-42-fix',
+                task_queue='forgejo-test-fix',
+            )
+            for stage in ('prepare', 'code', 'review', 'fix', 'review'):
+                task_id = await wait_for_stage(handle, stage)
+                await complete(handle, task_id, stage)
+            result = await handle.result()
+
+    assert result.status == 'completed'
+    assert [request.stage for request in activities.dispatched] == [
+        'prepare',
+        'code',
+        'review',
+        'fix',
+        'review',
+    ]
+    fix_request = activities.dispatched[3]
+    assert fix_request.fix_attempt == 1
+    assert fix_request.review_task_id.startswith('review-')
+
+
+@pytest.mark.asyncio
+async def test_temporal_cancel_propagates_to_active_task():
+    activities = FakeActivities()
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue='forgejo-test-cancel',
+            workflows=[ForgejoAgentWorkflow],
+            activities=activities.registered,
+        ):
+            handle = await env.client.start_workflow(
+                ForgejoAgentWorkflow.run,
+                INPUT,
+                id='forgejo-agent-task-42-cancel',
+                task_queue='forgejo-test-cancel',
+            )
+            prepare = await wait_for_stage(handle, 'prepare')
+            await handle.signal(
+                ForgejoAgentWorkflow.control,
+                ForgejoControlSignal(action='cancel', forgejo_task_id=42),
+            )
+            for _ in range(100):
+                if prepare in activities.cancelled:
+                    break
+                await asyncio.sleep(0.01)
+            assert prepare in activities.cancelled
+            state = await handle.query(ForgejoAgentWorkflow.state)
+            assert state['cancel_requested'] is True
+            await env.sleep(timedelta(days=8))
+            result = await handle.result()
+
+    assert result.status == 'cancelled'
+    assert activities.finalized[-1]['status'] == 'cancelled'
+
+
+@pytest.mark.asyncio
+async def test_temporal_retry_continues_as_new_attempt():
+    activities = FakeActivities(['APPROVED'])
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue='forgejo-test-retry',
+            workflows=[ForgejoAgentWorkflow],
+            activities=activities.registered,
+        ):
+            handle = await env.client.start_workflow(
+                ForgejoAgentWorkflow.run,
+                INPUT,
+                id='forgejo-agent-task-42-retry',
+                task_queue='forgejo-test-retry',
+            )
+            first_prepare = await wait_for_stage(handle, 'prepare')
+            await complete(handle, first_prepare, 'prepare', status='failed')
+            for _ in range(100):
+                if activities.finalized:
+                    break
+                await asyncio.sleep(0.01)
+            assert activities.finalized[-1]['status'] == 'failed'
+            await handle.signal(
+                ForgejoAgentWorkflow.control,
+                ForgejoControlSignal(action='retry', forgejo_task_id=42),
+            )
+            second_prepare = await wait_for_dispatched(activities, 'prepare', 2)
+            assert second_prepare != first_prepare
+            assert activities.dispatched[-1].workflow.attempt == 2
+            await complete(handle, second_prepare, 'prepare')
+            code = await wait_for_dispatched(activities, 'code', 1)
+            await complete(handle, code, 'code')
+            review = await wait_for_dispatched(activities, 'review', 1)
+            await complete(handle, review, 'review')
+            result = await handle.result()
+
+    assert result.status == 'completed'
+    assert result.attempt == 2
+    assert asdict(activities.dispatched[-1].workflow)['forgejo_task_id'] == 42
+
+
+@pytest.mark.asyncio
+async def test_temporal_activity_exhaustion_projects_failed_attempt():
+    activities = FakeActivities(fail_stage='prepare')
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue='forgejo-test-activity-failure',
+            workflows=[ForgejoAgentWorkflow],
+            activities=activities.registered,
+        ):
+            handle = await env.client.start_workflow(
+                ForgejoAgentWorkflow.run,
+                INPUT,
+                id='forgejo-agent-task-42-activity-failure',
+                task_queue='forgejo-test-activity-failure',
+            )
+            result = await handle.result()
+
+    assert result.status == 'failed'
+    assert result.error_type == 'forgejo_dispatch_stage_failed'
+    assert activities.finalized[-1]['status'] == 'failed'

--- a/tests/test_forgejo_webhooks.py
+++ b/tests/test_forgejo_webhooks.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import json
 import sys
+import time
 
 from types import SimpleNamespace
 
@@ -324,3 +325,76 @@ def test_configured_forgejo_host_is_allowed_without_credential_injection(
     assert not validate_git_url('https://token@forge.example/owner/repo.git')
     assert not validate_git_url('http://forge.example/owner/repo.git')
     assert not validate_git_url('https://evil.example/owner/repo.git')
+
+
+async def _post_control(app, payload, signature=None):
+    raw = json.dumps(payload).encode()
+    headers = {
+        'X-Forgejo-Event': 'agent_task_control',
+        'X-Forgejo-Signature': signature
+        if signature is not None
+        else _signature(raw),
+        'Content-Type': 'application/json',
+    }
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url='http://test'
+    ) as client:
+        return await client.post(
+            '/v1/webhooks/forgejo/agent-control',
+            content=raw,
+            headers=headers,
+        )
+
+
+@pytest.mark.asyncio
+async def test_signed_agent_control_signals_temporal(app, monkeypatch):
+    signals = []
+
+    async def fake_signal(signal):
+        signals.append(signal)
+
+    monkeypatch.setattr(
+        'a2a_server.temporal.client.signal_control', fake_signal
+    )
+    payload = {
+        'action': 'cancel',
+        'task_id': 42,
+        'requested_by': 'alice',
+        'request_id': 'control-1',
+        'issued_at': int(time.time()),
+    }
+    response = await _post_control(app, payload)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'accepted': True,
+        'task_id': 42,
+        'action': 'cancel',
+    }
+    assert len(signals) == 1
+    assert signals[0].forgejo_task_id == 42
+    assert signals[0].requested_by == 'alice'
+
+
+@pytest.mark.asyncio
+async def test_agent_control_rejects_bad_signature_and_expiry(app):
+    payload = {
+        'action': 'retry',
+        'task_id': 42,
+        'issued_at': int(time.time()) - 301,
+    }
+    bad_signature = await _post_control(app, payload, signature='bad')
+    assert bad_signature.status_code == 401
+
+    expired = await _post_control(app, payload)
+    assert expired.status_code == 401
+    assert expired.json()['detail'] == 'Expired Forgejo agent control'
+
+
+@pytest.mark.asyncio
+async def test_agent_control_rejects_unknown_action(app):
+    response = await _post_control(
+        app,
+        {'action': 'delete', 'task_id': 42, 'issued_at': int(time.time())},
+    )
+    assert response.status_code == 422

--- a/tests/test_forgejo_webhooks.py
+++ b/tests/test_forgejo_webhooks.py
@@ -3,6 +3,9 @@
 import hashlib
 import hmac
 import json
+import sys
+
+from types import SimpleNamespace
 
 import pytest
 
@@ -155,6 +158,36 @@ async def test_edited_existing_mention_does_not_retrigger(app):
         'accepted': False,
         'reason': 'unsupported-or-no-mention',
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('row', 'expected'), [({'id': 'task-1'}, True), (None, False)]
+)
+async def test_active_task_uses_database_pool(monkeypatch, row, expected):
+    class Connection:
+        async def fetchrow(self, query, repo, number):
+            assert "source' = 'forgejo-webhook'" in query
+            assert (repo, number) == ('owner/repo', '12')
+            return row
+
+    class Acquire:
+        async def __aenter__(self):
+            return Connection()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class Pool:
+        def acquire(self):
+            return Acquire()
+
+    async def get_pool():
+        return Pool()
+
+    database = SimpleNamespace(get_pool=get_pool)
+    monkeypatch.setitem(sys.modules, 'a2a_server.database', database)
+    assert await fw._active_task('owner/repo', 12) is expected  # noqa: SLF001
 
 
 def test_configured_forgejo_host_is_allowed_without_credential_injection(

--- a/tests/test_forgejo_webhooks.py
+++ b/tests/test_forgejo_webhooks.py
@@ -52,10 +52,10 @@ def app(monkeypatch):
     return app
 
 
-async def _post(app, payload, signature=None):
+async def _post(app, payload, signature=None, event='issue_comment'):
     raw = json.dumps(payload).encode()
     headers = {
-        'X-Forgejo-Event': 'issue_comment',
+        'X-Forgejo-Event': event,
         'X-Forgejo-Signature': signature
         if signature is not None
         else _signature(raw),
@@ -67,6 +67,132 @@ async def _post(app, payload, signature=None):
         return await client.post(
             '/v1/webhooks/forgejo', content=raw, headers=headers
         )
+
+
+def _status_payload(
+    *, state='failure', sha='abc123', sender='forgejo-actions', context='tests'
+):
+    return {
+        'id': 7,
+        'sha': sha,
+        'state': state,
+        'context': context,
+        'description': 'tests failed',
+        'target_url': 'https://forge.example/actions/runs/1',
+        'commit': {'id': sha},
+        'repository': {
+            'full_name': 'owner/repo',
+            'html_url': 'https://forge.example/owner/repo',
+        },
+        'sender': {'login': sender},
+    }
+
+
+@pytest.mark.asyncio
+async def test_failed_status_webhook_queues_matching_pr_remediation(
+    app, monkeypatch
+):
+    calls = []
+
+    async def fake_json(method, base, path, payload=None):
+        assert method == 'GET'
+        assert 'pulls?state=open' in path
+        return [
+            {
+                'number': 5,
+                'html_url': 'https://forge.example/owner/repo/pulls/5',
+                'head': {'sha': 'abc123', 'ref': 'feature'},
+            }
+        ]
+
+    async def fake_remediation(**kwargs):
+        calls.append(kwargs)
+        return 'fix-1'
+
+    monkeypatch.setattr(fw, 'forgejo_json', fake_json)
+    monkeypatch.setattr(
+        'a2a_server.forgejo_automation.create_status_remediation_task',
+        fake_remediation,
+    )
+    response = await _post(app, _status_payload(), event='status')
+    assert response.status_code == 200
+    assert response.json() == {
+        'accepted': True,
+        'reason': 'queued',
+        'task_id': 'fix-1',
+    }
+    assert calls[0]['repo'] == 'owner/repo'
+    assert calls[0]['pr']['number'] == 5
+    assert calls[0]['status']['status'] == 'failure'
+    assert calls[0]['status']['creator']['login'] == 'forgejo-actions'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('payload', 'reason'),
+    [
+        (_status_payload(state='success'), 'non-failed-or-self-status'),
+        (
+            _status_payload(sender='codetether-bot'),
+            'non-failed-or-self-status',
+        ),
+    ],
+)
+async def test_status_webhook_ignores_success_and_self_status(
+    app, monkeypatch, payload, reason
+):
+    async def unexpected(*args, **kwargs):
+        raise AssertionError('Forgejo PR lookup should not run')
+
+    monkeypatch.setattr(fw, 'forgejo_json', unexpected)
+    response = await _post(app, payload, event='status')
+    assert response.json() == {'accepted': False, 'reason': reason}
+
+
+@pytest.mark.asyncio
+async def test_status_webhook_paginates_open_pr_heads(app, monkeypatch):
+    paths = []
+
+    async def fake_json(method, base, path, payload=None):
+        paths.append(path)
+        if 'page=1' in path:
+            return [
+                {'number': number, 'head': {'sha': f'other-{number}'}}
+                for number in range(50)
+            ]
+        return [
+            {
+                'number': 77,
+                'html_url': 'https://forge.example/owner/repo/pulls/77',
+                'head': {'sha': 'abc123', 'ref': 'feature'},
+            }
+        ]
+
+    async def fake_remediation(**kwargs):
+        return 'fix-page-2'
+
+    monkeypatch.setattr(fw, 'forgejo_json', fake_json)
+    monkeypatch.setattr(
+        'a2a_server.forgejo_automation.create_status_remediation_task',
+        fake_remediation,
+    )
+    response = await _post(app, _status_payload(), event='status')
+    assert response.json()['task_id'] == 'fix-page-2'
+    assert any('page=1' in path for path in paths)
+    assert any('page=2' in path for path in paths)
+
+
+@pytest.mark.asyncio
+async def test_status_webhook_ignores_unmatched_sha(app, monkeypatch):
+    async def fake_json(method, base, path, payload=None):
+        return [{'number': 5, 'head': {'sha': 'different'}}]
+
+    monkeypatch.setattr(fw, 'forgejo_json', fake_json)
+    response = await _post(app, _status_payload(), event='status')
+    assert response.json() == {
+        'accepted': False,
+        'reason': 'no-open-pr-for-status-sha',
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_forgejo_webhooks.py
+++ b/tests/test_forgejo_webhooks.py
@@ -1,0 +1,167 @@
+# ruff: noqa: PLR2004
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from a2a_server import forgejo_webhooks as fw
+from a2a_server.git_service import validate_git_url
+
+
+def _payload(
+    body='@codetether handle this issue', *, sender='alice', action='created'
+):
+    return {
+        'action': action,
+        'comment': {'id': 9, 'body': body, 'user': {'login': sender}},
+        'issue': {
+            'number': 12,
+            'title': 'Broken widget',
+            'body': 'The widget fails.',
+            'html_url': 'https://forge.example/owner/repo/issues/12',
+        },
+        'repository': {
+            'full_name': 'owner/repo',
+            'html_url': 'https://forge.example/owner/repo',
+            'clone_url': 'https://forge.example/owner/repo.git',
+        },
+        'sender': {'login': sender},
+    }
+
+
+def _signature(body: bytes, secret='secret') -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv('FORGEJO_WEBHOOK_SECRET', 'secret')
+    monkeypatch.setenv('FORGEJO_TOKEN', 'token')
+    monkeypatch.setenv('FORGEJO_API_URL', 'https://forge.example/api/v1')
+    monkeypatch.setenv('FORGEJO_BOT_USERNAME', 'codetether')
+    app = FastAPI()
+    app.include_router(fw.forgejo_webhook_router)
+    return app
+
+
+async def _post(app, payload, signature=None):
+    raw = json.dumps(payload).encode()
+    headers = {
+        'X-Forgejo-Event': 'issue_comment',
+        'X-Forgejo-Signature': signature
+        if signature is not None
+        else _signature(raw),
+        'Content-Type': 'application/json',
+    }
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url='http://test'
+    ) as client:
+        return await client.post(
+            '/v1/webhooks/forgejo', content=raw, headers=headers
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_signature(app):
+    response = await _post(app, _payload(), 'wrong')
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_ignores_bot_authored_comment(app, monkeypatch):
+    monkeypatch.setattr(fw, '_active_task', lambda *args: None)
+    response = await _post(app, _payload(sender='codetether'))
+    assert response.json() == {
+        'accepted': False,
+        'reason': 'self-authored-event',
+    }
+
+
+@pytest.mark.asyncio
+async def test_non_fix_mention_posts_guidance(app, monkeypatch):
+    comments = []
+
+    async def inactive(*args):
+        return False
+
+    async def comment(*args):
+        comments.append(args)
+
+    monkeypatch.setattr(fw, '_active_task', inactive)
+    monkeypatch.setattr(fw, '_comment', comment)
+    response = await _post(app, _payload('@codetether hello'))
+    assert response.json() == {'accepted': False, 'reason': 'non-fix mention'}
+    assert 'Ask me explicitly' in comments[0][3]
+
+
+@pytest.mark.asyncio
+async def test_actionable_issue_dispatches_and_acknowledges(app, monkeypatch):
+    comments = []
+
+    async def inactive(*args):
+        return False
+
+    async def dispatch(ctx, base):
+        assert ctx['repo'] == 'owner/repo'
+        assert ctx['number'] == 12
+        assert not ctx['is_pr']
+        assert base == 'https://forge.example/api/v1'
+        return {'accepted': True, 'clone_task_id': 'task-1'}
+
+    async def comment(*args):
+        comments.append(args)
+
+    monkeypatch.setattr(fw, '_active_task', inactive)
+    monkeypatch.setattr(fw, '_dispatch', dispatch)
+    monkeypatch.setattr(fw, '_comment', comment)
+    response = await _post(app, _payload())
+    assert response.status_code == 200
+    assert response.json() == {'accepted': True, 'clone_task_id': 'task-1'}
+    assert 'Picked this up' in comments[0][3]
+
+
+@pytest.mark.asyncio
+async def test_pr_comment_is_normalized_as_pr(app, monkeypatch):
+    payload = _payload('@codetether fix the tests')
+    payload['issue']['pull_request'] = {'merged': False}
+
+    async def inactive(*args):
+        return False
+
+    async def dispatch(ctx, base):
+        assert ctx['is_pr']
+        return {'accepted': True}
+
+    async def comment(*args):
+        return None
+
+    monkeypatch.setattr(fw, '_active_task', inactive)
+    monkeypatch.setattr(fw, '_dispatch', dispatch)
+    monkeypatch.setattr(fw, '_comment', comment)
+    assert (await _post(app, payload)).json() == {'accepted': True}
+
+
+@pytest.mark.asyncio
+async def test_edited_existing_mention_does_not_retrigger(app):
+    payload = _payload(action='edited')
+    payload['changes'] = {'body': {'from': '@codetether handle this issue'}}
+    response = await _post(app, payload)
+    assert response.json() == {
+        'accepted': False,
+        'reason': 'unsupported-or-no-mention',
+    }
+
+
+def test_configured_forgejo_host_is_allowed_without_credential_injection(
+    monkeypatch,
+):
+    monkeypatch.setenv('FORGEJO_API_URL', 'https://forge.example/api/v1')
+    assert validate_git_url('https://forge.example/owner/repo.git')
+    assert not validate_git_url('https://token@forge.example/owner/repo.git')
+    assert not validate_git_url('http://forge.example/owner/repo.git')
+    assert not validate_git_url('https://evil.example/owner/repo.git')

--- a/tests/test_github_app_acceptance_dedupe.py
+++ b/tests/test_github_app_acceptance_dedupe.py
@@ -1,0 +1,100 @@
+import os
+
+os.environ.setdefault(
+    'DATABASE_URL', 'postgresql://test:test@localhost:5432/test'
+)
+
+import pytest
+
+from a2a_server.github_app.watch import (
+    _looks_like_acceptance_comment,
+    _within_window,
+    recent_app_acceptance_comment_exists,
+)
+
+
+def test_looks_like_acceptance_comment_matches_known_messages():
+    body_pr = (
+        '## 🛠️ CodeTether Fix\n\n'
+        'Picked up this request for PR #614 on branch `codetether/issue-613`. '
+        "I'm preparing the workspace and will push changes directly to the existing PR branch if the task succeeds. "
+        'I will also make sure the branch is mergeable with `main`.'
+    )
+    body_issue = (
+        '## 🛠️ CodeTether Fix\n\n'
+        'Picked up issue #42 on branch `codetether/issue-42`. '
+        "I'm preparing the workspace and will open a PR if the task succeeds."
+    )
+    body_other = '## 🛠️ CodeTether Fix\n\nPushed changes to this PR branch.'
+    assert _looks_like_acceptance_comment(body_pr) is True
+    assert _looks_like_acceptance_comment(body_issue) is True
+    assert _looks_like_acceptance_comment(body_other) is False
+    assert _looks_like_acceptance_comment('') is False
+
+
+def test_within_window_handles_z_suffix_and_recent_timestamps():
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    recent = (now - timedelta(seconds=30)).isoformat().replace('+00:00', 'Z')
+    ancient = (now - timedelta(seconds=3600)).isoformat().replace('+00:00', 'Z')
+    assert _within_window(recent, within_seconds=600) is True
+    assert _within_window(ancient, within_seconds=600) is False
+    assert _within_window('', within_seconds=600) is False
+    assert _within_window('not-a-timestamp', within_seconds=600) is False
+
+
+@pytest.mark.asyncio
+async def test_recent_app_acceptance_comment_exists_true(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    recent = (now - timedelta(seconds=10)).isoformat().replace('+00:00', 'Z')
+
+    async def fake_github_json(method, path, token, payload=None):
+        return [
+            {
+                'user': {'login': 'codetether[bot]'},
+                'body': '## 🛠️ CodeTether Fix\n\nPicked up this request for PR #614 on branch `x`.',
+                'created_at': recent,
+            }
+        ]
+
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.github_json', fake_github_json
+    )
+
+    def fake_within(ts, within_seconds):
+        assert ts == recent
+        assert within_seconds == 600
+        return True
+
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch._within_window', fake_within
+    )
+    found = await recent_app_acceptance_comment_exists(
+        'acme/widgets', 7, 'ghs_token', app_slug='codetether'
+    )
+    assert found is True
+
+
+@pytest.mark.asyncio
+async def test_recent_app_acceptance_comment_exists_false_for_human(
+    monkeypatch,
+):
+    async def fake_github_json(method, path, token, payload=None):
+        return [
+            {
+                'user': {'login': 'rileyseaburg'},
+                'body': 'Picked up this request for PR #614 on branch `x`.',
+                'created_at': '2024-01-01T00:00:00Z',
+            }
+        ]
+
+    monkeypatch.setattr(
+        'a2a_server.github_app.watch.github_json', fake_github_json
+    )
+    found = await recent_app_acceptance_comment_exists(
+        'acme/widgets', 7, 'ghs_token', app_slug='codetether'
+    )
+    assert found is False

--- a/tests/test_github_app_active_work.py
+++ b/tests/test_github_app_active_work.py
@@ -26,12 +26,18 @@ async def test_dispatch_active_work_for_repo_queues_open_issues_and_prs(
             '/repos/owner/repo/issues?state=open&per_page=100&page=1'
         )
         return [
-            {'id': 11, 'number': 1, 'body': '@codetether implement this'},
+            {
+                'id': 11,
+                'number': 1,
+                'body': '@codetether implement this',
+                'user': {'login': 'issue-author'},
+            },
             {
                 'id': 22,
                 'number': PR_NUMBER,
                 'body': '@codetether fix the failing PR',
                 'pull_request': {},
+                'user': {'login': 'pr-author'},
             },
         ]
 
@@ -70,8 +76,10 @@ async def test_dispatch_active_work_for_repo_queues_open_issues_and_prs(
     assert [result.task_id for result in results] == ['task-1', 'task-2']
     assert calls[0][0].pr_number is None
     assert calls[0][0].comment_body == '@codetether implement this'
+    assert calls[0][0].actor_login == 'issue-author'
     assert calls[1][0].pr_number == PR_NUMBER
     assert calls[1][0].comment_body == '@codetether fix the failing PR'
+    assert calls[1][0].actor_login == 'pr-author'
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_app_issue_review_flow.py
+++ b/tests/test_github_app_issue_review_flow.py
@@ -107,6 +107,7 @@ async def test_issue_final_comment_queues_review_task(monkeypatch, pr_payload):
                 'github_issue_url': 'https://github.com/acme/widgets/issues/12',
                 'github_installation_id': 123,
                 'target_worker_id': 'wrk1',
+                'trigger_actor_login': 'rileyseaburg',
             },
         }
     )
@@ -114,23 +115,35 @@ async def test_issue_final_comment_queues_review_task(monkeypatch, pr_payload):
     assert created
     assert created[0]['parent_task_id'] == 'task-code'
     assert created[0]['pr']['number'] == 77
+    assert created[0]['token'] == 'token'
+    assert created[0]['trigger_actor_login'] == 'rileyseaburg'
     assert 'target_worker_id' not in created[0]
     assert 'Queued CodeTether reviewer task `task-review-1`' in comments[0]
     assert 'Automation provenance:' in comments[0]
 
 
 @pytest.mark.asyncio
-async def test_review_completion_queues_merge_task(monkeypatch):
+async def test_review_completion_publishes_review_before_merge_task(
+    monkeypatch,
+):
     calls = []
 
     async def fake_context(task):
         return 'acme/widgets', 77, 'codetether/issue-12', 'token'
 
+    async def fake_publish_review(review_task, token):
+        calls.append(('publish', review_task, token))
+        return {'published': True, 'review_id': 991}
+
     async def fake_create_merge_task(review_task, token):
-        calls.append((review_task, token))
+        calls.append(('merge', review_task, token))
         return 'task-merge-1'
 
     monkeypatch.setattr(task_context, 'github_app_task_context', fake_context)
+    monkeypatch.setattr(
+        'a2a_server.github_app.review_publish.publish_github_review',
+        fake_publish_review,
+    )
     monkeypatch.setattr(
         issue_review_task, 'create_issue_merge_task', fake_create_merge_task
     )
@@ -144,7 +157,10 @@ async def test_review_completion_queues_merge_task(monkeypatch):
 
     await task_completion.notify_issue_task_completion(task)
 
-    assert calls == [(task, 'token')]
+    assert calls == [
+        ('publish', task, 'token'),
+        ('merge', task, 'token'),
+    ]
 
 
 @pytest.mark.asyncio
@@ -234,6 +250,53 @@ async def test_create_review_task_records_deny_decision(
     assert task_id is None
     assert decisions[0]['decision']['allowed'] is False
     assert decisions[0]['task_id'] == 'task-code'
+
+
+@pytest.mark.asyncio
+async def test_create_review_task_requests_triggering_human_review(
+    monkeypatch, pr_payload
+):
+    requests = []
+
+    async def fake_dispatch(**kwargs):
+        return 'task-review-1'
+
+    async def fake_record(**kwargs):
+        return None
+
+    async def fake_request_human_review(repo, pr_number, token, reviewer_login):
+        requests.append((repo, pr_number, token, reviewer_login))
+        return True
+
+    monkeypatch.setattr(
+        'a2a_server.persistent_worker_pool.create_and_dispatch_task',
+        fake_dispatch,
+    )
+    monkeypatch.setattr(
+        issue_review_task, 'record_automation_decision', fake_record
+    )
+    monkeypatch.setattr(
+        'a2a_server.github_app.review_request.request_human_review',
+        fake_request_human_review,
+    )
+
+    task_id = await issue_review_task.create_issue_review_task(
+        workspace_id='ws1',
+        repo='acme/widgets',
+        issue_number=12,
+        branch='codetether/issue-12',
+        pr=pr_payload,
+        github_issue_url='https://github.com/acme/widgets/issues/12',
+        github_installation_id=123,
+        token='ghs_installation_token',
+        parent_task_id='task-code',
+        trigger_actor_login='rileyseaburg',
+    )
+
+    assert task_id == 'task-review-1'
+    assert requests == [
+        ('acme/widgets', 77, 'ghs_installation_token', 'rileyseaburg')
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_app_mentions.py
+++ b/tests/test_github_app_mentions.py
@@ -1,5 +1,8 @@
 from a2a_server.github_app.mention import is_fix_request, mentions_bot
-from a2a_server.github_app.payload import extract_context, is_supported_event_action
+from a2a_server.github_app.payload import (
+    extract_context,
+    is_supported_event_action,
+)
 from a2a_server.github_app.settings import APP_SLUG
 
 
@@ -51,3 +54,46 @@ def test_issue_edit_only_triggers_when_mention_is_new():
 
     payload['changes']['body']['from'] = f'@{APP_SLUG} old instructions'
     assert not is_supported_event_action('issues', payload)
+
+
+def test_edited_issue_attributes_trigger_to_sender():
+    payload = {
+        'action': 'edited',
+        'changes': {'body': {'from': 'plain issue body'}},
+        'installation': {'id': 123},
+        'repository': {'full_name': 'owner/repo'},
+        'issue': {
+            'id': 456,
+            'number': 7,
+            'body': f'@{APP_SLUG} handle this issue',
+            'user': {'login': 'original-author'},
+        },
+        'sender': {'login': 'human-editor'},
+    }
+
+    context = extract_context('issues', payload)
+
+    assert context is not None
+    assert context.actor_login == 'human-editor'
+
+
+def test_edited_pull_request_attributes_trigger_to_sender():
+    payload = {
+        'action': 'edited',
+        'changes': {'body': {'from': 'plain pull request body'}},
+        'installation': {'id': 123},
+        'repository': {'full_name': 'owner/repo'},
+        'pull_request': {
+            'id': 789,
+            'number': 8,
+            'body': f'@{APP_SLUG} fix this pull request',
+            'user': {'login': 'original-author'},
+        },
+        'sender': {'login': 'human-editor'},
+    }
+
+    context = extract_context('pull_request', payload)
+
+    assert context is not None
+    assert context.pr_number == 8
+    assert context.actor_login == 'human-editor'

--- a/tests/test_github_app_review_publish.py
+++ b/tests/test_github_app_review_publish.py
@@ -1,0 +1,138 @@
+import pytest
+
+from a2a_server.github_app import review_publish
+
+
+def _review_task(result: str = 'APPROVED: looks safe') -> dict:
+    return {
+        'id': 'task-review-1',
+        'result': result,
+        'metadata': {
+            'source': 'github-app',
+            'workflow_stage': 'review',
+            'repo': 'acme/widgets',
+            'pr_number': 77,
+            'pr_head_sha': 'abc123',
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ('result', 'event'),
+    [
+        ('APPROVED: looks safe', 'APPROVE'),
+        ('CHANGES_REQUESTED: fix the tests', 'REQUEST_CHANGES'),
+        ('BLOCKED: provenance mismatch', 'REQUEST_CHANGES'),
+        ('Review completed without a terminal verdict', 'COMMENT'),
+    ],
+)
+def test_review_event_maps_reviewer_verdict(result, event):
+    assert review_publish.review_event(_review_task(result)) == event
+
+
+@pytest.mark.asyncio
+async def test_publish_github_review_posts_semantic_review(monkeypatch):
+    calls = []
+
+    async def fake_github_json(method, path, token, payload=None):
+        calls.append((method, path, token, payload))
+        if method == 'GET':
+            return []
+        return {'id': 991}
+
+    monkeypatch.setattr(review_publish, 'github_json', fake_github_json)
+
+    result = await review_publish.publish_github_review(
+        _review_task(), 'ghs_token'
+    )
+
+    assert result == {
+        'published': True,
+        'duplicate': False,
+        'event': 'APPROVE',
+        'review_id': 991,
+    }
+    assert calls[0] == (
+        'GET',
+        '/repos/acme/widgets/pulls/77/reviews?per_page=100',
+        'ghs_token',
+        None,
+    )
+    assert calls[1][0:3] == (
+        'POST',
+        '/repos/acme/widgets/pulls/77/reviews',
+        'ghs_token',
+    )
+    assert calls[1][3]['event'] == 'APPROVE'
+    assert calls[1][3]['commit_id'] == 'abc123'
+    assert 'APPROVED: looks safe' in calls[1][3]['body']
+    assert review_publish.review_marker('task-review-1') in calls[1][3]['body']
+
+
+@pytest.mark.asyncio
+async def test_publish_github_review_suppresses_duplicate_marker(monkeypatch):
+    calls = []
+    marker = review_publish.review_marker('task-review-1')
+
+    async def fake_github_json(method, path, token, payload=None):
+        calls.append((method, path, token, payload))
+        return [{'id': 440, 'state': 'COMMENTED', 'body': f'done\n{marker}'}]
+
+    monkeypatch.setattr(review_publish, 'github_json', fake_github_json)
+
+    result = await review_publish.publish_github_review(
+        _review_task(), 'ghs_token'
+    )
+
+    assert result == {
+        'published': True,
+        'duplicate': True,
+        'event': 'COMMENTED',
+        'review_id': 440,
+    }
+    assert len(calls) == 1
+    assert calls[0][0] == 'GET'
+
+
+@pytest.mark.asyncio
+async def test_publish_github_review_retries_self_review_as_comment(
+    monkeypatch,
+):
+    calls = []
+
+    async def fake_github_json(method, path, token, payload=None):
+        calls.append((method, path, token, payload))
+        if method == 'GET':
+            return []
+        if payload['event'] == 'REQUEST_CHANGES':
+            raise RuntimeError(
+                'Can not request changes on your own pull request'
+            )
+        return {'id': 992}
+
+    monkeypatch.setattr(review_publish, 'github_json', fake_github_json)
+    task = _review_task('CHANGES_REQUESTED: fix the tests')
+
+    result = await review_publish.publish_github_review(task, 'ghs_token')
+
+    assert result == {
+        'published': True,
+        'duplicate': False,
+        'event': 'COMMENT',
+        'requested_event': 'REQUEST_CHANGES',
+        'review_id': 992,
+    }
+    assert [call[3]['event'] for call in calls if call[0] == 'POST'] == [
+        'REQUEST_CHANGES',
+        'COMMENT',
+    ]
+    assert calls[-1][3]['commit_id'] == 'abc123'
+    assert 'CHANGES_REQUESTED' in calls[-1][3]['body']
+
+
+@pytest.mark.asyncio
+async def test_publish_github_review_requires_complete_context():
+    with pytest.raises(ValueError, match='missing GitHub publication context'):
+        await review_publish.publish_github_review(
+            {'id': 'task-review-1', 'metadata': {}}, 'ghs_token'
+        )

--- a/tests/test_github_app_review_request.py
+++ b/tests/test_github_app_review_request.py
@@ -1,0 +1,63 @@
+import pytest
+
+from a2a_server.github_app.review_request import (
+    is_human_reviewer_login,
+    request_human_review,
+)
+
+
+def test_is_human_reviewer_login_filters_app_and_bots():
+    assert is_human_reviewer_login('rileyseaburg') is True
+    assert is_human_reviewer_login('codetether[bot]') is False
+    assert is_human_reviewer_login('codetether') is False
+    assert is_human_reviewer_login('codetether-bot') is False
+    assert is_human_reviewer_login('codetether-human') is True
+    assert is_human_reviewer_login('dependabot[bot]') is False
+    assert is_human_reviewer_login('') is False
+
+
+@pytest.mark.asyncio
+async def test_request_human_review_posts_requested_reviewers(monkeypatch):
+    calls = []
+
+    async def fake_github_json(method, path, token, payload=None):
+        calls.append((method, path, token, payload))
+        return {}
+
+    monkeypatch.setattr(
+        'a2a_server.github_app.review_request.github_json', fake_github_json
+    )
+
+    result = await request_human_review(
+        'acme/widgets', 77, 'ghs_token', 'rileyseaburg'
+    )
+
+    assert result is True
+    assert calls == [
+        (
+            'POST',
+            '/repos/acme/widgets/pulls/77/requested_reviewers',
+            'ghs_token',
+            {'reviewers': ['rileyseaburg']},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_human_review_skips_bot_login(monkeypatch):
+    calls = []
+
+    async def fake_github_json(method, path, token, payload=None):
+        calls.append((method, path, token, payload))
+        return {}
+
+    monkeypatch.setattr(
+        'a2a_server.github_app.review_request.github_json', fake_github_json
+    )
+
+    result = await request_human_review(
+        'acme/widgets', 77, 'ghs_token', 'codetether[bot]'
+    )
+
+    assert result is False
+    assert calls == []

--- a/tests/test_github_app_routing.py
+++ b/tests/test_github_app_routing.py
@@ -66,6 +66,20 @@ async def test_resolve_task_target_uses_capability_metadata_when_no_worker(monke
     }
 
 
+def test_clone_task_routing_collapses_persistent_capability_aliases(monkeypatch):
+    monkeypatch.setattr(routing, 'TARGET_WORKER_ID', '')
+    monkeypatch.setattr(routing, 'TARGET_AGENT', '')
+    monkeypatch.setattr(
+        routing,
+        'TARGET_CAPABILITIES',
+        ('persistent-workspace', 'persistent', 'persistent_workspace'),
+    )
+
+    assert routing.clone_task_routing_metadata() == {
+        'required_capabilities': ['persistent-workspace']
+    }
+
+
 @pytest.mark.asyncio
 async def test_resolve_task_target_preserves_configured_target_agent_with_capability(monkeypatch):
     async def fake_workers(status):

--- a/tests/test_github_app_routing.py
+++ b/tests/test_github_app_routing.py
@@ -1,14 +1,14 @@
-import sys
 from datetime import datetime, timezone
-from types import SimpleNamespace
 
 import pytest
 
-import a2a_server
+from a2a_server import database
 from a2a_server.github_app import routing
 
 
-def _recent_worker(worker_id, name, capabilities, *, hostname='node', is_busy=False):
+def _recent_worker(
+    worker_id, name, capabilities, *, hostname='node', is_busy=False
+):
     return {
         'worker_id': worker_id,
         'name': name,
@@ -21,28 +21,28 @@ def _recent_worker(worker_id, name, capabilities, *, hostname='node', is_busy=Fa
 
 
 def _patch_database(monkeypatch, db_list_workers):
-    fake_db = SimpleNamespace(db_list_workers=db_list_workers)
-    monkeypatch.setitem(
-        sys.modules,
-        'a2a_server.database',
-        fake_db,
-    )
-    monkeypatch.setattr(a2a_server, 'database', fake_db, raising=False)
+    monkeypatch.setattr(database, 'db_list_workers', db_list_workers)
 
 
 @pytest.mark.asyncio
-async def test_resolve_task_target_prefers_persistent_workspace_capability(monkeypatch):
+async def test_resolve_task_target_prefers_persistent_workspace_capability(
+    monkeypatch,
+):
     async def fake_workers(status):
         assert status == 'active'
         return [
             _recent_worker('wrk-knative', 'knative-worker', []),
-            _recent_worker('wrk-harvester', 'harvester-a', ['persistent-workspace']),
+            _recent_worker(
+                'wrk-harvester', 'harvester-a', ['persistent-workspace']
+            ),
         ]
 
     _patch_database(monkeypatch, fake_workers)
     monkeypatch.setattr(routing, 'TARGET_WORKER_ID', '')
     monkeypatch.setattr(routing, 'TARGET_AGENT', '')
-    monkeypatch.setattr(routing, 'TARGET_CAPABILITIES', ('persistent-workspace',))
+    monkeypatch.setattr(
+        routing, 'TARGET_CAPABILITIES', ('persistent-workspace',)
+    )
     monkeypatch.setattr(routing, 'PREFERRED_AGENTS', ('knative-worker',))
 
     assert await routing.resolve_task_target() == {
@@ -52,21 +52,27 @@ async def test_resolve_task_target_prefers_persistent_workspace_capability(monke
 
 
 @pytest.mark.asyncio
-async def test_resolve_task_target_uses_capability_metadata_when_no_worker(monkeypatch):
+async def test_resolve_task_target_uses_capability_metadata_when_no_worker(
+    monkeypatch,
+):
     async def fake_workers(status):
         return []
 
     _patch_database(monkeypatch, fake_workers)
     monkeypatch.setattr(routing, 'TARGET_WORKER_ID', '')
     monkeypatch.setattr(routing, 'TARGET_AGENT', '')
-    monkeypatch.setattr(routing, 'TARGET_CAPABILITIES', ('persistent-workspace',))
+    monkeypatch.setattr(
+        routing, 'TARGET_CAPABILITIES', ('persistent-workspace',)
+    )
 
     assert await routing.resolve_task_target() == {
         'required_capabilities': ['persistent-workspace']
     }
 
 
-def test_clone_task_routing_collapses_persistent_capability_aliases(monkeypatch):
+def test_clone_task_routing_collapses_persistent_capability_aliases(
+    monkeypatch,
+):
     monkeypatch.setattr(routing, 'TARGET_WORKER_ID', '')
     monkeypatch.setattr(routing, 'TARGET_AGENT', '')
     monkeypatch.setattr(
@@ -81,14 +87,18 @@ def test_clone_task_routing_collapses_persistent_capability_aliases(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_resolve_task_target_preserves_configured_target_agent_with_capability(monkeypatch):
+async def test_resolve_task_target_preserves_configured_target_agent_with_capability(
+    monkeypatch,
+):
     async def fake_workers(status):
         return []
 
     _patch_database(monkeypatch, fake_workers)
     monkeypatch.setattr(routing, 'TARGET_WORKER_ID', '')
     monkeypatch.setattr(routing, 'TARGET_AGENT', 'knative-worker')
-    monkeypatch.setattr(routing, 'TARGET_CAPABILITIES', ('persistent-workspace',))
+    monkeypatch.setattr(
+        routing, 'TARGET_CAPABILITIES', ('persistent-workspace',)
+    )
 
     assert await routing.resolve_task_target() == {
         'target_agent_name': 'knative-worker',

--- a/tests/test_github_app_task_priority.py
+++ b/tests/test_github_app_task_priority.py
@@ -1,0 +1,44 @@
+import ast
+from pathlib import Path
+
+from a2a_server.github_app.settings import TASK_PRIORITY
+
+
+GITHUB_APP_DIR = Path(__file__).parents[1] / 'a2a_server' / 'github_app'
+
+
+def test_github_app_task_priority_is_high_and_positive():
+    assert TASK_PRIORITY == 100
+
+
+def test_every_github_app_dispatch_uses_shared_priority():
+    dispatches = []
+    missing_priority = []
+
+    for path in sorted(GITHUB_APP_DIR.glob('*.py')):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            function_name = getattr(node.func, 'id', None) or getattr(
+                node.func, 'attr', None
+            )
+            if function_name != 'create_and_dispatch_task':
+                continue
+            dispatches.append(f'{path.name}:{node.lineno}')
+            priority = next(
+                (
+                    keyword.value
+                    for keyword in node.keywords
+                    if keyword.arg == 'priority'
+                ),
+                None,
+            )
+            if not (
+                isinstance(priority, ast.Name)
+                and priority.id == 'TASK_PRIORITY'
+            ):
+                missing_priority.append(f'{path.name}:{node.lineno}')
+
+    assert len(dispatches) == 9
+    assert missing_priority == []

--- a/tests/test_github_app_terminal_reconciler.py
+++ b/tests/test_github_app_terminal_reconciler.py
@@ -1,0 +1,113 @@
+import os
+
+os.environ.setdefault(
+    'DATABASE_URL', 'postgresql://test:test@localhost:5432/test'
+)
+
+import pytest
+
+from a2a_server import database as db
+from a2a_server.github_app import task_completion, task_status_hook
+
+
+class _FakeConnection:
+    def __init__(self, rows):
+        self.rows = rows
+        self.query = ''
+        self.limit = None
+
+    async def fetch(self, query, limit):
+        self.query = query
+        self.limit = limit
+        return self.rows
+
+
+class _AcquireContext:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _FakePool:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def acquire(self):
+        return _AcquireContext(self.connection)
+
+
+@pytest.mark.asyncio
+async def test_reconciler_recovers_merge_and_fix_review_outcomes(monkeypatch):
+    connection = _FakeConnection(
+        [
+            {'id': 'review-approved'},
+            {'id': 'review-changes'},
+            {'id': 'review-blocked'},
+            {'id': 'review-without-verdict'},
+        ]
+    )
+    pool = _FakePool(connection)
+    tasks = {
+        'review-approved': {
+            'id': 'review-approved',
+            'result': 'APPROVED: looks safe',
+        },
+        'review-changes': {
+            'id': 'review-changes',
+            'result': 'CHANGES_REQUESTED: fix the tests',
+        },
+        'review-blocked': {
+            'id': 'review-blocked',
+            'result': 'BLOCKED: provenance mismatch',
+        },
+        'review-without-verdict': {
+            'id': 'review-without-verdict',
+            'result': 'review completed',
+        },
+    }
+    handled = []
+
+    async def fake_get_pool():
+        return pool
+
+    async def fake_get_task(task_id):
+        return tasks[task_id]
+
+    async def fake_notify(task, worker_id=None):
+        handled.append(task['id'])
+
+    monkeypatch.setattr(db, 'get_pool', fake_get_pool)
+    monkeypatch.setattr(db, 'db_get_task', fake_get_task)
+    monkeypatch.setattr(
+        task_completion, 'notify_issue_task_completion', fake_notify
+    )
+
+    count = await task_status_hook.reconcile_github_app_terminal_tasks(limit=9)
+
+    assert count == 3
+    assert handled == [
+        'review-approved',
+        'review-changes',
+        'review-blocked',
+    ]
+    assert connection.limit == 9
+    assert "d.action = 'github:merge_pr'" in connection.query
+    assert "fix.metadata->>'review_task_id' = t.id" in connection.query
+    assert "fix.metadata->>'fix_followup' = 'true'" in connection.query
+    assert "t.result ILIKE '%CHANGES_REQUESTED%'" in connection.query
+    assert "t.result ~* 'BLOCKED\\s*:'" in connection.query
+
+
+@pytest.mark.asyncio
+async def test_reconciler_returns_zero_without_database_pool(monkeypatch):
+    async def fake_get_pool():
+        return None
+
+    monkeypatch.setattr(db, 'get_pool', fake_get_pool)
+
+    assert await task_status_hook.reconcile_github_app_terminal_tasks() == 0

--- a/tests/test_session_view.py
+++ b/tests/test_session_view.py
@@ -1,0 +1,148 @@
+# ruff: noqa: I001
+
+import os
+import time
+
+
+os.environ.setdefault(
+    'DATABASE_URL', 'postgresql://test:test@localhost:5432/test'
+)
+
+import pytest
+
+from fastapi import FastAPI, status
+from httpx import ASGITransport, AsyncClient
+
+from a2a_server import session_view
+
+DEFAULT_LIMIT = 1000
+EXPECTED_REDACTIONS = 2
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setenv('CODETETHER_SESSION_VIEW_SECRET', 'test-session-secret')
+    monkeypatch.setenv('CODETETHER_PUBLIC_URL', 'https://api.codetether.run')
+
+
+@pytest.mark.asyncio
+async def test_signed_session_view_renders_tools_and_redacts_secrets(
+    monkeypatch, configured
+):
+    task = {
+        'id': 'task-1',
+        'status': 'completed',
+        'metadata': {
+            'session_id': 'session-1',
+            'repo': 'riley/codetether',
+            'pr_number': 5,
+        },
+    }
+    messages = [
+        {
+            'id': 'message-1',
+            'session_id': 'session-1',
+            'role': 'assistant',
+            'content': 'I ran the focused test.',
+            'model': 'test-model',
+            'created_at': '2026-07-17T12:00:00+00:00',
+            'tool_calls': [
+                {
+                    'name': 'bash',
+                    'status': 'completed',
+                    'args': {
+                        'command': 'pytest tests/test_session_view.py',
+                        'token': 'must-not-render',
+                    },
+                    'result': {'stdout': '1 passed', 'password': 'hidden'},
+                }
+            ],
+        }
+    ]
+
+    async def fake_task(task_id):
+        return task if task_id == 'task-1' else None
+
+    async def fake_task_messages(value, limit):
+        assert value == task
+        assert limit == DEFAULT_LIMIT
+        return 'session-1', messages
+
+    monkeypatch.setattr(session_view.db, 'db_get_task', fake_task)
+    monkeypatch.setattr(session_view, '_task_messages', fake_task_messages)
+
+    app = FastAPI()
+    app.include_router(session_view.session_view_router)
+    url = session_view.build_task_session_url(
+        'task-1', expires=int(time.time()) + 300
+    )
+    assert url is not None
+    path = url.removeprefix('https://api.codetether.run')
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url='http://test'
+    ) as client:
+        response = await client.get(path)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert 'CodeTether Agent · View session' in response.text
+    assert 'I ran the focused test.' in response.text
+    assert 'pytest tests/test_session_view.py' in response.text
+    assert '1 passed' in response.text
+    assert 'must-not-render' not in response.text
+    assert 'hidden' not in response.text
+    assert response.text.count('[REDACTED]') == EXPECTED_REDACTIONS
+    assert response.headers['cache-control'] == 'private, no-store'
+    assert response.headers['referrer-policy'] == 'no-referrer'
+    assert (
+        "frame-ancestors 'none'" in response.headers['content-security-policy']
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_view_rejects_forged_and_expired_links(configured):
+    app = FastAPI()
+    app.include_router(session_view.session_view_router)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url='http://test'
+    ) as client:
+        forged = await client.get(
+            '/sessions/tasks/task-1',
+            params={
+                'expires': int(time.time()) + 300,
+                'signature': 'not-valid',
+            },
+        )
+        expired_at = int(time.time()) - 1
+        expired_url = session_view.build_task_session_url(
+            'task-1', expires=expired_at
+        )
+        assert expired_url is not None
+        expired = await client.get(
+            expired_url.removeprefix('https://api.codetether.run')
+        )
+
+    assert forged.status_code == status.HTTP_403_FORBIDDEN
+    assert expired.status_code == status.HTTP_410_GONE
+
+
+def test_task_session_url_is_task_scoped(monkeypatch, configured):
+    expires = int(time.time()) + 300
+    first = session_view.build_task_session_url('task-1', expires=expires)
+    second = session_view.build_task_session_url('task-2', expires=expires)
+    assert first and second and first != second
+    assert '/sessions/tasks/task-1?' in first
+    assert '/sessions/tasks/task-2?' in second
+    first_signature = first.split('signature=', 1)[1]
+    with pytest.raises(Exception) as exc:
+        session_view.verify_task_session_signature(
+            'task-2', expires, first_signature
+        )
+    assert getattr(exc.value, 'status_code', None) == status.HTTP_403_FORBIDDEN
+
+
+def test_missing_configuration_does_not_publish_link(monkeypatch):
+    monkeypatch.delenv('CODETETHER_SESSION_VIEW_SECRET', raising=False)
+    monkeypatch.delenv('FORGEJO_WEBHOOK_SECRET', raising=False)
+    monkeypatch.setenv('CODETETHER_PUBLIC_URL', 'https://api.codetether.run')
+    assert session_view.build_task_session_url('task-1') is None

--- a/tests/test_session_view_persistence.py
+++ b/tests/test_session_view_persistence.py
@@ -1,0 +1,51 @@
+# ruff: noqa: I001
+
+import os
+from datetime import datetime
+from types import SimpleNamespace
+
+os.environ.setdefault(
+    'DATABASE_URL', 'postgresql://test:test@localhost:5432/test'
+)
+
+import pytest
+
+from a2a_server import agent_bridge
+
+
+@pytest.mark.asyncio
+async def test_save_task_persists_session_id_in_metadata(monkeypatch):
+    captured = {}
+
+    async def fake_upsert(value):
+        captured.update(value)
+        return True
+
+    monkeypatch.setattr(agent_bridge.db, 'db_upsert_task', fake_upsert)
+    bridge = object.__new__(agent_bridge.AgentBridge)
+    now = datetime.utcnow()
+    task = SimpleNamespace(
+        id='task-1',
+        codebase_id='workspace-1',
+        title='Fix the issue',
+        prompt='Please fix it',
+        agent_type='build',
+        status=agent_bridge.AgentTaskStatus.RUNNING,
+        priority=0,
+        result=None,
+        error=None,
+        metadata={'source': 'forgejo-webhook'},
+        model=None,
+        model_ref=None,
+        target_agent_name=None,
+        model_used=None,
+        session_id='session-1',
+        created_at=now,
+        started_at=now,
+        completed_at=None,
+    )
+
+    await agent_bridge.AgentBridge._save_task(bridge, task)
+
+    assert captured['metadata']['session_id'] == 'session-1'
+    assert captured['metadata']['source'] == 'forgejo-webhook'

--- a/tests/test_task_session_id_update.py
+++ b/tests/test_task_session_id_update.py
@@ -16,7 +16,7 @@ import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from a2a_server.agent_bridge import AgentBridge, AgentTask, AgentTaskStatus
+from a2a_server.agent_bridge import AgentBridge, AgentTaskStatus
 from a2a_server.monitor_api import agent_router
 import a2a_server.monitor_api as monitor_api
 
@@ -74,46 +74,6 @@ async def client(monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url='http://test') as ac:
         yield ac
-
-
-@pytest.mark.asyncio
-async def test_get_task_refreshes_stale_replica_cache_from_database(
-    monkeypatch,
-):
-    bridge = AgentBridge(auto_start=False)
-    cached = AgentTask(
-        id='task-review',
-        codebase_id='global',
-        title='review',
-        prompt='review prompt',
-    )
-    bridge._tasks[cached.id] = cached
-    bridge._codebase_tasks['global'] = [cached.id]
-    assert cached.status == AgentTaskStatus.PENDING
-
-    database_row = cached.to_dict()
-    database_row.update(
-        {
-            'workspace_id': 'global',
-            'status': 'completed',
-            'result': 'review complete',
-        }
-    )
-
-    async def _completed_task(task_id):
-        assert task_id == cached.id
-        return database_row
-
-    monkeypatch.setattr(
-        'a2a_server.agent_bridge.db.db_get_task', _completed_task
-    )
-
-    refreshed = await bridge.get_task(cached.id)
-
-    assert refreshed is not None
-    assert refreshed.status == AgentTaskStatus.COMPLETED
-    assert refreshed.result == 'review complete'
-    assert bridge._tasks[cached.id] is refreshed
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_session_id_update.py
+++ b/tests/test_task_session_id_update.py
@@ -16,7 +16,7 @@ import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from a2a_server.agent_bridge import AgentBridge, AgentTaskStatus
+from a2a_server.agent_bridge import AgentBridge, AgentTask, AgentTaskStatus
 from a2a_server.monitor_api import agent_router
 import a2a_server.monitor_api as monitor_api
 
@@ -74,6 +74,46 @@ async def client(monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url='http://test') as ac:
         yield ac
+
+
+@pytest.mark.asyncio
+async def test_get_task_refreshes_stale_replica_cache_from_database(
+    monkeypatch,
+):
+    bridge = AgentBridge(auto_start=False)
+    cached = AgentTask(
+        id='task-review',
+        codebase_id='global',
+        title='review',
+        prompt='review prompt',
+    )
+    bridge._tasks[cached.id] = cached
+    bridge._codebase_tasks['global'] = [cached.id]
+    assert cached.status == AgentTaskStatus.PENDING
+
+    database_row = cached.to_dict()
+    database_row.update(
+        {
+            'workspace_id': 'global',
+            'status': 'completed',
+            'result': 'review complete',
+        }
+    )
+
+    async def _completed_task(task_id):
+        assert task_id == cached.id
+        return database_row
+
+    monkeypatch.setattr(
+        'a2a_server.agent_bridge.db.db_get_task', _completed_task
+    )
+
+    refreshed = await bridge.get_task(cached.id)
+
+    assert refreshed is not None
+    assert refreshed.status == AgentTaskStatus.COMPLETED
+    assert refreshed.result == 'review complete'
+    assert bridge._tasks[cached.id] is refreshed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move Forgejo prepare/code/review/fix orchestration into a durable Temporal workflow
- keep prompts, credentials, clone URLs, transcripts, and tool payloads out of workflow history
- route native Forgejo cancel/retry controls through signed HMAC signals
- add a dedicated feature-flagged Temporal worker Deployment and rollout/rollback runbook
- retain the legacy path when `FORGEJO_TEMPORAL_ENABLED=false`

## Validation
- `171 passed` across Forgejo, session-view, policy, and check-failure tests
- 5 Temporal time-skipping workflow scenarios: approval, fix/re-review, cancel, retry/continue-as-new, exhausted activity
- Ruff lint/format and Python compile checks
- Helm lint plus disabled/enabled chart rendering
- Forgejo-side package tests, vet, full build, and focused SQLite HTTP integrations passed locally

## Rollout
Temporal remains disabled by default. See `docs/operations/forgejo-temporal-orchestration.md` for security boundaries, staged enablement, canary evidence, and rollback.

## Dependency
The corresponding Forgejo change is committed locally as `0c15ec6` (`feat(agent): deliver task controls to CodeTether`). Codeberg push is blocked in this environment because the configured HTTPS remote has no noninteractive credentials; it must be pushed to an authorized Forgejo fork/review remote before live rollout.
